### PR TITLE
Implementation of reward issues screen

### DIFF
--- a/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardsSummaryResponse+.swift
+++ b/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardsSummaryResponse+.swift
@@ -61,6 +61,24 @@ extension NetworkDeviceRewardsSummary: Identifiable {
 	}
 }
 
+extension RewardAnnotation {
+	var warningType: CardWarningType? {
+		guard let severity else {
+			return nil
+		}
+
+		switch severity {
+			case .info:
+				return .info
+			case .warning:
+				return .warning
+			case .error:
+				return .error
+		}
+	}
+}
+
+
 extension NetworkDeviceRewardsSummaryTimelineEntry {
 	var toWeeklyEntry: WeeklyStreakView.Entry? {
 		guard let timestamp else {

--- a/PresentationLayer/Navigation/Router.swift
+++ b/PresentationLayer/Navigation/Router.swift
@@ -53,6 +53,8 @@ enum Route: Hashable, Equatable {
 				hasher.combine("\(title)-\(url)-\(params)")
 			case .selectStationLocation(let vm):
 				hasher.combine(vm)
+			case .rewardAnnotations(let vm):
+				hasher.combine(vm)
 			case .safariView(let url):
 				hasher.combine(url)
         }
@@ -96,6 +98,8 @@ enum Route: Hashable, Equatable {
 				"webView"
 			case .selectStationLocation:
 				"selectStationLocation"
+			case .rewardAnnotations:
+				"rewardAnnotations"
 			case .safariView:
 				"safariView"
 		}
@@ -119,6 +123,7 @@ enum Route: Hashable, Equatable {
 	case rewardDetails(RewardDetailsViewModel)
 	case webView(String, String, [DisplayLinkParams: String]?, DeepLinkHandler.QueryParamsCallBack?)
 	case selectStationLocation(SelectStationLocationViewModel)
+	case rewardAnnotations(RewardAnnotationsViewModel)
 	case safariView(URL)
 }
 
@@ -191,6 +196,8 @@ extension Route {
 				NavigationContainerView {
 					SelectStationLocationView(viewModel: selectStationLocationViewModel)
 				}
+			case .rewardAnnotations(let rewardAnnotationsViewModel):
+				RewardAnnotaionsView(viewModel: rewardAnnotationsViewModel)
 			case .safariView(let url):
 				SafariView(url: url)
 					.ignoresSafeArea()

--- a/PresentationLayer/UI Components/Modifiers/WXMButtonStyle.swift
+++ b/PresentationLayer/UI Components/Modifiers/WXMButtonStyle.swift
@@ -96,7 +96,7 @@ extension WXMButtonStyle {
 	static var transparent: Self {
 		Self.init(textColor: Color(colorEnum: .primary),
 				  textColorDisabled: Color(colorEnum: .midGrey),
-				  fillColor: Color(colorEnum: .top).opacity(0.15),
+				  fillColor: Color(colorEnum: .top).opacity(0.5),
 				  fillColorDisabled: Color(colorEnum: .midGrey).opacity(0.15),
 				  strokeColor: Color.clear,
 				  strokeColorDisabled: Color.clear)

--- a/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotaionsView.swift
+++ b/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotaionsView.swift
@@ -53,7 +53,9 @@ private extension ContentView {
 			}
 
 			HStack {
-				Text(LocalizableString.RewardDetails.reportFor(viewModel.refDate.getFormattedDate(format: .monthLiteralDayYear, showTimeZoneIndication: true).capitalized).localized)
+				Text(LocalizableString.RewardDetails.reportFor(viewModel.refDate.getFormattedDate(format: .monthLiteralDayYear,
+																								  timezone: .UTCTimezone,
+																								  showTimeZoneIndication: true).capitalizedSentence).localized)
 					.foregroundColor(Color(.darkGrey))
 					.font(.system(size: CGFloat(.normalFontSize)))
 				Spacer()

--- a/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotaionsView.swift
+++ b/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotaionsView.swift
@@ -53,7 +53,7 @@ private extension ContentView {
 			}
 
 			HStack {
-				Text(LocalizableString.RewardDetails.reportFor("").localized)
+				Text(LocalizableString.RewardDetails.reportFor(viewModel.refDate.getFormattedDate(format: .monthLiteralDayYear, showTimeZoneIndication: true).capitalized).localized)
 					.foregroundColor(Color(.darkGrey))
 					.font(.system(size: CGFloat(.normalFontSize)))
 				Spacer()
@@ -106,5 +106,6 @@ private extension ContentView {
 																										title: "Wallet annotation",
 																										message: "Wallet annotation message",
 																										docUrl: "url")],
-																					followState: .init(deviceId: "", relation: .owned)))
+																					followState: .init(deviceId: "", relation: .owned),
+																					refDate: .now))
 }

--- a/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotaionsView.swift
+++ b/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotaionsView.swift
@@ -24,7 +24,7 @@ private struct ContentView: View {
 
 	var body: some View {
 		ZStack {
-			Color(colorEnum: .bg)
+			Color(colorEnum: .top)
 				.ignoresSafeArea()
 			TrackableScrollView {
 				VStack(spacing: CGFloat(.largeSpacing)) {
@@ -36,7 +36,7 @@ private struct ContentView: View {
 			}
 		}
 		.onAppear {
-			navigationObject.navigationBarColor = Color(.bg)
+			navigationObject.navigationBarColor = Color(.top)
 		}
 	}
 }
@@ -44,7 +44,7 @@ private struct ContentView: View {
 private extension ContentView {
 	@ViewBuilder
 	var titleView: some View {
-		VStack(spacing: 0.0) {
+		VStack(spacing: CGFloat(.minimumSpacing)) {
 			HStack {
 				Text(LocalizableString.RewardDetails.rewardIssues.localized)
 					.foregroundColor(Color(.text))

--- a/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotaionsView.swift
+++ b/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotaionsView.swift
@@ -1,0 +1,110 @@
+//
+//  RewardAnnotaionsView.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 28/2/24.
+//
+
+import SwiftUI
+import DomainLayer
+
+struct RewardAnnotaionsView: View {
+	@StateObject var viewModel: RewardAnnotationsViewModel
+
+	var body: some View {
+		NavigationContainerView {
+			ContentView(viewModel: viewModel)
+		}
+	}
+}
+
+private struct ContentView: View {
+	@StateObject var viewModel: RewardAnnotationsViewModel
+	@EnvironmentObject var navigationObject: NavigationObject
+
+	var body: some View {
+		ZStack {
+			Color(colorEnum: .bg)
+				.ignoresSafeArea()
+			TrackableScrollView {
+				VStack(spacing: CGFloat(.largeSpacing)) {
+					titleView
+
+					annotationsListView
+				}
+				.padding(.horizontal, CGFloat(.defaultSidePadding))
+			}
+		}
+		.onAppear {
+			navigationObject.navigationBarColor = Color(.bg)
+		}
+	}
+}
+
+private extension ContentView {
+	@ViewBuilder
+	var titleView: some View {
+		VStack(spacing: 0.0) {
+			HStack {
+				Text(LocalizableString.RewardDetails.rewardIssues.localized)
+					.foregroundColor(Color(.text))
+					.font(.system(size: CGFloat(.titleFontSize), weight: .bold))
+				Spacer()
+			}
+
+			HStack {
+				Text(LocalizableString.RewardDetails.reportFor("").localized)
+					.foregroundColor(Color(.darkGrey))
+					.font(.system(size: CGFloat(.normalFontSize)))
+				Spacer()
+			}
+
+		}
+	}
+
+	@ViewBuilder
+	var annotationsListView: some View {
+		VStack(spacing: CGFloat(.mediumSpacing)) {
+			ForEach(viewModel.annotations) { annotation in
+				CardWarningView(type: annotation.warningType ?? .warning,
+								showIcon: false,
+								title: annotation.title ?? "",
+								message: annotation.message ?? "",
+								showBorder: true,
+								closeAction: nil) {
+					actionView(for: annotation)
+						.padding(.top, CGFloat(.smallSidePadding))
+				}
+			}
+		}
+	}
+
+	@ViewBuilder
+	func actionView(for error: RewardAnnotation) -> some View {
+		if let title = viewModel.annotationActionButtonTile(for: error) {
+			Button {
+				viewModel.handleButtonTap(for: error)
+			} label: {
+				Text(title)
+			}
+			.buttonStyle(WXMButtonStyle.transparent)
+		} else {
+			EmptyView()
+		}
+	}
+}
+
+#Preview {
+	RewardAnnotaionsView(viewModel: ViewModelsFactory.getRewardAnnotationsViewModel(device: .mockDevice,
+																					annotations: [.init(severity: .warning,
+																										group: .noWallet,
+																										title: "Wallet annotation",
+																										message: "Wallet annotation message",
+																										docUrl: "url"),
+																								  .init(severity: .error,
+																										group: .noWallet,
+																										title: "Wallet annotation",
+																										message: "Wallet annotation message",
+																										docUrl: "url")],
+																					followState: .init(deviceId: "", relation: .owned)))
+}

--- a/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotationsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotationsViewModel.swift
@@ -1,0 +1,92 @@
+//
+//  RewardAnnotationsViewModel.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 28/2/24.
+//
+
+import Foundation
+import Combine
+import DomainLayer
+import SwiftUI
+import Toolkit
+
+class RewardAnnotationsViewModel: ObservableObject {
+	let device: DeviceDetails
+	let annotations: [RewardAnnotation]
+	let followState: UserDeviceFollowState?
+
+	init(device: DeviceDetails, annotations: [RewardAnnotation], followState: UserDeviceFollowState?) {
+		self.device = device
+		self.annotations = annotations.sorted { ($0.severity ?? .info) < ($1.severity ?? .info) }
+		self.followState = followState
+	}
+
+	func annotationActionButtonTile(for annotation: RewardAnnotation?) -> String? {
+		guard let group = annotation?.group else {
+			return nil
+		}
+
+		let isOwned = followState?.relation == .owned
+		switch group {
+			case .noWallet:
+				if MainScreenViewModel.shared.isWalletMissing, isOwned {
+					return LocalizableString.RewardDetails.noWalletProblemButtonTitle.localized
+				} else if annotation?.docUrl != nil {
+					return LocalizableString.RewardDetails.readMore.localized
+				}
+				return nil
+			case .locationNotVerified:
+				if isOwned {
+					return LocalizableString.RewardDetails.editLocation.localized
+				} else if annotation?.docUrl != nil {
+					return LocalizableString.RewardDetails.readMore.localized
+				}
+				return nil
+			case .unknown:
+				if annotation?.docUrl != nil {
+					return LocalizableString.RewardDetails.readMore.localized
+				}
+				return nil
+		}
+	}
+
+	func handleButtonTap(for error: RewardAnnotation) {
+		Logger.shared.trackEvent(.userAction, parameters: [.actionName: .rewardDetailsError,
+														   .itemId: .custom(error.group?.rawValue ?? "")])
+		handleRewardAnnotation(annotation: error)
+	}
+
+	func handleRewardAnnotation(annotation: RewardAnnotation) {
+		guard let group = annotation.group else {
+			return
+		}
+
+		let isOwned = followState?.relation == .owned
+
+		switch group {
+			case .noWallet:
+				if MainScreenViewModel.shared.isWalletMissing, isOwned {
+					Router.shared.navigateTo(.wallet(ViewModelsFactory.getMyWalletViewModel()))
+				} else if let docUrl = annotation.docUrl,
+				   let url = URL(string: docUrl) {
+					UIApplication.shared.open(url)
+				}
+			case .locationNotVerified:
+				if isOwned {
+					let viewModel = ViewModelsFactory.getSelectLocationViewModel(device: device,
+																				 followState: followState,
+																				 delegate: nil)
+					Router.shared.navigateTo(.selectStationLocation(viewModel))
+				} else if let docUrl = annotation.docUrl,
+						  let url = URL(string: docUrl) {
+					 UIApplication.shared.open(url)
+				 }
+			case .unknown:
+				if let docUrl = annotation.docUrl,
+				   let url = URL(string: docUrl) {
+					UIApplication.shared.open(url)
+				}
+		}
+	}
+}

--- a/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotationsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotationsViewModel.swift
@@ -92,3 +92,9 @@ class RewardAnnotationsViewModel: ObservableObject {
 		}
 	}
 }
+
+extension RewardAnnotationsViewModel: HashableViewModel {
+	func hash(into hasher: inout Hasher) {
+		hasher.combine("\(device.id)-\(refDate.timeIntervalSince1970)")
+	}
+}

--- a/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotationsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotationsViewModel.swift
@@ -15,11 +15,13 @@ class RewardAnnotationsViewModel: ObservableObject {
 	let device: DeviceDetails
 	let annotations: [RewardAnnotation]
 	let followState: UserDeviceFollowState?
+	let refDate: Date
 
-	init(device: DeviceDetails, annotations: [RewardAnnotation], followState: UserDeviceFollowState?) {
+	init(device: DeviceDetails, annotations: [RewardAnnotation], followState: UserDeviceFollowState?, refDate: Date) {
 		self.device = device
 		self.annotations = annotations.sorted { ($0.severity ?? .info) < ($1.severity ?? .info) }
 		self.followState = followState
+		self.refDate = refDate
 	}
 
 	func annotationActionButtonTile(for annotation: RewardAnnotation?) -> String? {

--- a/PresentationLayer/UI Components/ViewModelsFactory.swift
+++ b/PresentationLayer/UI Components/ViewModelsFactory.swift
@@ -160,4 +160,10 @@ enum ViewModelsFactory {
 		let useCase = SwinjectHelper.shared.getContainerForSwinject().resolve(MainUseCase.self)!
 		return AppUpdateViewModel(useCase: useCase)
 	}
+
+	static func getRewardAnnotationsViewModel(device: DeviceDetails,
+											  annotations: [RewardAnnotation],
+											  followState: UserDeviceFollowState?) -> RewardAnnotationsViewModel {
+		return RewardAnnotationsViewModel(device: device, annotations: annotations, followState: followState)
+	}
 }

--- a/PresentationLayer/UI Components/ViewModelsFactory.swift
+++ b/PresentationLayer/UI Components/ViewModelsFactory.swift
@@ -163,7 +163,8 @@ enum ViewModelsFactory {
 
 	static func getRewardAnnotationsViewModel(device: DeviceDetails,
 											  annotations: [RewardAnnotation],
-											  followState: UserDeviceFollowState?) -> RewardAnnotationsViewModel {
-		return RewardAnnotationsViewModel(device: device, annotations: annotations, followState: followState)
+											  followState: UserDeviceFollowState?,
+											  refDate: Date) -> RewardAnnotationsViewModel {
+		return RewardAnnotationsViewModel(device: device, annotations: annotations, followState: followState, refDate: refDate)
 	}
 }

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -407,6 +407,8 @@
 		26E9A5142AE26AFE003E0830 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E9A5132AE26AFE003E0830 /* View+.swift */; };
 		26F246362A278DAB0089D3E7 /* CustomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2664831829C31AF400748F9C /* CustomSheet.swift */; };
 		26FFAD682B8DF9C200BF0A6B /* LazyLoadingPager in Frameworks */ = {isa = PBXBuildFile; productRef = 26FFAD672B8DF9C200BF0A6B /* LazyLoadingPager */; };
+		26FFADD42B8F684C00BF0A6B /* RewardAnnotaionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFADD32B8F684C00BF0A6B /* RewardAnnotaionsView.swift */; };
+		26FFADD82B8F688900BF0A6B /* RewardAnnotationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFADD72B8F688900BF0A6B /* RewardAnnotationsViewModel.swift */; };
 		7423EC15283F81E2004E9B26 /* anim_weather_cloudy.json in Resources */ = {isa = PBXBuildFile; fileRef = 7423EBFE283F81E2004E9B26 /* anim_weather_cloudy.json */; };
 		7423EC16283F81E2004E9B26 /* anim_weather_clear_day.json in Resources */ = {isa = PBXBuildFile; fileRef = 7423EBFF283F81E2004E9B26 /* anim_weather_clear_day.json */; };
 		7423EC17283F81E2004E9B26 /* anim_not_available.json in Resources */ = {isa = PBXBuildFile; fileRef = 7423EC00283F81E2004E9B26 /* anim_not_available.json */; };
@@ -843,6 +845,8 @@
 		26E88AF429DD69930023BBD5 /* WXMShadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WXMShadow.swift; sourceTree = "<group>"; };
 		26E88AFE29E02F590023BBD5 /* anim_loader.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_loader.json; sourceTree = "<group>"; };
 		26E9A5132AE26AFE003E0830 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
+		26FFADD32B8F684C00BF0A6B /* RewardAnnotaionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAnnotaionsView.swift; sourceTree = "<group>"; };
+		26FFADD72B8F688900BF0A6B /* RewardAnnotationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAnnotationsViewModel.swift; sourceTree = "<group>"; };
 		7423EBFE283F81E2004E9B26 /* anim_weather_cloudy.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_weather_cloudy.json; sourceTree = "<group>"; };
 		7423EBFF283F81E2004E9B26 /* anim_weather_clear_day.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_weather_clear_day.json; sourceTree = "<group>"; };
 		7423EC00283F81E2004E9B26 /* anim_not_available.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_not_available.json; sourceTree = "<group>"; };
@@ -968,6 +972,7 @@
 		262A4CEB2A93517300A4BC17 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				26FFADD22B8F682D00BF0A6B /* RewardAnnotations */,
 				268D07912B2B1B54002BD77E /* Select Station Location */,
 				262B03052B20BC5400C31FE7 /* App Update */,
 				2623FF8F2AF1467E00BCDAC6 /* Daily Rewards  */,
@@ -2093,6 +2098,15 @@
 			path = "Station Details";
 			sourceTree = "<group>";
 		};
+		26FFADD22B8F682D00BF0A6B /* RewardAnnotations */ = {
+			isa = PBXGroup;
+			children = (
+				26FFADD32B8F684C00BF0A6B /* RewardAnnotaionsView.swift */,
+				26FFADD72B8F688900BF0A6B /* RewardAnnotationsViewModel.swift */,
+			);
+			path = RewardAnnotations;
+			sourceTree = "<group>";
+		};
 		7423EBFD283F81E2004E9B26 /* LottieJSON */ = {
 			isa = PBXGroup;
 			children = (
@@ -2599,6 +2613,7 @@
 				26D47EA12A1783E60078723A /* AnalyticsView.swift in Sources */,
 				269E85712B0242C100BE774C /* WXMShareModifier.swift in Sources */,
 				26CA845A2AD93BB6006D47D7 /* String+Common.swift in Sources */,
+				26FFADD82B8F688900BF0A6B /* RewardAnnotationsViewModel.swift in Sources */,
 				26D47EA32A179CEB0078723A /* AnalyticsViewModel.swift in Sources */,
 				267548D529A91A87008BCF40 /* AnimationsEnums.swift in Sources */,
 				B557E2152825212700E0BDCB /* AppDelegate.swift in Sources */,
@@ -2823,6 +2838,7 @@
 				267548CD29A91A87008BCF40 /* TabSelectionEnum.swift in Sources */,
 				262A4D862A94D89300A4BC17 /* TabViewWrapper.swift in Sources */,
 				268D07952B2B1B85002BD77E /* SelectStationLocationViewModel.swift in Sources */,
+				26FFADD42B8F684C00BF0A6B /* RewardAnnotaionsView.swift in Sources */,
 				267548F429A91A87008BCF40 /* Text+.swift in Sources */,
 				26348DF82A42F430000846C6 /* TextfieldClearButton.swift in Sources */,
 				267548CE29A91A87008BCF40 /* TextFieldError.swift in Sources */,

--- a/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
+++ b/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
@@ -18,6 +18,8 @@ extension LocalizableString {
 		case noWalletProblemButtonTitle
 		case viewTransaction
 		case readMore
+		case rewardIssues
+		case reportFor(String)
 		case editLocation
 		case rewardScoreInfoTitle
 		case rewardScoreInfoDescription(String)
@@ -35,7 +37,8 @@ extension LocalizableString.RewardDetails: WXMLocalizable {
 		switch self {
 			case .problemsDescription(let text),
 					.rewardScoreInfoDescription(let text),
-					.maxRewardsInfoDescription(let text):
+					.maxRewardsInfoDescription(let text),
+					.reportFor(let text):
 				localized = String(format: localized, text)
 			case .timelineInfoDescription(let timezoneOffset, let url):
 				localized = String(format: localized, arguments: [timezoneOffset, url].compactMap { $0 })
@@ -65,6 +68,10 @@ extension LocalizableString.RewardDetails: WXMLocalizable {
 				return "reward_details_view_transaction"
 			case .readMore:
 				return "reward_details_read_more"
+			case .rewardIssues:
+				return "reward_details_reward_issues"
+			case .reportFor:
+				return "reward_details_report_for_format"
 			case .editLocation:
 				return "reward_details_edit_location"
 			case .rewardScoreInfoTitle:

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -4835,6 +4835,28 @@
         }
       }
     },
+    "reward_details_report_for_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Report for %@"
+          }
+        }
+      }
+    },
+    "reward_details_reward_issues" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reward Issues"
+          }
+        }
+      }
+    },
     "reward_details_reward_score_info_description_format" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## **Why?**
Implementation of annotations screen 
### **How?**
A temp functionality to open the annotations screen on `View Reward Details` tap
### **Testing**
Ignore any weird stuff in the rewards tap and just tap the `View Reward Details` button to navigate to the annotations screen.
Once the PR is approved the navigation functionality will be removed and will be finalized in the next PR
### **Additional context**
fixes fe-656
