### PR TITLE
Handle case of invalid cache in widgets

### DIFF
--- a/station-widget/station_widget.swift
+++ b/station-widget/station_widget.swift
@@ -85,8 +85,8 @@ struct Provider: IntentTimelineProvider {
 												 errorInfo: nil,
 												 isLoggedIn: isUserLoggedIn)
 				return entry
-			case .failure(let error):
-				let devices: [DeviceDetails] = (try? await useCase.getDevices(useCache: true).get()) ?? []
+			case .failure(_):
+				let devices: [DeviceDetails] = useCase.getCachedDevices() ?? []
 
 				let entry = StationTimelineEntry(date: .now,
 												 displaySize: displaySize,

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/MeRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/MeRepositoryImpl.swift
@@ -50,6 +50,10 @@ public struct MeRepositoryImpl: MeRepository {
         return ApiClient.shared.requestCodableAuthorized(urlRequest)
     }
 
+	public func getCachedDevices() -> [NetworkDevicesResponse]? {
+		userDevicesService.getCachedDevices()
+	}
+	
 	public func getDevices(useCache: Bool) throws -> AnyPublisher<DataResponse<[NetworkDevicesResponse], NetworkErrorResponse>, Never> {
         try userDevicesService.getDevices(useCache: useCache)
     }

--- a/wxm-ios/DataLayer/UserDevicesService.swift
+++ b/wxm-ios/DataLayer/UserDevicesService.swift
@@ -40,6 +40,10 @@ public class UserDevicesService {
         NotificationCenter.default.removeObserver(self)
     }
 
+	func getCachedDevices() -> [NetworkDevicesResponse]? {
+		userDevicesCache.getCachedValue(for: userDevicesCacheKey)
+	}
+
 	func getDevices(useCache: Bool) throws -> AnyPublisher<DataResponse<[NetworkDevicesResponse], NetworkErrorResponse>, Never> {
 		if useCache, let cachedDevices = userDevicesCache.getValue(for: userDevicesCacheKey) {
 			return Just(DataResponse(request: nil,

--- a/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/MeRepository.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/MeRepository.swift
@@ -31,6 +31,7 @@ public protocol MeRepository {
     func getUserWallet() throws -> AnyPublisher<DataResponse<Wallet, NetworkErrorResponse>, Never>
     func saveUserWallet(address: String) throws -> AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never>
 	func getDevices(useCache: Bool) throws -> AnyPublisher<DataResponse<[NetworkDevicesResponse], NetworkErrorResponse>, Never>
+	func getCachedDevices() -> [NetworkDevicesResponse]?
     func claimDevice(claimDeviceBody: ClaimDeviceBody) throws -> AnyPublisher<DataResponse<NetworkDevicesResponse, NetworkErrorResponse>, Never>
     func getFirmwares(testSearch: String) throws -> AnyPublisher<DataResponse<[NetworkFirmwareResponse], NetworkErrorResponse>, Never>
     func getUserDeviceById(deviceId: String) throws -> AnyPublisher<DataResponse<NetworkDevicesResponse, NetworkErrorResponse>, Never>

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/WidgetUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/WidgetUseCase.swift
@@ -23,6 +23,10 @@ public struct WidgetUseCase {
 		keychainRepository.isUserLoggedIn()
 	}
 
+	public func getCachedDevices() -> [DeviceDetails]? {
+		meRepository.getCachedDevices()?.map { $0.toDeviceDetails }
+	}
+
 	public func getDevices(useCache: Bool = true) async throws -> Result<[DeviceDetails], NetworkErrorResponse> {
 		let userDevices = try meRepository.getDevices(useCache: useCache)
 		let publisher = userDevices.convertedToDeviceDetailsResultPublisher

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/WidgetUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/WidgetUseCase.swift
@@ -22,7 +22,9 @@ public struct WidgetUseCase {
 	public var isUserLoggedIn: Bool {
 		keychainRepository.isUserLoggedIn()
 	}
-
+	
+	/// Get the local persisted user devices
+	/// - Returns: An array of the local persisted user devices
 	public func getCachedDevices() -> [DeviceDetails]? {
 		meRepository.getCachedDevices()?.map { $0.toDeviceDetails }
 	}

--- a/wxm-ios/Toolkit/Toolkit/Utils/TimeValidationCache.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/TimeValidationCache.swift
@@ -60,13 +60,18 @@ public class TimeValidationCache<T: Codable> {
 		dispatchQueue.sync {
 			guard let obj = cache[key],
 				  Date.now.timeIntervalSince(obj.timestamp) < obj.expireInterval else {
-				cache.removeValue(forKey: key)
 				return nil
 			}
 
 			return obj.value
 		}
     }
+
+	public func getCachedValue(for key: String) -> T? {
+		dispatchQueue.sync {
+			return cache[key]?.value
+		}
+	}
 
     public func invalidate() {
 		persistCacheManager.remove(key: persistKey)

--- a/wxm-ios/Toolkit/Toolkit/Utils/TimeValidationCache.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/TimeValidationCache.swift
@@ -55,7 +55,10 @@ public class TimeValidationCache<T: Codable> {
 									 expireInterval: expire)
 		}
     }
-
+	
+	/// Returns the "validated" value respecting the `expireInterval`
+	/// - Parameter key: The key used to pesist the data
+	/// - Returns: The local persisted an valid value
     public func getValue(for key: String) -> T? {
 		dispatchQueue.sync {
 			guard let obj = cache[key],
@@ -66,7 +69,10 @@ public class TimeValidationCache<T: Codable> {
 			return obj.value
 		}
     }
-
+	
+	/// Returns the persisted data ignoring the `expireInterval`
+	/// - Parameter key: The key used to pesist the data
+	/// - Returns: The local persisted data
 	public func getCachedValue(for key: String) -> T? {
 		dispatchQueue.sync {
 			return cache[key]?.value


### PR DESCRIPTION
## **Why?**
In case of api error and invalidated devices cache, the widget shows empty state
### **How?**
Added functionality to get cached devices regardless if the cache is time-wise invalidated
### **Testing**
Not so easy. Make sure the widget has the correct state. Check code wise if there is something weird
### **Additional context**
fixes fe-578
