### PR TITLE
Reward period doesnt show under the 7d chart in stations

### DIFF
--- a/PresentationLayer/Extensions/Domain Extensions/DeviceRewardsOverview+.swift
+++ b/PresentationLayer/Extensions/Domain Extensions/DeviceRewardsOverview+.swift
@@ -81,7 +81,7 @@ extension DeviceRewardsOverview {
 
 	var timelineCaption: String? {
 		guard let timestamp = timeline?.referenceDate else {
-			return nil
+			return timelineDateRangeCaption
 		}
 
 		let val = timestamp.getFormattedDate(format: .monthLiteralDayYearShort, timezone: TimeZone.UTCTimezone).localizedCapitalized
@@ -89,6 +89,24 @@ extension DeviceRewardsOverview {
 		let comma = relativeDay.isEmpty ? "" : ", "
 		let valueString = "\(relativeDay)\(comma)\(val)"
 		return LocalizableString.StationDetails.rewardsTimelineCaption(valueString).localized
+	}
+
+	private var timelineDateRangeCaption: String? {
+		guard let fromDate = fromDate, let toDate = toDate else {
+			return nil
+		}
+
+		let from = fromDate.getFormattedDate(format: .monthLiteralDay,
+											 relativeFormat: false,
+											 timezone: .UTCTimezone).capitalizedSentence
+
+		let to = toDate.getFormattedDate(format: .monthLiteralDay,
+										 relativeFormat: false,
+										 timezone: .UTCTimezone).capitalizedSentence
+
+		let rangeString = from + " - " + to
+
+		return LocalizableString.StationDetails.rewardsTimelineCaption(rangeString).localized
 	}
 
 	private var timelineDateRangeString: String? {

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -75,7 +75,7 @@ private struct ContentView: View {
 					VStack(spacing: CGFloat(.defaultSpacing)) {
 						StationRewardsOverviewView(overview: viewModel.rewardsCardOverview, showError: false, buttonActions: viewModel.buttonActions)
 
-						if !viewModel.rewardsCardOverview.annnotationsList.isEmpty {
+						if viewModel.rewardsCardOverview.lostAmount > 0.0, !viewModel.rewardsCardOverview.annnotationsList.isEmpty {
 							errorsList
 						}
 					}

--- a/PresentationLayer/UI Components/Screens/WXMTransactionsDetails/TransactionDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/WXMTransactionsDetails/TransactionDetailsView.swift
@@ -56,7 +56,7 @@ struct TransactionDetailsView: View {
                                 ForEach(arrayOfTransactions) { record in
 									let lostData = record.lostAmountData
                                     BaseRewardsCard(record: record)
-										.indication(show: .constant(!record.annotationsList.isEmpty),
+										.indication(show: .constant(record.lostAmount > 0.0),
 													borderColor: Color(colorEnum: lostData.problemsViewBorder),
 													bgColor: Color(colorEnum: lostData.problemsViewBackground)) {
 											StationRewardsErrorView(lostAmount: record.lostAmount,

--- a/PresentationLayer/UI Components/Screens/WeatherStations/Station Details/Rewards/StationRewardsOverviewView.swift
+++ b/PresentationLayer/UI Components/Screens/WeatherStations/Station Details/Rewards/StationRewardsOverviewView.swift
@@ -39,7 +39,7 @@ private extension StationRewardsOverviewView {
 				}
 			}
 
-			if showError, !overview.annnotationsList.isEmpty {
+			if showError, lostAmountData.value > 0.0 {
 				errorView(for: lostAmountData)
 			}
 


### PR DESCRIPTION
## **Why?**
- Missing error indication under `Last 7D` and `Last 30D` tabs
- Missing timeline caption under `Last 7D` and `Last 30D` tabs
### **How?**
- Show error indication if lost rewards > 0
- Show date range on timeline caption when there is no `reference_date`
### **Testing**
Make sure all mentioned fields are rendered properly. You can have the Android app as a reference 
### **Additional context**
fixes fe-545
