### PR TITLE
Empty object causes unknown error

### DIFF
--- a/wxm-ios/DataLayer/DataLayer/Networking/ApiClient.swift
+++ b/wxm-ios/DataLayer/DataLayer/Networking/ApiClient.swift
@@ -11,6 +11,12 @@ import DomainLayer
 import Foundation
 import Toolkit
 
+private enum Constants: String {
+	case emptyJsonObject = "empty_json_object"
+	case url = "url"
+	case emptyObjectString = "{}"
+}
+
 public class ApiClient {
     let session = {
         let conf = URLSessionConfiguration.default
@@ -224,8 +230,8 @@ public class ApiClient {
 		print(NSString(string: String(data: prettyPrintedJsonData, encoding: .utf8)!))
 
 		if let noSlashesString = String(data: noSlashesJsonData, encoding: .utf8),
-		   noSlashesString.contains("{}") {
-			let error = NSError(domain: "empty_json_object", code: -1, userInfo: ["url": urlString ?? ""])
+		   noSlashesString.contains(Constants.emptyObjectString.rawValue) {
+			let error = NSError(domain: Constants.emptyJsonObject.rawValue, code: -1, userInfo: [Constants.url.rawValue: urlString ?? ""])
 			Logger.shared.logError(error)
 		}
     }

--- a/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/get_transactions.json
+++ b/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/get_transactions.json
@@ -36,40 +36,44 @@
 					1.0
 				]
 			},
-			"errors": {
+			"annotations": {
 				"qod": [
 					{
-						"error": "SPIKES",
+						"annotation": "SPIKES",
 						"affects": [
 							{
 								"parameter": "temperature",
-								"ratio": 0.7
+								"ratio": 70
 							},
 							{
 								"parameter": "wind_speed",
-								"ratio": 0.5
+								"ratio": 50
 							}
 						]
 					},
 					{
-						"error": "SHORT_CONST",
+						"annotation": "SHORT_CONST",
 						"affects": [
 							{
 								"parameter": "precipitation_rate",
-								"ratio": 0.7
+								"ratio": 70
 							}
 						]
 					}
 				],
 				"pol": [
 					{
-						"error": "LOCATION_NOT_VERIFIED",
-						"ratio": 0.8
+						"annotation": "LOCATION_NOT_VERIFIED",
+						"ratio": 80
 					}
 				],
 				"rm": [
 					{
-						"error": "NO_WALLET"
+
+
+
+
+						
 					}
 				]
 			}


### PR DESCRIPTION
## **Why?**
We should monitor cases of empty objects in JSON responses
### **How?**
On every received response, we check if the JSON string contains an empty object string (`{}`)
### **Testing**
Run the mock scheme and make sure the ln235 in `ApiClient` is invoked in the transactions screen. Mock JSON for this screen (`get_transactions.json`) contains an empty object
### **Additional context**
fixes fe-519
