### PR TITLE
Handle case of missing last activity field 

### DIFF
--- a/PresentationLayer/UI Components/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
@@ -264,7 +264,7 @@ private extension WeatherStationsHomeViewModel {
                 case .name:
                     $0.displayName < $1.displayName
                 case .lastActive:
-                    $0.lastActiveAt!.timestampToDate() > $1.lastActiveAt!.timestampToDate()
+					($0.lastActiveAt?.timestampToDate() ?? .distantPast) > ($1.lastActiveAt?.timestampToDate() ?? .distantPast)
             }
         }
     }


### PR DESCRIPTION
## **Why?**
We have some crashes with newly claimed stations bacause of missing `lastWeatherStationActivity`
### **How?**
Handle case of nil property.
### **Testing**
You can use the mock scheme and edit `get_user_devices.json` to feed a station without `lastWeatherStationActivity`
### **Additional context**
fixes fe-553
