### PR TITLE
Feature/fe 529 receive and open announcement notifications

### DIFF
--- a/PresentationLayer/Navigation/DeepLinkHandler.swift
+++ b/PresentationLayer/Navigation/DeepLinkHandler.swift
@@ -10,6 +10,7 @@ import DomainLayer
 import Combine
 import UIKit
 import Toolkit
+import UserNotifications
 
 class DeepLinkHandler {
 	typealias QueryParamsCallBack = GenericCallback<[String: String]?>
@@ -60,6 +61,13 @@ class DeepLinkHandler {
 
 		return handled
     }
+
+	func handleNotificationReceive(_ notification: UNNotificationResponse) -> Bool {
+		print(notification)
+		/// TODO: - Handle notification
+		return true
+	}
+
 
     deinit {
         print("deInit \(Self.self)")

--- a/PresentationLayer/Navigation/DeepLinkHandler.swift
+++ b/PresentationLayer/Navigation/DeepLinkHandler.swift
@@ -63,9 +63,6 @@ class DeepLinkHandler {
     }
 
 	func handleNotificationReceive(_ notification: UNNotificationResponse) -> Bool {
-		print(notification)
-		/// TODO: - Handle notification
-		///
 		guard let type = notification.toNotificationType else {
 			return false
 		}

--- a/PresentationLayer/Navigation/DeepLinkHandler.swift
+++ b/PresentationLayer/Navigation/DeepLinkHandler.swift
@@ -65,7 +65,20 @@ class DeepLinkHandler {
 	func handleNotificationReceive(_ notification: UNNotificationResponse) -> Bool {
 		print(notification)
 		/// TODO: - Handle notification
-		return true
+		///
+		guard let type = notification.toNotificationType else {
+			return false
+		}
+
+		switch type {
+			case .announcement(let urlString):
+				if let url = URL(string: urlString) {
+					Router.shared.showFullScreen(.safariView(url))
+					return true
+				}
+		}
+
+		return false
 	}
 
 
@@ -194,4 +207,31 @@ private extension DeepLinkHandler {
 
         }
     }
+}
+
+private enum NotificationType {
+	case announcement(String)
+}
+
+private extension UNNotificationResponse {
+	static let typeKey = "type"
+	static let announcementVal = "announcement"
+	static let urlKey = "url"
+
+	var toNotificationType: NotificationType? {
+		let userInfo = notification.request.content.userInfo
+		guard let type = userInfo[Self.typeKey] as? String else {
+			return nil
+		}
+
+		switch type {
+			case Self.announcementVal:
+				if let url = userInfo[Self.urlKey] as? String {
+					return .announcement(url)
+				}
+				return nil
+			default:
+				return nil
+		}
+	}
 }

--- a/PresentationLayer/UI Components/Modifiers/ReceiveNotificationsModifier.swift
+++ b/PresentationLayer/UI Components/Modifiers/ReceiveNotificationsModifier.swift
@@ -17,7 +17,7 @@ private struct ReceiveNotificationsModifier: ViewModifier {
 
 	init(onNotificationReceive: @escaping (UNNotificationResponse) -> Void) {
 		self.onNotificationReceive = onNotificationReceive
-		notificationPublisher?.sink { response in
+		notificationPublisher?.receive(on: DispatchQueue.main).sink { response in
 			if let response {
 				onNotificationReceive(response)
 			}

--- a/PresentationLayer/UI Components/Modifiers/ReceiveNotificationsModifier.swift
+++ b/PresentationLayer/UI Components/Modifiers/ReceiveNotificationsModifier.swift
@@ -1,0 +1,38 @@
+//
+//  ReceiveNotificationsModifier.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 19/1/24.
+//
+
+import SwiftUI
+import Toolkit
+import Combine
+
+private struct ReceiveNotificationsModifier: ViewModifier {
+	private let notificationPublisher = FirebaseManager.shared.latestReceivedNotificationPublisher
+	private let cancellables = CancellableWrapper()
+
+	let onNotificationReceive: (UNNotificationResponse) -> Void
+
+	init(onNotificationReceive: @escaping (UNNotificationResponse) -> Void) {
+		self.onNotificationReceive = onNotificationReceive
+		notificationPublisher?.sink { response in
+			if let response {
+				onNotificationReceive(response)
+			}
+		}
+		.store(in: &cancellables.cancellableSet)
+	}
+
+	func body(content: Content) -> some View {
+		content
+	}
+}
+
+extension View {
+	@ViewBuilder
+	func onNotificateionReceive(_ onNotificationReceive: @escaping (UNNotificationResponse) -> Void) -> some View {
+		modifier(ReceiveNotificationsModifier(onNotificationReceive: onNotificationReceive))
+	}
+}

--- a/PresentationLayer/UI Components/Modifiers/ReceiveNotificationsModifier.swift
+++ b/PresentationLayer/UI Components/Modifiers/ReceiveNotificationsModifier.swift
@@ -32,7 +32,7 @@ private struct ReceiveNotificationsModifier: ViewModifier {
 
 extension View {
 	@ViewBuilder
-	func onNotificateionReceive(_ onNotificationReceive: @escaping (UNNotificationResponse) -> Void) -> some View {
+	func onNotificationReceive(_ onNotificationReceive: @escaping (UNNotificationResponse) -> Void) -> some View {
 		modifier(ReceiveNotificationsModifier(onNotificationReceive: onNotificationReceive))
 	}
 }

--- a/PresentationLayer/UI Components/Screens/Main Screen/MainScreen.swift
+++ b/PresentationLayer/UI Components/Screens/Main Screen/MainScreen.swift
@@ -37,6 +37,9 @@ public struct MainScreen: View {
         .onOpenURL {
             viewModel.deepLinkHandler.handleUrl($0)
         }
+		.onNotificateionReceive { notificationResponse in
+			viewModel.deepLinkHandler.handleNotificationReceive(notificationResponse)
+		}
     }
 
     public var mainScreenSwitch: some View {

--- a/PresentationLayer/UI Components/Screens/Main Screen/MainScreen.swift
+++ b/PresentationLayer/UI Components/Screens/Main Screen/MainScreen.swift
@@ -37,7 +37,7 @@ public struct MainScreen: View {
         .onOpenURL {
             viewModel.deepLinkHandler.handleUrl($0)
         }
-		.onNotificateionReceive { notificationResponse in
+		.onNotificationReceive { notificationResponse in
 			viewModel.deepLinkHandler.handleNotificationReceive(notificationResponse)
 		}
     }

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -8,7 +8,7 @@ setupConfiguration(){
 	echo "UserAccessTokenService = accessTokenService;" >> $CONFIGURATION_PATH
 	echo "UserRefreshTokenService = refreshTokenService;" >> $CONFIGURATION_PATH
 	echo "Account = weatherXM;" >> $CONFIGURATION_PATH
-	echo "TeamId = ${CI_TEAM_ID};" >> $CONFIGURATION_PATH
+	echo "TeamId = ${TEAM_ID};" >> $CONFIGURATION_PATH
 	echo "ApiUrl = ${API_URL};" >> $CONFIGURATION_PATH
 	echo "ClaimTokenUrl = ${CLAIM_TOKEN_URL};" >> $CONFIGURATION_PATH
 	echo "AppStoreUrl = ${APP_STORE_URL};" >> $CONFIGURATION_PATH

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -32,7 +32,6 @@ DEBUG_CONFIGURATION_PATH=${CI_PRIMARY_REPOSITORY_PATH}/Configuration/Debug/Confi
 setupConfiguration $DEBUG_CONFIGURATION_PATH
 echo "BranchName = ${CI_BRANCH};" >> $CONFIGURATION_PATH
 
-cat $DEBUG_CONFIGURATION_PATH
 fi
 
 if [ "$CI_WORKFLOW" = "Submit to App Store" ];

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -31,6 +31,8 @@ chmod +x ./firebase-tools-macos
 DEBUG_CONFIGURATION_PATH=${CI_PRIMARY_REPOSITORY_PATH}/Configuration/Debug/ConfigDebug.xcconfig
 setupConfiguration $DEBUG_CONFIGURATION_PATH
 echo "BranchName = ${CI_BRANCH};" >> $CONFIGURATION_PATH
+
+cat $DEBUG_CONFIGURATION_PATH
 fi
 
 if [ "$CI_WORKFLOW" = "Submit to App Store" ];

--- a/ci_scripts/firebase_submission.sh
+++ b/ci_scripts/firebase_submission.sh
@@ -8,6 +8,6 @@ while getopts "p:k:t:" arg; do
 done
 
 echo "Starting distribution of IPA to Firebase"
-./firebase-tools-macos appdistribution:distribute "${ipa}" --app "${app_id}" --token "${token}"
+./firebase-tools-macos appdistribution:distribute "${ipa}" --app "${app_id}" --token "${token}" --groups "QA Group"
 
 echo "Upload Symbols"

--- a/ci_scripts/firebase_submission.sh
+++ b/ci_scripts/firebase_submission.sh
@@ -8,6 +8,6 @@ while getopts "p:k:t:" arg; do
 done
 
 echo "Starting distribution of IPA to Firebase"
-./firebase-tools-macos appdistribution:distribute "${ipa}" --app "${app_id}" --token "${token}" --groups "QA Group"
+./firebase-tools-macos appdistribution:distribute "${ipa}" --app "${app_id}" --token "${token}" --groups "qa-group"
 
 echo "Upload Symbols"

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		2645823B2A41C07000195C21 /* FailSuccessViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2645823A2A41C07000195C21 /* FailSuccessViewModifier.swift */; };
 		2646D8F329C8BF3D0000237F /* StationRewardsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2646D8F229C8BF3D0000237F /* StationRewardsView.swift */; };
 		2646D8F529C8BFB40000237F /* StationRewardsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2646D8F429C8BFB40000237F /* StationRewardsViewModel.swift */; };
+		264CDE0F2B5A8817004C8F39 /* ReceiveNotificationsModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264CDE0E2B5A8817004C8F39 /* ReceiveNotificationsModifier.swift */; };
 		264E2F5329DC3533009580A2 /* ThemeEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264E2F5229DC3533009580A2 /* ThemeEnum.swift */; };
 		264E2F6129DC5AEE009580A2 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 264E2F6029DC5AEE009580A2 /* Settings.bundle */; };
 		2655F1812AD3FA8400BB19D5 /* WidgetConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2655F1802AD3FA8400BB19D5 /* WidgetConstants.swift */; };
@@ -550,6 +551,7 @@
 		2645823A2A41C07000195C21 /* FailSuccessViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailSuccessViewModifier.swift; sourceTree = "<group>"; };
 		2646D8F229C8BF3D0000237F /* StationRewardsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationRewardsView.swift; sourceTree = "<group>"; };
 		2646D8F429C8BFB40000237F /* StationRewardsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationRewardsViewModel.swift; sourceTree = "<group>"; };
+		264CDE0E2B5A8817004C8F39 /* ReceiveNotificationsModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveNotificationsModifier.swift; sourceTree = "<group>"; };
 		264E2F5229DC3533009580A2 /* ThemeEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnum.swift; sourceTree = "<group>"; };
 		264E2F6029DC5AEE009580A2 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		2655F1802AD3FA8400BB19D5 /* WidgetConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetConstants.swift; sourceTree = "<group>"; };
@@ -1353,6 +1355,7 @@
 				266DC01A2A55786F00EC9E1F /* WXMPopover.swift */,
 				26E88AF429DD69930023BBD5 /* WXMShadow.swift */,
 				2675470429A9181E008BCF40 /* WXMToggleStyle.swift */,
+				264CDE0E2B5A8817004C8F39 /* ReceiveNotificationsModifier.swift */,
 			);
 			path = Modifiers;
 			sourceTree = "<group>";
@@ -2717,6 +2720,7 @@
 				2692D8722A4D8DEA0060CB3C /* Numeric+.swift in Sources */,
 				26A4115929B6078500A2C10B /* ObservationsView.swift in Sources */,
 				2655F1812AD3FA8400BB19D5 /* WidgetConstants.swift in Sources */,
+				264CDE0F2B5A8817004C8F39 /* ReceiveNotificationsModifier.swift in Sources */,
 				26A4115B29B60F2900A2C10B /* ObservationsViewModel.swift in Sources */,
 				267547CC29A9181E008BCF40 /* OnAnimationCompletedModifier.swift in Sources */,
 				2664831929C31AF400748F9C /* OverlayAnimator.swift in Sources */,

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -3180,7 +3180,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.12.1;
+				MARKETING_VERSION = 1.13.0;
 				OTHER_SWIFT_FLAGS = "-DMAIN_APP";
 				PRODUCT_BUNDLE_IDENTIFIER = com.weatherxm.app.mock;
 				PRODUCT_NAME = WeatherXM;
@@ -3347,7 +3347,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.12.1;
+				MARKETING_VERSION = 1.13.0;
 				OTHER_SWIFT_FLAGS = "-DMAIN_APP";
 				PRODUCT_BUNDLE_IDENTIFIER = com.weatherxm.app.debug;
 				PRODUCT_NAME = WeatherXM;
@@ -3395,7 +3395,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.12.1;
+				MARKETING_VERSION = 1.13.0;
 				OTHER_SWIFT_FLAGS = "-DMAIN_APP";
 				PRODUCT_BUNDLE_IDENTIFIER = com.weatherxm.app;
 				PRODUCT_NAME = WeatherXM;

--- a/wxm-ios/AppCore/AppDelegate.swift
+++ b/wxm-ios/AppCore/AppDelegate.swift
@@ -23,4 +23,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 	func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
 		print(error)
 	}
+
+	func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+		FirebaseManager.shared.setApnsToken(deviceToken)
+	}
 }

--- a/wxm-ios/Info.plist
+++ b/wxm-ios/Info.plist
@@ -69,7 +69,6 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>
-		<string>remote-notification</string>
 	</array>
 	<key>UserAccessTokenService</key>
 	<string>$(UserAccessTokenService)</string>

--- a/wxm-ios/Info.plist
+++ b/wxm-ios/Info.plist
@@ -76,5 +76,7 @@
 	<string>$(UserRefreshTokenService)</string>
 	<key>Username</key>
 	<string>$(Username)</string>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<string>NO</string>
 </dict>
 </plist>

--- a/wxm-ios/Info.plist
+++ b/wxm-ios/Info.plist
@@ -49,6 +49,8 @@
 	</array>
 	<key>MBXAccessToken</key>
 	<string>$(MBXAccessToken)</string>
+	<key>NSUserNotificationsUsageDescription</key>
+	<string>WeatherXM will send you notifications about the project or your station.</string>
 	<key>Password</key>
 	<string>$(Password)</string>
 	<key>SupportUrl</key>

--- a/wxm-ios/Toolkit/Toolkit/Firebase Manager/FirebaseManager.swift
+++ b/wxm-ios/Toolkit/Toolkit/Firebase Manager/FirebaseManager.swift
@@ -50,6 +50,10 @@ public class FirebaseManager {
 	public func requestNotificationAuthorization() async throws {
 		try await firebaseManagerImpl.requestNotificationAuthorization()
 	}
+
+	public func setApnsToken(_ token: Data) {
+		firebaseManagerImpl.setApnsToken(token)
+	}
 }
 
 private class RemoteFirebaseManager: FirbaseManagerImplementation {
@@ -93,6 +97,10 @@ private class RemoteFirebaseManager: FirbaseManagerImplementation {
 		await notificationsHandler.getAuthorizationStatus()
 	}
 
+	func setApnsToken(_ token: Data) {
+		notificationsHandler.setApnsToken(token)
+	}
+
 	private func assignInstallationId() async {
 		return await withCheckedContinuation { continuation in
 			Installations.installations().installationID { [weak self] installationId, error in
@@ -121,4 +129,5 @@ private class MockFirebaseManager: FirbaseManagerImplementation {
 	func setAnalyticsCollectionEnabled(_ enabled: Bool) {}
 	func requestNotificationAuthorization() async throws {}
 	func getAuthorizationStatus() async -> UNAuthorizationStatus { .authorized }
+	func setApnsToken(_ token: Data) {}
 }

--- a/wxm-ios/Toolkit/Toolkit/Firebase Manager/FirebaseManagerTypes.swift
+++ b/wxm-ios/Toolkit/Toolkit/Firebase Manager/FirebaseManagerTypes.swift
@@ -18,6 +18,7 @@ protocol FirbaseManagerImplementation {
 	func setAnalyticsCollectionEnabled(_ enabled: Bool)
 	func requestNotificationAuthorization() async throws
 	func getAuthorizationStatus() async -> UNAuthorizationStatus
+	func setApnsToken(_ token: Data)
 }
 
 protocol RemoteConfigManagerImplementation: AnyObject {

--- a/wxm-ios/Toolkit/Toolkit/Firebase Manager/NotificationsHandler.swift
+++ b/wxm-ios/Toolkit/Toolkit/Firebase Manager/NotificationsHandler.swift
@@ -14,7 +14,7 @@ class NotificationsHandler: NSObject {
 	let latestNotificationPublisher: AnyPublisher<UNNotificationResponse?, Never>
 	let authorizationStatusPublisher: AnyPublisher<UNAuthorizationStatus?, Never>
 	
-	private let latestNotificationSubject: CurrentValueSubject<UNNotificationResponse?, Never> = .init(nil)
+	private let latestNotificationSubject: PassthroughSubject<UNNotificationResponse?, Never> = .init()
 	private let authorizationStatusSubject: CurrentValueSubject<UNAuthorizationStatus?, Never> = .init(nil)
 	private var cancellableSet: Set<AnyCancellable> = .init()
 
@@ -22,13 +22,11 @@ class NotificationsHandler: NSObject {
 		latestNotificationPublisher = latestNotificationSubject.eraseToAnyPublisher()
 		authorizationStatusPublisher = authorizationStatusSubject.eraseToAnyPublisher()
 		super.init()
-
+		UNUserNotificationCenter.current().delegate = self
 		observeAuthorizationStatus()
 	}
 
 	func requestNotificationAuthorization() async throws {
-		UNUserNotificationCenter.current().delegate = self
-
 		let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
 		let granted = try await UNUserNotificationCenter.current().requestAuthorization(options: authOptions)
 		if granted {
@@ -72,6 +70,7 @@ extension NotificationsHandler: UNUserNotificationCenterDelegate {
 		completionHandler([.banner, .badge, .sound, .list])
 	}
 
+	@MainActor
 	func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
 		latestNotificationSubject.send(response)
 	}

--- a/wxm-ios/Toolkit/Toolkit/Firebase Manager/NotificationsHandler.swift
+++ b/wxm-ios/Toolkit/Toolkit/Firebase Manager/NotificationsHandler.swift
@@ -44,6 +44,10 @@ class NotificationsHandler: NSObject {
 	func getAuthorizationStatus() async -> UNAuthorizationStatus {
 		await UNUserNotificationCenter.current().notificationSettings().authorizationStatus		
 	}
+
+	func setApnsToken(_ token: Data) {
+		Messaging.messaging().apnsToken = token
+	}
 }
 
 private extension NotificationsHandler {


### PR DESCRIPTION
## **Why?**
Handle received notifications for announcements
### **How?**
- Handle received notifications for type `announcements`
- Functionality to open safari view on full-screen
### **Testing**
To send a push notification to a simulator run the following line on terminal
```
xcrun simctl push <simulator_id> <app_bundle_id> <apns file>
```
`simulator_id `: run `xcrun simctl list` and find the id of your `booted` simulator
`app_bundle_id `: the app bundle id, eg. `com.weatherxm.app.debug`
`apns file`: the json file with the push notification structure
Test when app is on foreground, background or killed.
Since there is different navigation functionality for iOS 15, give a try on an iOS 15 simulator 
### **Additional context**
fixes fe-529
