### PR TITLE
Sync screens on friendly name updates

### DIFF
--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/DeviceInfoRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/DeviceInfoRepositoryImpl.swift
@@ -26,14 +26,13 @@ extension DeviceInfoRepositoryImpl {
         let urlRequest = try builder.asURLRequest()
         return ApiClient.shared.requestCodableAuthorized(urlRequest, mockFileName: builder.mockFileName)
     }
-    public func setFriendlyName(deviceId: String, name: String) throws -> AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never> {
-        let urlRequest = try MeApiRequestBuilder.setFriendlyName(deviceId: deviceId, name: name).asURLRequest()
-        return ApiClient.shared.requestCodableAuthorized(urlRequest)
+
+	public func setFriendlyName(deviceId: String, name: String) throws -> AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never> {
+		try userDevicesService.setFriendlyName(deviceId: deviceId, name: name)
     }
 
     public func deleteFriendlyName(deviceId: String) throws -> AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never> {
-        let urlRequest = try MeApiRequestBuilder.deleteFriendlyName(deviceId: deviceId).asURLRequest()
-        return ApiClient.shared.requestCodableAuthorized(urlRequest)
+		try userDevicesService.deleteFriendlyName(deviceId: deviceId)
     }
 
     public func disclaimDevice(serialNumber: String) throws -> AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never> {

--- a/wxm-ios/DataLayer/UserDevicesService.swift
+++ b/wxm-ios/DataLayer/UserDevicesService.swift
@@ -210,6 +210,36 @@ public class UserDevicesService {
 			}
 			.eraseToAnyPublisher()
 	}
+
+	func setFriendlyName(deviceId: String, name: String) throws -> AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never> {
+		let urlRequest = try MeApiRequestBuilder.setFriendlyName(deviceId: deviceId, name: name).asURLRequest()
+		let publisher: AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never> = ApiClient.shared.requestCodableAuthorized(urlRequest)
+		return publisher
+			.flatMap { [weak self] response in
+				if response.error == nil {
+					self?.invalidateCaches()
+					WidgetCenter.shared.reloadAllTimelines()
+					NotificationCenter.default.post(name: .userDevicesListUpdated, object: deviceId)
+				}
+				return Just(response)
+			}
+			.eraseToAnyPublisher()
+	}
+
+	func deleteFriendlyName(deviceId: String) throws -> AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never> {
+		let urlRequest = try MeApiRequestBuilder.deleteFriendlyName(deviceId: deviceId).asURLRequest()
+		let publisher: AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never> = ApiClient.shared.requestCodableAuthorized(urlRequest)
+		return publisher
+			.flatMap { [weak self] response in
+				if response.error == nil {
+					self?.invalidateCaches()
+					WidgetCenter.shared.reloadAllTimelines()
+					NotificationCenter.default.post(name: .userDevicesListUpdated, object: deviceId)
+				}
+				return Just(response)
+			}
+			.eraseToAnyPublisher()
+	}
 }
 
 private extension UserDevicesService {


### PR DESCRIPTION
## **Why?**
Sync previous screens on station friendly name updates
### **How?**
The station name updates follow the same flow with devices-related requests (`UserDevicesService`).
### **Testing**
Change the friendly name of a station, go back to station details screen and make sure the name is updated
### **Additional context**
fixes fe-573
