### PR TITLE
Missing indication in observations tab

### DIFF
--- a/PresentationLayer/UI Components/Base Components/WeatherStationCard/WeatherStationCard+Content.swift
+++ b/PresentationLayer/UI Components/Base Components/WeatherStationCard/WeatherStationCard+Content.swift
@@ -48,17 +48,6 @@ extension WeatherStationCard {
             .padding(CGFloat(.smallSidePadding))
         }
     }
-
-    @ViewBuilder
-    var statusContainerBackground: some View {
-        if !device.isActive {
-            Color(colorEnum: .errorTint)
-        } else if device.needsUpdate(mainVM: mainScreenViewModel, followState: followState) {
-            Color(colorEnum: .warningTint)
-        } else {
-            EmptyView()
-        }
-    }
 }
 
 /// Viewbuilders and stuff used internally from the main Viewbuilders

--- a/PresentationLayer/UI Components/Base Components/WeatherStationCard/WeatherStationCard+Content.swift
+++ b/PresentationLayer/UI Components/Base Components/WeatherStationCard/WeatherStationCard+Content.swift
@@ -25,29 +25,6 @@ extension WeatherStationCard {
     var weatherView: some View {
         WeatherOverviewView(weather: device.weather)
     }
-
-    @ViewBuilder
-    var statusView: some View {
-        let alertsCount = device.alertsCount(mainVM: mainScreenViewModel, followState: followState)
-        if alertsCount > 1 {
-            multipleAlertsView(alertsCount: alertsCount)
-        } else if device.isActive {
-            warningView
-        } else {
-            HStack(spacing: CGFloat(.smallSpacing)) {
-                Image(asset: .offlineIcon)
-                    .renderingMode(.template)
-                    .foregroundColor(Color(colorEnum: .error))
-
-                Text(LocalizableString.offlineStation.localized)
-                    .foregroundColor(Color(colorEnum: .text))
-                    .font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
-
-                Spacer()
-            }
-            .padding(CGFloat(.smallSidePadding))
-        }
-    }
 }
 
 /// Viewbuilders and stuff used internally from the main Viewbuilders
@@ -55,60 +32,5 @@ private extension WeatherStationCard {
     @ViewBuilder
     var lastActiveView: some View {
         StationLastActiveView(configuration: device.stationLastActiveConf)
-    }
-
-    @ViewBuilder
-    var warningView: some View {
-        if device.needsUpdate(mainVM: mainScreenViewModel, followState: followState) {
-            CardWarningView(title: LocalizableString.stationWarningUpdateTitle.localized,
-                            message: LocalizableString.stationWarningUpdateDescription.localized,
-                            showContentFullWidth: true,
-                            closeAction: nil) {
-                Button {
-                    updateFirmwareAction()
-                    Logger.shared.trackEvent(.prompt, parameters: [.promptName: .OTAAvailable,
-                                                                   .promptType: .warnPromptType,
-                                                                   .action: .action])
-                } label: {
-                    Text(LocalizableString.stationWarningUpdateButtonTitle.localized)
-                }
-                .buttonStyle(WXMButtonStyle())
-                .buttonStyle(.plain)
-            }
-			.padding(.vertical, CGFloat(.smallSidePadding))
-            .onAppear {
-                Logger.shared.trackEvent(.prompt, parameters: [.promptName: .OTAAvailable,
-                                                               .promptType: .warnPromptType,
-                                                               .action: .viewAction])
-            }
-        } else {
-            EmptyView()
-        }
-    }
-
-    @ViewBuilder
-    func multipleAlertsView(alertsCount: Int) -> some View {
-        HStack(spacing: CGFloat(.smallSpacing)) {
-            Image(asset: .offlineIcon)
-                .renderingMode(.template)
-                .foregroundColor(Color(colorEnum: .error))
-
-            Text(LocalizableString.issues(alertsCount).localized)
-                .foregroundColor(Color(colorEnum: .text))
-                .font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
-
-            Spacer()
-
-            Button {
-                viewMoreAction()
-            } label: {
-                Text(LocalizableString.viewMore.localized)
-                    .foregroundColor(Color(colorEnum: .primary))
-                    .font(.system(size: CGFloat(.normalFontSize), weight: .bold))
-                    .padding(.horizontal, CGFloat(.smallSidePadding))
-            }
-
-        }
-        .padding(CGFloat(.smallSidePadding))
     }
 }

--- a/PresentationLayer/UI Components/Base Components/WeatherStationCard/WeatherStationCard.swift
+++ b/PresentationLayer/UI Components/Base Components/WeatherStationCard/WeatherStationCard.swift
@@ -10,45 +10,43 @@ import SwiftUI
 import Toolkit
 
 struct WeatherStationCard: View {
-    let device: DeviceDetails
-    let followState: UserDeviceFollowState?
-    var updateFirmwareAction: VoidCallback = {}
-    var viewMoreAction: VoidCallback = {}
-    var followAction: VoidCallback?
+	let device: DeviceDetails
+	let followState: UserDeviceFollowState?
+	var updateFirmwareAction: VoidCallback = {}
+	var viewMoreAction: VoidCallback = {}
+	var followAction: VoidCallback?
 	let mainScreenViewModel: MainScreenViewModel = .shared
 
-    var body: some View {
+	var body: some View {
 		VStack(spacing: 0.0) {
 			WeatherStationCardView(device: device, followState: followState, followAction: followAction)
 				.background {
 					Color(colorEnum: .top)
 						.cornerRadius(CGFloat(.cardCornerRadius))
 				}
-
-			statusView
-        }
-		.background {
-			statusContainerBackground
-				.cornerRadius(CGFloat(.cardCornerRadius))
 		}
-        .if(!device.isActive) { view in
-            view.strokeBorder(color: Color(colorEnum: .error), lineWidth: 1.0, radius: CGFloat(.cardCornerRadius))
-        }
-        .if(device.isActive && device.needsUpdate(mainVM: mainScreenViewModel, followState: followState)) { view in
-            view.strokeBorder(color: Color(colorEnum: .warning), lineWidth: 1.0, radius: CGFloat(.cardCornerRadius))
-        }
-        .WXMCardStyle(backgroundColor: Color(colorEnum: .top),
-                            insideHorizontalPadding: .zero,
-                            insideVerticalPadding: .zero,
-                            cornerRadius: CGFloat(.cardCornerRadius))
-        .wxmShadow()
-    }
+		.indication(show: .init(get: { !device.isActive }, set: { _ in }),
+					borderColor: Color(colorEnum: .error),
+					bgColor: Color(colorEnum: .errorTint)) {
+			statusView
+		}
+		.indication(show: .init(get: { device.isActive && device.needsUpdate(mainVM: mainScreenViewModel, followState: followState) }, set: { _ in }),
+					borderColor: Color(colorEnum: .warning),
+					bgColor: Color(colorEnum: .warning)) {
+			statusView
+		}
+		.WXMCardStyle(backgroundColor: Color(colorEnum: .top),
+						insideHorizontalPadding: .zero,
+						insideVerticalPadding: .zero,
+						cornerRadius: CGFloat(.cardCornerRadius))
+		.wxmShadow()
+	}
 }
 
 struct WeatherStationCard_Previews: PreviewProvider {
-    static var previews: some View {
-        let device = DeviceDetails.mockDevice
-        return WeatherStationCard(device: device,
-                                  followState: UserDeviceFollowState(deviceId: device.id!, relation: .owned))
-    }
+	static var previews: some View {
+		let device = DeviceDetails.mockDevice
+		return WeatherStationCard(device: device,
+								  followState: UserDeviceFollowState(deviceId: device.id!, relation: .owned))
+	}
 }

--- a/PresentationLayer/UI Components/Base Components/WeatherStationCard/WeatherStationCard.swift
+++ b/PresentationLayer/UI Components/Base Components/WeatherStationCard/WeatherStationCard.swift
@@ -32,7 +32,7 @@ struct WeatherStationCard: View {
 		}
 		.indication(show: .init(get: { device.isActive && device.needsUpdate(mainVM: mainScreenViewModel, followState: followState) }, set: { _ in }),
 					borderColor: Color(colorEnum: .warning),
-					bgColor: Color(colorEnum: .warning)) {
+					bgColor: Color(colorEnum: .warningTint)) {
 			statusView
 		}
 		.WXMCardStyle(backgroundColor: Color(colorEnum: .top),

--- a/PresentationLayer/UI Components/Base Components/WeatherStationCard/WeatherStationCard.swift
+++ b/PresentationLayer/UI Components/Base Components/WeatherStationCard/WeatherStationCard.swift
@@ -25,20 +25,11 @@ struct WeatherStationCard: View {
 						.cornerRadius(CGFloat(.cardCornerRadius))
 				}
 		}
-		.indication(show: .init(get: { !device.isActive }, set: { _ in }),
-					borderColor: Color(colorEnum: .error),
-					bgColor: Color(colorEnum: .errorTint)) {
-			statusView
-		}
-		.indication(show: .init(get: { device.isActive && device.needsUpdate(mainVM: mainScreenViewModel, followState: followState) }, set: { _ in }),
-					borderColor: Color(colorEnum: .warning),
-					bgColor: Color(colorEnum: .warningTint)) {
-			statusView
-		}
 		.WXMCardStyle(backgroundColor: Color(colorEnum: .top),
-						insideHorizontalPadding: .zero,
-						insideVerticalPadding: .zero,
-						cornerRadius: CGFloat(.cardCornerRadius))
+					  insideHorizontalPadding: .zero,
+					  insideVerticalPadding: .zero,
+					  cornerRadius: CGFloat(.cardCornerRadius))
+		.stationIndication(device: device, followState: followState)
 		.wxmShadow()
 	}
 }

--- a/PresentationLayer/UI Components/Modifiers/StationIndication.swift
+++ b/PresentationLayer/UI Components/Modifiers/StationIndication.swift
@@ -1,0 +1,138 @@
+//
+//  StationIndication.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 22/2/24.
+//
+
+import SwiftUI
+import DomainLayer
+import Toolkit
+
+private struct StationIndicationModifier: ViewModifier {
+	let device: DeviceDetails
+	let followState: UserDeviceFollowState?
+	let mainScreenViewModel = MainScreenViewModel.shared
+
+	func body(content: Content) -> some View {
+		content
+			.indication(show: .init(get: { !device.isActive }, set: { _ in }),
+						borderColor: Color(colorEnum: .error),
+						bgColor: Color(colorEnum: .errorTint)) {
+				statusView
+			}
+			.indication(show: .init(get: { device.isActive && device.needsUpdate(mainVM: mainScreenViewModel, followState: followState) }, set: { _ in }),
+						borderColor: Color(colorEnum: .warning),
+						bgColor: Color(colorEnum: .warningTint)) {
+				statusView
+			}
+
+	}
+}
+
+private extension StationIndicationModifier {
+	@ViewBuilder
+	var statusView: some View {
+		let alertsCount = device.alertsCount(mainVM: mainScreenViewModel, followState: followState)
+		if alertsCount > 1 {
+			multipleAlertsView(alertsCount: alertsCount)
+		} else if device.isActive {
+			warningView
+		} else {
+			HStack(spacing: CGFloat(.smallSpacing)) {
+				Image(asset: .offlineIcon)
+					.renderingMode(.template)
+					.foregroundColor(Color(colorEnum: .error))
+
+				Text(LocalizableString.offlineStation.localized)
+					.foregroundColor(Color(colorEnum: .text))
+					.font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
+
+				Spacer()
+			}
+			.padding(CGFloat(.smallSidePadding))
+		}
+	}
+
+	@ViewBuilder
+	func multipleAlertsView(alertsCount: Int) -> some View {
+		HStack(spacing: CGFloat(.smallSpacing)) {
+			Image(asset: .offlineIcon)
+				.renderingMode(.template)
+				.foregroundColor(Color(colorEnum: .error))
+
+			Text(LocalizableString.issues(alertsCount).localized)
+				.foregroundColor(Color(colorEnum: .text))
+				.font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
+
+			Spacer()
+
+			Button {
+				Router.shared.navigateTo(.viewMoreAlerts(ViewModelsFactory.getAlertsViewModel(device: device,
+																							  mainVM: mainScreenViewModel,
+																							  followState: followState)))
+
+			} label: {
+				Text(LocalizableString.viewMore.localized)
+					.foregroundColor(Color(colorEnum: .primary))
+					.font(.system(size: CGFloat(.normalFontSize), weight: .bold))
+					.padding(.horizontal, CGFloat(.smallSidePadding))
+			}
+
+		}
+		.padding(CGFloat(.smallSidePadding))
+	}
+
+	@ViewBuilder
+	var warningView: some View {
+		if device.needsUpdate(mainVM: mainScreenViewModel, followState: followState) {
+			CardWarningView(title: LocalizableString.stationWarningUpdateTitle.localized,
+							message: LocalizableString.stationWarningUpdateDescription.localized,
+							showContentFullWidth: true,
+							closeAction: nil) {
+				Button {
+					mainScreenViewModel.showFirmwareUpdate(device: device)
+
+					Logger.shared.trackEvent(.prompt, parameters: [.promptName: .OTAAvailable,
+																   .promptType: .warnPromptType,
+																   .action: .action])
+				} label: {
+					Text(LocalizableString.stationWarningUpdateButtonTitle.localized)
+				}
+				.buttonStyle(WXMButtonStyle())
+				.buttonStyle(.plain)
+			}
+			.padding(.vertical, CGFloat(.smallSidePadding))
+			.onAppear {
+				Logger.shared.trackEvent(.prompt, parameters: [.promptName: .OTAAvailable,
+															   .promptType: .warnPromptType,
+															   .action: .viewAction])
+			}
+		} else {
+			EmptyView()
+		}
+	}
+
+}
+
+
+extension View {
+	@ViewBuilder
+	func stationIndication(device: DeviceDetails, followState: UserDeviceFollowState?) -> some View {
+		modifier(StationIndicationModifier(device: device, followState: followState))
+	}
+}
+
+#Preview {
+	VStack {
+		HStack {
+			Spacer()
+			Text(verbatim: "Station")
+			Spacer()
+		}
+	}
+	.WXMCardStyle()
+	.stationIndication(device: .mockDevice, followState: nil)
+	.wxmShadow()
+	.padding()
+}

--- a/PresentationLayer/UI Components/Screens/Multiple Alerts/MultipleAlertsView.swift
+++ b/PresentationLayer/UI Components/Screens/Multiple Alerts/MultipleAlertsView.swift
@@ -32,7 +32,7 @@ struct MultipleAlertsView: View {
                             .padding(.top, CGFloat(.smallSidePadding))
                         }
                         .onAppear(perform: alert.appearAction)
-                    }
+					}.iPadMaxWidth()
                 }
                 .padding(CGFloat(.defaultSidePadding))
             }

--- a/PresentationLayer/UI Components/Screens/WeatherStations/Station Details/Observations/ObservationsView.swift
+++ b/PresentationLayer/UI Components/Screens/WeatherStations/Station Details/Observations/ObservationsView.swift
@@ -57,6 +57,7 @@ private extension ObservationsView {
                                 isButtonEnabled: viewModel.followState != nil) {
                 viewModel.handleHistoricalDataButtonTap()
             }
+			.stationIndication(device: device, followState: viewModel.followState)
         } else {
             EmptyView()
         }

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		266B01912B836FE6007AC689 /* anim_rocket.json in Resources */ = {isa = PBXBuildFile; fileRef = 266B01902B836FE6007AC689 /* anim_rocket.json */; };
 		266B01932B8380FA007AC689 /* AnnouncementCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266B01922B8380FA007AC689 /* AnnouncementCardView.swift */; };
 		266B01CD2B84FB59007AC689 /* NetworkDeviceRewardsSummaryResponse+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266B01CC2B84FB59007AC689 /* NetworkDeviceRewardsSummaryResponse+.swift */; };
+		266B01E52B8767E4007AC689 /* StationIndication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266B01E42B8767E4007AC689 /* StationIndication.swift */; };
 		266BAF4D2AA8769C004F5DE0 /* LocalizableString+Bluetooth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266BAF4C2AA8769C004F5DE0 /* LocalizableString+Bluetooth.swift */; };
 		266BAF552AA88631004F5DE0 /* LocalizableString+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266BAF542AA88631004F5DE0 /* LocalizableString+Analytics.swift */; };
 		266BAF632AA88996004F5DE0 /* LocalizableString+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266BAF622AA88996004F5DE0 /* LocalizableString+Search.swift */; };
@@ -582,6 +583,7 @@
 		266B01902B836FE6007AC689 /* anim_rocket.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_rocket.json; sourceTree = "<group>"; };
 		266B01922B8380FA007AC689 /* AnnouncementCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementCardView.swift; sourceTree = "<group>"; };
 		266B01CC2B84FB59007AC689 /* NetworkDeviceRewardsSummaryResponse+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkDeviceRewardsSummaryResponse+.swift"; sourceTree = "<group>"; };
+		266B01E42B8767E4007AC689 /* StationIndication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationIndication.swift; sourceTree = "<group>"; };
 		266BAF4C2AA8769C004F5DE0 /* LocalizableString+Bluetooth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalizableString+Bluetooth.swift"; sourceTree = "<group>"; };
 		266BAF542AA88631004F5DE0 /* LocalizableString+Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalizableString+Analytics.swift"; sourceTree = "<group>"; };
 		266BAF622AA88996004F5DE0 /* LocalizableString+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalizableString+Search.swift"; sourceTree = "<group>"; };
@@ -1353,6 +1355,7 @@
 				2675470429A9181E008BCF40 /* WXMToggleStyle.swift */,
 				264CDE0E2B5A8817004C8F39 /* ReceiveNotificationsModifier.swift */,
 				269E85702B0242C100BE774C /* WXMShareModifier.swift */,
+				266B01E42B8767E4007AC689 /* StationIndication.swift */,
 			);
 			path = Modifiers;
 			sourceTree = "<group>";
@@ -2744,6 +2747,7 @@
 				26BA07772B7FC2AC00F7F5A0 /* WeeklyStreakView.swift in Sources */,
 				2692D8722A4D8DEA0060CB3C /* Numeric+.swift in Sources */,
 				26A4115929B6078500A2C10B /* ObservationsView.swift in Sources */,
+				266B01E52B8767E4007AC689 /* StationIndication.swift in Sources */,
 				2655F1812AD3FA8400BB19D5 /* WidgetConstants.swift in Sources */,
 				264CDE0F2B5A8817004C8F39 /* ReceiveNotificationsModifier.swift in Sources */,
 				26A4115B29B60F2900A2C10B /* ObservationsViewModel.swift in Sources */,


### PR DESCRIPTION
## **Why?**
Show the same error/warning indication with home screen in observations' tab
### **How?**
- Declared a dedicated modifier for station indication to be used in home and station screens
- Fixed layout issue for iPad in multiple alerts view
### **Testing**
Check a station with errors and make sure the indication is presented properly
### **Additional context**
fixes fe-600
