### PR TITLE
Reward details screen and components

### DIFF
--- a/PresentationLayer/Constants/FontsEnum.swift
+++ b/PresentationLayer/Constants/FontsEnum.swift
@@ -33,6 +33,8 @@ enum FontIcon: String {
     case home = "home"
     case hexagon
 	case hexagonCheck = "hexagon-check"
+	case hexagonExclamation = "hexagon-exclamation"
+	case hexagonXmark = "hexagon-xmark"
     case share = "share-nodes"
     case heart
     case lock

--- a/PresentationLayer/Constants/FontsEnum.swift
+++ b/PresentationLayer/Constants/FontsEnum.swift
@@ -32,6 +32,7 @@ enum FontIcon: String {
     case externalLink = "arrow-up-right-from-square"
     case home = "home"
     case hexagon
+	case hexagonCheck = "hexagon-check"
     case share = "share-nodes"
     case heart
     case lock

--- a/PresentationLayer/Constants/Strings/SuccessFailEnum.swift
+++ b/PresentationLayer/Constants/Strings/SuccessFailEnum.swift
@@ -32,6 +32,7 @@ enum SuccessFailEnum: CustomStringConvertible {
 	case profile
 	case deleteAccount
 	case editLocation
+	case rewardDetails
 
     var description: String {
         switch self {
@@ -82,6 +83,8 @@ enum SuccessFailEnum: CustomStringConvertible {
 			case .deleteAccount:
 				return ""
 			case .editLocation:
+				return ""
+			case .rewardDetails:
 				return ""
         }
     }

--- a/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
+++ b/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
@@ -1,0 +1,16 @@
+//
+//  NetworkDeviceRewardDetailsResponse+.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 28/2/24.
+//
+
+import Foundation
+import DomainLayer
+
+extension NetworkDeviceRewardDetailsResponse {
+
+}
+
+extension NetworkDeviceRewardDetailsResponse.Annotation {
+}

--- a/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
+++ b/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
@@ -80,11 +80,11 @@ extension NetworkDeviceRewardDetailsResponse {
 		}
 
 		switch rewardScore {
-			case 0..<65:
+			case 0..<10:
 				return .error
-			case 65..<98:
+			case 10..<95:
 				return .warning
-			case 98...100:
+			case 95...100:
 				return .success
 			default:
 				return .clear
@@ -97,11 +97,11 @@ extension NetworkDeviceRewardDetailsResponse {
 		}
 
 		switch rewardScore {
-			case 0..<65:
+			case 0..<10:
 				return .hexagonXmark
-			case 65..<98:
+			case 10..<95:
 				return .hexagonExclamation
-			case 98...100:
+			case 95...100:
 				return .hexagonCheck
 			default:
 				return .hexagonExclamation

--- a/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
+++ b/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
@@ -43,17 +43,17 @@ extension NetworkDeviceRewardDetailsResponse.Annotation {
 	}
 }
 
-extension NetworkDeviceRewardDetailsResponse.Base {
-	func scoreObject(followState: UserDeviceFollowState?) -> RewardFieldView.Score {
-		.init(fontIcon: fontIcon,
-			  score: Float(rewardScore ?? 0),
-			  color: color,
-			  message: message(followState: followState),
-			  showIndication: color != .success )
+extension NetworkDeviceRewardDetailsResponse {
+	func dataQualityScoreObject(followState: UserDeviceFollowState?) -> RewardFieldView.Score {
+		.init(fontIcon: dataQualityfontIcon,
+			  score: Float(base?.rewardScore ?? 0),
+			  color: dataQualityColor,
+			  message: dataQualityMessage(followState: followState),
+			  showIndication: dataQualityColor != .success )
 	}
 
-	private func message(followState: UserDeviceFollowState?) -> String {
-		guard let rewardScore else {
+	private func dataQualityMessage(followState: UserDeviceFollowState?) -> String {
+		guard let rewardScore = base?.rewardScore else {
 			return LocalizableString.RewardDetails.dataQualityNoInfoMessage.localized
 		}
 
@@ -95,8 +95,8 @@ extension NetworkDeviceRewardDetailsResponse.Base {
 	}
 
 
-	private var color: ColorEnum {
-		guard let rewardScore else {
+	private var dataQualityColor: ColorEnum {
+		guard let rewardScore = base?.rewardScore else {
 			return .clear
 		}
 
@@ -112,8 +112,8 @@ extension NetworkDeviceRewardDetailsResponse.Base {
 		}
 	}
 
-	private var fontIcon: FontIcon {
-		guard let rewardScore else {
+	private var dataQualityfontIcon: FontIcon {
+		guard let rewardScore = base?.rewardScore else {
 			return .hexagonExclamation
 		}
 
@@ -127,6 +127,65 @@ extension NetworkDeviceRewardDetailsResponse.Base {
 			default:
 				return .hexagonExclamation
 		}
+	}
+
+}
+
+extension NetworkDeviceRewardDetailsResponse {
+	var locationQualityScoreObject: RewardFieldView.Score {
+		.init(fontIcon: locationQualityFontIcon,
+			  score: nil,
+			  color: locationQualityColor,
+			  message: locationQualityMessage,
+			  showIndication: locationQualityColor != .success)
+	}
+
+	private var locationQualityFontIcon: FontIcon {
+		guard let summary = annotation?.summary?.first(where: { $0.group == .locationNotVerified || $0.group == .noLocationData || $0.group == .userRelocationPenalty }),
+			  let severity = summary.severity else {
+			return .hexagonCheck
+		}
+
+		switch severity {
+			case .info:
+				return .hexagonCheck
+			case .warning:
+				return .hexagonExclamation
+			case .error:
+				return .hexagonXmark
+		}
+	}
+
+	private var locationQualityColor: ColorEnum {
+		guard let summary = annotation?.summary?.first(where: { $0.group == .locationNotVerified || $0.group == .noLocationData || $0.group == .userRelocationPenalty }),
+			  let severity = summary.severity else {
+			return .success
+		}
+
+		switch severity {
+			case .info:
+				return .success
+			case .warning:
+				return .warning
+			case .error:
+				return .error
+		}
+	}
+
+	private var locationQualityMessage: String {
+		if annotation?.summary?.first(where: { $0.group == .locationNotVerified }) != nil {
+			return LocalizableString.RewardDetails.locationNotVerified.localized
+		}
+
+		if annotation?.summary?.first(where: { $0.group == .noLocationData }) != nil {
+			return LocalizableString.RewardDetails.noLocationData.localized
+		}
+
+		if annotation?.summary?.first(where: { $0.group == .userRelocationPenalty }) != nil {
+			return LocalizableString.RewardDetails.recentlyRelocated.localized
+		}
+
+		return LocalizableString.RewardDetails.locationVerified.localized
 	}
 
 }

--- a/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
+++ b/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
@@ -9,33 +9,12 @@ import Foundation
 import DomainLayer
 
 extension NetworkDeviceRewardDetailsResponse {
-
-}
-
-extension NetworkDeviceRewardDetailsResponse.Annotation {
-	var color: ColorEnum? {
-		guard let score else {
-			return nil
-		}
-
-		switch score {
-			case 0..<10:
-				return .error
-			case 10..<95:
-				return .warning
-			case 95..<100:
-				return .darkestBlue
-			default:
-				return nil
-		}
-	}
-
 	var mainAnnotation: RewardAnnotation? {
-		if let annotation = summary?.first(where: { $0.severity == .error }) {
+		if let annotation = annotations?.first(where: { $0.severity == .error }) {
 			return annotation
-		} else if let annotation = summary?.first(where: { $0.severity == .warning }) {
+		} else if let annotation = annotations?.first(where: { $0.severity == .warning }) {
 			return annotation
-		} else if let annotation = summary?.first(where: { $0.severity == .info }) {
+		} else if let annotation = annotations?.first(where: { $0.severity == .info }) {
 			return annotation
 		}
 
@@ -141,7 +120,7 @@ extension NetworkDeviceRewardDetailsResponse {
 	}
 
 	private var locationQualityFontIcon: FontIcon {
-		guard let summary = annotation?.summary?.first(where: { $0.group == .locationNotVerified || $0.group == .noLocationData || $0.group == .userRelocationPenalty }),
+		guard let summary = annotations?.first(where: { $0.group == .locationNotVerified || $0.group == .noLocationData || $0.group == .userRelocationPenalty }),
 			  let severity = summary.severity else {
 			return .hexagonCheck
 		}
@@ -157,7 +136,7 @@ extension NetworkDeviceRewardDetailsResponse {
 	}
 
 	private var locationQualityColor: ColorEnum {
-		guard let summary = annotation?.summary?.first(where: { $0.group == .locationNotVerified || $0.group == .noLocationData || $0.group == .userRelocationPenalty }),
+		guard let summary = annotations?.first(where: { $0.group == .locationNotVerified || $0.group == .noLocationData || $0.group == .userRelocationPenalty }),
 			  let severity = summary.severity else {
 			return .success
 		}
@@ -173,15 +152,15 @@ extension NetworkDeviceRewardDetailsResponse {
 	}
 
 	private var locationQualityMessage: String {
-		if annotation?.summary?.first(where: { $0.group == .locationNotVerified }) != nil {
+		if annotations?.first(where: { $0.group == .locationNotVerified }) != nil {
 			return LocalizableString.RewardDetails.locationNotVerified.localized
 		}
 
-		if annotation?.summary?.first(where: { $0.group == .noLocationData }) != nil {
+		if annotations?.first(where: { $0.group == .noLocationData }) != nil {
 			return LocalizableString.RewardDetails.noLocationData.localized
 		}
 
-		if annotation?.summary?.first(where: { $0.group == .userRelocationPenalty }) != nil {
+		if annotations?.first(where: { $0.group == .userRelocationPenalty }) != nil {
 			return LocalizableString.RewardDetails.recentlyRelocated.localized
 		}
 
@@ -199,7 +178,7 @@ extension NetworkDeviceRewardDetailsResponse {
 	}
 
 	private var cellPositionFontIcon: FontIcon {
-		guard let severity = annotation?.summary?.first(where: { $0.group == .cellCapacityReached })?.severity else {
+		guard let severity = annotations?.first(where: { $0.group == .cellCapacityReached })?.severity else {
 			return .hexagonCheck
 		}
 
@@ -214,7 +193,7 @@ extension NetworkDeviceRewardDetailsResponse {
 	}
 
 	private var cellPositionColor: ColorEnum {
-		guard let severity = annotation?.summary?.first(where: { $0.group == .cellCapacityReached })?.severity else {
+		guard let severity = annotations?.first(where: { $0.group == .cellCapacityReached })?.severity else {
 			return .success
 		}
 
@@ -229,7 +208,7 @@ extension NetworkDeviceRewardDetailsResponse {
 	}
 
 	private var cellPositionMessage: String {
-		guard let annotation = annotation?.summary?.first(where: { $0.group == .cellCapacityReached }) else {
+		guard let annotation = annotations?.first(where: { $0.group == .cellCapacityReached }) else {
 			return LocalizableString.RewardDetails.cellPositionSuccessMessage.localized
 		}
 

--- a/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
+++ b/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
@@ -13,4 +13,32 @@ extension NetworkDeviceRewardDetailsResponse {
 }
 
 extension NetworkDeviceRewardDetailsResponse.Annotation {
+	var color: ColorEnum? {
+		guard let score else {
+			return nil
+		}
+
+		switch score {
+			case 0..<10:
+				return .error
+			case 10..<95:
+				return .warning
+			case 95..<100:
+				return .darkestBlue
+			default:
+				return nil
+		}
+	}
+
+	var mainAnnotation: RewardAnnotation? {
+		if let annotation = summary?.first(where: { $0.severity == .error }) {
+			return annotation
+		} else if let annotation = summary?.first(where: { $0.severity == .warning }) {
+			return annotation
+		} else if let annotation = summary?.first(where: { $0.severity == .info }) {
+			return annotation
+		}
+
+		return nil
+	}
 }

--- a/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
+++ b/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
@@ -187,5 +187,52 @@ extension NetworkDeviceRewardDetailsResponse {
 
 		return LocalizableString.RewardDetails.locationVerified.localized
 	}
+}
 
+extension NetworkDeviceRewardDetailsResponse {
+	var cellPositionScoreObject: RewardFieldView.Score {
+		.init(fontIcon: cellPositionFontIcon,
+			  score: nil,
+			  color: cellPositionColor,
+			  message: cellPositionMessage,
+			  showIndication: cellPositionColor != .success)
+	}
+
+	private var cellPositionFontIcon: FontIcon {
+		guard let severity = annotation?.summary?.first(where: { $0.group == .cellCapacityReached })?.severity else {
+			return .hexagonCheck
+		}
+
+		switch severity {
+			case .info:
+				return .hexagonCheck
+			case .warning:
+				return .hexagonExclamation
+			case .error:
+				return .hexagonXmark
+		}
+	}
+
+	private var cellPositionColor: ColorEnum {
+		guard let severity = annotation?.summary?.first(where: { $0.group == .cellCapacityReached })?.severity else {
+			return .success
+		}
+
+		switch severity {
+			case .info:
+				return .success
+			case .warning:
+				return .warning
+			case .error:
+				return .error
+		}
+	}
+
+	private var cellPositionMessage: String {
+		guard let annotation = annotation?.summary?.first(where: { $0.group == .cellCapacityReached }) else {
+			return LocalizableString.RewardDetails.cellPositionSuccessMessage.localized
+		}
+
+		return annotation.message ?? ""
+	}
 }

--- a/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
+++ b/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
@@ -42,3 +42,91 @@ extension NetworkDeviceRewardDetailsResponse.Annotation {
 		return nil
 	}
 }
+
+extension NetworkDeviceRewardDetailsResponse.Base {
+	func scoreObject(followState: UserDeviceFollowState?) -> RewardFieldView.Score {
+		.init(fontIcon: fontIcon,
+			  score: Float(rewardScore ?? 0),
+			  color: color,
+			  message: message(followState: followState),
+			  showIndication: color != .success )
+	}
+
+	private func message(followState: UserDeviceFollowState?) -> String {
+		guard let rewardScore else {
+			return LocalizableString.RewardDetails.dataQualityNoInfoMessage.localized
+		}
+
+		switch rewardScore {
+			case 0:
+				return LocalizableString.RewardDetails.dataQualityNoInfoMessage.localized
+			case 0..<20:
+				if followState?.relation == .owned {
+					return LocalizableString.RewardDetails.dataQualityVeryLowMessage(rewardScore).localized
+				}
+				return LocalizableString.RewardDetails.dataQualityPublicVeryLowMessage(rewardScore).localized
+			case 20..<40:
+				if followState?.relation == .owned {
+					return LocalizableString.RewardDetails.dataQualityLowMessage(rewardScore).localized
+				}
+				return LocalizableString.RewardDetails.dataQualityPublicLowMessage(rewardScore).localized
+			case 40..<60:
+				if followState?.relation == .owned {
+					return LocalizableString.RewardDetails.dataQualityAverageMessage(rewardScore).localized
+				}
+				return LocalizableString.RewardDetails.dataQualityPublicAverageMessage(rewardScore).localized
+			case 60..<80:
+				if followState?.relation == .owned {
+					return LocalizableString.RewardDetails.dataQualityOkMessage(rewardScore).localized
+				}
+				return LocalizableString.RewardDetails.dataQualityPublicOkMessage(rewardScore).localized
+			case 80..<95:
+				if followState?.relation == .owned {
+					return LocalizableString.RewardDetails.dataQualityGreatMessage(rewardScore).localized
+				}
+				return LocalizableString.RewardDetails.dataQualityPublicGreatMessage(rewardScore).localized
+			case 95..<100:
+				return LocalizableString.RewardDetails.dataQualityAlmostPerfectMessage(rewardScore).localized
+			case 100:
+				return LocalizableString.RewardDetails.dataQualitySolidMessage(rewardScore).localized
+			default:
+				return LocalizableString.RewardDetails.dataQualityNoInfoMessage.localized
+		}
+	}
+
+
+	private var color: ColorEnum {
+		guard let rewardScore else {
+			return .clear
+		}
+
+		switch rewardScore {
+			case 0..<65:
+				return .error
+			case 65..<98:
+				return .warning
+			case 98...100:
+				return .success
+			default:
+				return .clear
+		}
+	}
+
+	private var fontIcon: FontIcon {
+		guard let rewardScore else {
+			return .hexagonExclamation
+		}
+
+		switch rewardScore {
+			case 0..<65:
+				return .hexagonXmark
+			case 65..<98:
+				return .hexagonExclamation
+			case 98...100:
+				return .hexagonCheck
+			default:
+				return .hexagonExclamation
+		}
+	}
+
+}

--- a/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardsSummaryResponse+.swift
+++ b/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardsSummaryResponse+.swift
@@ -78,7 +78,6 @@ extension RewardAnnotation {
 	}
 }
 
-
 extension NetworkDeviceRewardsSummaryTimelineEntry {
 	var toWeeklyEntry: WeeklyStreakView.Entry? {
 		guard let timestamp else {

--- a/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardsSummaryResponse+.swift
+++ b/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardsSummaryResponse+.swift
@@ -6,6 +6,7 @@
 //
 
 import DomainLayer
+import UIKit
 
 extension NetworkDeviceRewardsSummaryResponse {
 	var isEmpty: Bool {
@@ -74,6 +75,68 @@ extension RewardAnnotation {
 				return .warning
 			case .error:
 				return .error
+		}
+	}
+
+	func annotationActionButtonTile(with followState: UserDeviceFollowState?) -> String? {
+		guard let group else {
+			return nil
+		}
+
+		let isOwned = followState?.relation == .owned
+		switch group {
+			case .noWallet:
+				if MainScreenViewModel.shared.isWalletMissing, isOwned {
+					return LocalizableString.RewardDetails.noWalletProblemButtonTitle.localized
+				} else if docUrl != nil {
+					return LocalizableString.RewardDetails.readMore.localized
+				}
+				return nil
+			case .locationNotVerified:
+				if isOwned {
+					return LocalizableString.RewardDetails.editLocation.localized
+				} else if docUrl != nil {
+					return LocalizableString.RewardDetails.readMore.localized
+				}
+				return nil
+			default:
+				if docUrl != nil {
+					return LocalizableString.RewardDetails.readMore.localized
+				}
+				return nil
+		}
+	}
+
+	func handleRewardAnnotationTap(with device: DeviceDetails, followState: UserDeviceFollowState?) {
+		guard let group else {
+			return
+		}
+
+		let isOwned = followState?.relation == .owned
+
+		switch group {
+			case .noWallet:
+				if MainScreenViewModel.shared.isWalletMissing, isOwned {
+					Router.shared.navigateTo(.wallet(ViewModelsFactory.getMyWalletViewModel()))
+				} else if let docUrl,
+				   let url = URL(string: docUrl) {
+					UIApplication.shared.open(url)
+				}
+			case .locationNotVerified:
+				if isOwned {
+					let viewModel = ViewModelsFactory.getSelectLocationViewModel(device: device,
+																				 followState: followState,
+																				 delegate: nil)
+					Router.shared.navigateTo(.selectStationLocation(viewModel))
+				} else if let docUrl,
+						  let url = URL(string: docUrl) {
+					 UIApplication.shared.open(url)
+				 }
+			default:
+				if let docUrl,
+				   let url = URL(string: docUrl) {
+					UIApplication.shared.open(url)
+				}
 		}
 	}
 }

--- a/PresentationLayer/UI Components/Base Components/Custom Sheet/BottomSheetModifier.swift
+++ b/PresentationLayer/UI Components/Base Components/Custom Sheet/BottomSheetModifier.swift
@@ -113,6 +113,15 @@ extension View {
 
 						Spacer()
 					}
+					.modify { view in
+						if info.scrollable == true {
+							ScrollView(showsIndicators: false) {
+								view
+							}
+						} else {
+							view
+						}
+					}
 
 					if let buttonTitle = info.buttonTitle, let buttonAction = info.buttonAction {
 						Button(action: buttonAction) {
@@ -130,6 +139,7 @@ extension View {
 struct BottomSheetInfo {
 	let title: String?
 	let description: String?
+	var scrollable: Bool = false
 	var buttonTitle: String? = nil
 	var buttonAction: VoidCallback? = nil
 }

--- a/PresentationLayer/UI Components/Base Components/Custom Sheet/BottomSheetModifier.swift
+++ b/PresentationLayer/UI Components/Base Components/Custom Sheet/BottomSheetModifier.swift
@@ -89,7 +89,7 @@ extension View {
     }
 
 	@ViewBuilder
-	func bottomInfoView(info: (title: String?, description: String)?) -> some View {
+	func bottomInfoView(info: BottomSheetInfo?) -> some View {
 		ZStack {
 			Color(colorEnum: .layer1)
 				.ignoresSafeArea()
@@ -107,15 +107,29 @@ extension View {
 					}
 
 					HStack {
-						Text(info.description.attributedMarkdown ?? "")
+						Text(info.description?.attributedMarkdown ?? "")
 							.font(.system(size: CGFloat(.mediumFontSize)))
 							.foregroundColor(Color(colorEnum: .text))
 
 						Spacer()
+					}
+
+					if let buttonTitle = info.buttonTitle, let buttonAction = info.buttonAction {
+						Button(action: buttonAction) {
+							Text(buttonTitle)
+						}
+						.buttonStyle(WXMButtonStyle.transparent)
 					}
 				}
 			}
 			.padding(CGFloat(.largeSidePadding))
 		}
 	}
+}
+
+struct BottomSheetInfo {
+	let title: String?
+	let description: String?
+	var buttonTitle: String? = nil
+	var buttonAction: VoidCallback? = nil
 }

--- a/PresentationLayer/UI Components/Base Components/ProgressBarStyle.swift
+++ b/PresentationLayer/UI Components/Base Components/ProgressBarStyle.swift
@@ -55,7 +55,7 @@ struct ProgressBarStyle: ProgressViewStyle {
 
 private extension ProgressBarStyle {
 	func progressWidth(with value: Double, containerSize: CGSize) -> CGFloat {
-		let offset = withOffset ? containerSize.width / 5.0 : 0.0
+		let offset = withOffset ? containerSize.width / 10.0 : 0.0
 		let actualContainerWidth = containerSize.width - offset
 		let width = value * actualContainerWidth
 		return width + offset

--- a/PresentationLayer/UI Components/Base Components/ProgressBarStyle.swift
+++ b/PresentationLayer/UI Components/Base Components/ProgressBarStyle.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ProgressBarStyle: ProgressViewStyle {
+	var withOffset: Bool = false
     var text: String?
     var bgColor: Color = Color(colorEnum: .midGrey)
     var progressColor: Color = Color(colorEnum: .primary)
@@ -21,7 +22,8 @@ struct ProgressBarStyle: ProgressViewStyle {
                 bgColor
                 HStack(spacing: 0.0) {
                     progressColor
-                        .frame(width: CGFloat(configuration.fractionCompleted ?? 0) * geometry.size.width)
+						.frame(width: progressWidth(with: configuration.fractionCompleted ?? 0,
+													containerSize: geometry.size))
                         .clipShape(Capsule())
                         .animation(.linear, value: configuration.fractionCompleted)
                         .sizeObserver(size: $progressSize)
@@ -51,11 +53,20 @@ struct ProgressBarStyle: ProgressViewStyle {
     }
 }
 
+private extension ProgressBarStyle {
+	func progressWidth(with value: Double, containerSize: CGSize) -> CGFloat {
+		let offset = withOffset ? containerSize.width / 5.0 : 0.0
+		let actualContainerWidth = containerSize.width - offset
+		let width = value * actualContainerWidth
+		return width + offset
+	}
+}
+
 struct ProgressBarStyle_Previews: PreviewProvider {
     static var previews: some View {
         ProgressView(value: 5,
                      total: 10)
-            .progressViewStyle(ProgressBarStyle(text: "\(4)"))
+            .progressViewStyle(ProgressBarStyle(withOffset: true, text: "\(4)"))
             .previewLayout(.fixed(width: 256, height: 22))
     }
 }

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /Components/BoostsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /Components/BoostsView.swift
@@ -1,0 +1,56 @@
+//
+//  BoostsView.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 1/3/24.
+//
+
+import SwiftUI
+
+struct BoostsView: View {
+	let title: String
+	let description: String
+	let rewards: Double
+	let imageUrl: String
+
+	var body: some View {
+		VStack(spacing: CGFloat(.smallSpacing)) {
+			HStack {
+				Text(title)
+					.font(.system(size: CGFloat(.normalFontSize), weight: .bold))
+					.foregroundColor(Color(colorEnum: .white))
+				Spacer()
+
+				Text("+ \(rewards.toWXMTokenPrecisionString) \(StringConstants.wxmCurrency)")
+					.font(.system(size: CGFloat(.caption), weight: .medium))
+					.foregroundColor(Color(colorEnum: .white))
+			}
+
+			HStack {
+				Text(description)
+					.font(.system(size: CGFloat(.caption)))
+					.foregroundColor(Color(colorEnum: .white))
+
+				Spacer()
+			}
+		}
+		.background {
+			AsyncImage(url: URL(string: imageUrl)!) { image in
+				image
+					.clipped()
+			} placeholder: {
+				ProgressView()
+			}
+
+		}
+		.WXMCardStyle()
+    }
+}
+
+#Preview {
+	BoostsView(title: "Beta reward",
+			   description: "Rewarded for participating in our beta reward program.",
+			   rewards: 2.453543,
+			   imageUrl: "https://i0.wp.com/weatherxm.com/wp-content/uploads/2023/12/Home-header-image-1200-x-1200-px-2.png").wxmShadow()
+		.padding()
+}

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /Components/BoostsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /Components/BoostsView.swift
@@ -34,14 +34,16 @@ struct BoostsView: View {
 				Spacer()
 			}
 		}
+		.padding(CGFloat(.defaultSidePadding))
 		.background {
 			AsyncImage(url: URL(string: imageUrl)!) { image in
 				image
+					.resizable()
 			} placeholder: {
 				ProgressView()
 			}
 		}
-		.WXMCardStyle()
+		.WXMCardStyle(insideHorizontalPadding: 0.0, insideVerticalPadding: 0.0)
 		.contentShape(Rectangle())
     }
 }
@@ -50,6 +52,6 @@ struct BoostsView: View {
 	BoostsView(title: "Beta reward",
 			   description: "Rewarded for participating in our beta reward program.",
 			   rewards: 2.453543,
-			   imageUrl: "https://i0.wp.com/weatherxm.com/wp-content/uploads/2023/12/Home-header-image-1200-x-1200-px-2.png").wxmShadow()
+			   imageUrl: "https://s3-alpha-sig.figma.com/img/eb97/5518/24aa70629514355d092dfc646d9b51bd?Expires=1710720000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=OVc-UV-lBgXfX~Nl1VFoL-JijJx72Wld-L40tKQBLBo2afCyJijAJWkRicakQ~celi0ACIuP8W~N2Ixev1roqtO9JAl2IW0u55fOQdITuhDYq0pcqW-Nen7vzvATzti9A-c-pm6IDE37Md7gc0dYgnM55HhR1GAM4FlEIx4~RWOYmOI5rOgXQl6wN7YCB1gv3WI3JvmA1YgZKxLoei0Adny6PVGOlmQYXacN3WMcy6EfPFUO4rVvk~lrgQIOBJi8bSOnVX8RFHZ0RMW9lPljynCPKgbpuwUl0X6djRmdku-ntEnlCCsFp0LF0d~Y-qEK-edLpT96KdG4MM7TS64Qsg__").wxmShadow()
 		.padding()
 }

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /Components/BoostsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /Components/BoostsView.swift
@@ -37,13 +37,12 @@ struct BoostsView: View {
 		.background {
 			AsyncImage(url: URL(string: imageUrl)!) { image in
 				image
-					.clipped()
 			} placeholder: {
 				ProgressView()
 			}
-
 		}
 		.WXMCardStyle()
+		.contentShape(Rectangle())
     }
 }
 

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /Components/NoBoostsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /Components/NoBoostsView.swift
@@ -1,0 +1,35 @@
+//
+//  NoBoostsView.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 1/3/24.
+//
+
+import SwiftUI
+
+struct NoBoostsView: View {
+    var body: some View {
+		VStack(spacing: CGFloat(.minimumSpacing)) {
+			HStack {
+				Text(LocalizableString.RewardDetails.noActiveBoostsTitle.localized)
+					.foregroundColor(Color(colorEnum: .text))
+					.font(.system(size: CGFloat(.normalFontSize), weight: .medium))
+				Spacer()
+			}
+
+			HStack {
+				Text(LocalizableString.RewardDetails.noActiveBoostsDescription.localized)
+					.foregroundColor(Color(colorEnum: .text))
+					.font(.system(size: CGFloat(.normalFontSize)))
+				Spacer()
+			}
+		}
+		.WXMCardStyle()
+    }
+}
+
+#Preview {
+    NoBoostsView()
+		.wxmShadow()
+		.padding()
+}

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /Components/RewardFieldView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /Components/RewardFieldView.swift
@@ -49,6 +49,9 @@ struct RewardFieldView: View {
 			}
 		}
 		.WXMCardStyle()
+		.indication(show: .constant(score.showIndication),
+					borderColor: Color(colorEnum: score.color),
+					bgColor: .clear, content: { EmptyView() })
     }
 }
 
@@ -57,13 +60,17 @@ extension RewardFieldView {
 		let score: Float
 		let color: ColorEnum
 		let message: String
+		let showIndication: Bool
 	}
 
 }
 
 #Preview {
 	RewardFieldView(title: "Data Quality",
-					score: .init(score: 75.0, color: .warning, message: "Almost perfect! Got 98%.")) {}
+					score: .init(score: 75.0,
+								 color: .warning,
+								 message: "Almost perfect! Got 98%.",
+								 showIndication: true)) {}
 		.wxmShadow()
 		.padding()
 }

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /Components/RewardFieldView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /Components/RewardFieldView.swift
@@ -1,0 +1,69 @@
+//
+//  RewardFieldView.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 27/2/24.
+//
+
+import SwiftUI
+import Toolkit
+
+struct RewardFieldView: View {
+	let title: String
+	let score: Score
+	let infoAction: VoidCallback
+
+    var body: some View {
+		VStack(spacing: CGFloat(.smallSpacing)) {
+			HStack {
+				Text(title)
+					.font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
+
+				Spacer()
+
+				Button{
+					infoAction()
+				} label: {
+					Text(FontIcon.infoCircle.rawValue)
+						.font(.fontAwesome(font: .FAPro, size: CGFloat(.mediumFontSize)))
+				}
+			}
+			.foregroundColor(Color(colorEnum: .text))
+
+			VStack(spacing: CGFloat(.mediumSpacing)) {
+				HStack(spacing: CGFloat(.smallSpacing)) {
+					Text(FontIcon.hexagonCheck.rawValue)
+						.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.smallTitleFontSize)))
+						.foregroundColor(Color(colorEnum: score.color))
+
+					Text(score.message)
+						.font(.system(size: CGFloat(.caption)))
+
+					Spacer()
+				}
+
+				ProgressView(value: score.score, total: 100)
+					.progressViewStyle(ProgressBarStyle(text: nil, bgColor: Color(colorEnum: .blueTint), progressColor: Color(colorEnum: score.color)))
+					.frame(height: 22.0)
+
+			}
+		}
+		.WXMCardStyle()
+    }
+}
+
+extension RewardFieldView {
+	struct Score {
+		let score: Float
+		let color: ColorEnum
+		let message: String
+	}
+
+}
+
+#Preview {
+	RewardFieldView(title: "Data Quality",
+					score: .init(score: 75.0, color: .warning, message: "Almost perfect! Got 98%.")) {}
+		.wxmShadow()
+		.padding()
+}

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /Components/RewardFieldView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /Components/RewardFieldView.swift
@@ -15,9 +15,9 @@ struct RewardFieldView: View {
 
     var body: some View {
 		VStack(spacing: CGFloat(.smallSpacing)) {
-			HStack {
+			HStack(spacing: 0.0) {
 				Text(title)
-					.font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
+					.font(.system(size: CGFloat(.normalFontSize), weight: .bold))
 
 				Spacer(minLength: 0.0)
 

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /Components/RewardFieldView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /Components/RewardFieldView.swift
@@ -45,7 +45,10 @@ struct RewardFieldView: View {
 
 				if let scoreVal = score.score {
 					ProgressView(value: scoreVal, total: 100)
-						.progressViewStyle(ProgressBarStyle(text: nil, bgColor: Color(colorEnum: .blueTint), progressColor: Color(colorEnum: score.color)))
+						.progressViewStyle(ProgressBarStyle(withOffset: true,
+															text: nil,
+															bgColor: Color(colorEnum: .blueTint),
+															progressColor: Color(colorEnum: score.color)))
 						.frame(height: 22.0)
 				}
 

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /Components/RewardFieldView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /Components/RewardFieldView.swift
@@ -43,9 +43,11 @@ struct RewardFieldView: View {
 					Spacer()
 				}
 
-				ProgressView(value: score.score, total: 100)
-					.progressViewStyle(ProgressBarStyle(text: nil, bgColor: Color(colorEnum: .blueTint), progressColor: Color(colorEnum: score.color)))
-					.frame(height: 22.0)
+				if let scoreVal = score.score {
+					ProgressView(value: scoreVal, total: 100)
+						.progressViewStyle(ProgressBarStyle(text: nil, bgColor: Color(colorEnum: .blueTint), progressColor: Color(colorEnum: score.color)))
+						.frame(height: 22.0)
+				}
 
 			}
 		}
@@ -59,7 +61,7 @@ struct RewardFieldView: View {
 extension RewardFieldView {
 	struct Score {
 		let fontIcon: FontIcon
-		let score: Float
+		let score: Float?
 		let color: ColorEnum
 		let message: String
 		let showIndication: Bool
@@ -70,7 +72,7 @@ extension RewardFieldView {
 #Preview {
 	RewardFieldView(title: "Data Quality",
 					score: .init(fontIcon: .hexagonExclamation,
-								 score: 75.0,
+								 score: nil,
 								 color: .warning,
 								 message: "Almost perfect! Got 98%.",
 								 showIndication: true)) {}

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /Components/RewardFieldView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /Components/RewardFieldView.swift
@@ -19,7 +19,7 @@ struct RewardFieldView: View {
 				Text(title)
 					.font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
 
-				Spacer()
+				Spacer(minLength: 0.0)
 
 				Button{
 					infoAction()
@@ -40,7 +40,7 @@ struct RewardFieldView: View {
 						.font(.system(size: CGFloat(.caption)))
 						.fixedSize(horizontal: false, vertical: true)
 
-					Spacer()
+					Spacer(minLength: 0.0)
 				}
 
 				if let scoreVal = score.score {

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /Components/RewardFieldView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /Components/RewardFieldView.swift
@@ -32,12 +32,13 @@ struct RewardFieldView: View {
 
 			VStack(spacing: CGFloat(.mediumSpacing)) {
 				HStack(spacing: CGFloat(.smallSpacing)) {
-					Text(FontIcon.hexagonCheck.rawValue)
+					Text(score.fontIcon.rawValue)
 						.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.smallTitleFontSize)))
 						.foregroundColor(Color(colorEnum: score.color))
 
 					Text(score.message)
 						.font(.system(size: CGFloat(.caption)))
+						.fixedSize(horizontal: false, vertical: true)
 
 					Spacer()
 				}
@@ -57,6 +58,7 @@ struct RewardFieldView: View {
 
 extension RewardFieldView {
 	struct Score {
+		let fontIcon: FontIcon
 		let score: Float
 		let color: ColorEnum
 		let message: String
@@ -67,7 +69,8 @@ extension RewardFieldView {
 
 #Preview {
 	RewardFieldView(title: "Data Quality",
-					score: .init(score: 75.0,
+					score: .init(fontIcon: .hexagonExclamation,
+								 score: 75.0,
 								 color: .warning,
 								 message: "Almost perfect! Got 98%.",
 								 showIndication: true)) {}

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -67,8 +67,11 @@ private struct ContentView: View {
 			Color(colorEnum: .bg)
 				.ignoresSafeArea()
 
-			TrackableScrollView {
+			TrackableScrollView { completion in
+				viewModel.refresh(completion: completion)
+			} content: {
 				VStack(spacing: CGFloat(.defaultSpacing)) {
+					titleView
 
 					if viewModel.followState?.relation == .owned {
 						Button {
@@ -82,6 +85,7 @@ private struct ContentView: View {
 				.iPadMaxWidth()
 				.padding(.horizontal, CGFloat(.defaultSidePadding))
 			}
+			.fail(show: .init(get: { viewModel.state == .fail }, set: { _ in }), obj: viewModel.failObj)
 			.onAppear {
 				navigationObject.title = LocalizableString.RewardDetails.title.localized
 				navigationObject.subtitle = viewModel.device.displayName
@@ -90,6 +94,47 @@ private struct ContentView: View {
 
 				Logger.shared.trackScreen(.deviceRewardsDetails)
 			}
+		}
+	}
+
+	@ViewBuilder
+	var titleView: some View {
+		VStack(spacing: CGFloat(.mediumSpacing)) {
+			VStack(spacing: 0.0) {
+				HStack {
+					Text(LocalizableString.RewardDetails.dailyReward.localized)
+						.font(.system(size: CGFloat(.titleFontSize), weight: .bold))
+						.foregroundColor(Color(.text))
+
+					Button{
+					} label: {
+						Text(FontIcon.infoCircle.rawValue)
+							.font(.fontAwesome(font: .FAPro, size: CGFloat(.mediumFontSize)))
+							.foregroundColor(Color(.text))
+					}
+
+					Spacer()
+				}
+				
+				HStack {
+					Text(LocalizableString.RewardDetails.earningsFor("").localized)
+						.font(.system(size: CGFloat(.normalFontSize)))
+						.foregroundColor(Color(.darkGrey))
+					Spacer()
+				}
+			}
+
+			if let rewards = viewModel.rewardDetailsResponse?.totalDailyReward {
+				HStack {
+					Text("+ \(rewards.toWXMTokenPrecisionString) \(StringConstants.wxmCurrency)")
+						.lineLimit(1)
+						.font(.system(size: CGFloat(.XLTitleFontSize), weight: .bold))
+						.foregroundColor(Color(colorEnum: .darkestBlue))
+
+					Spacer()
+				}
+			}
+
 		}
 	}
 }

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -16,40 +16,9 @@ struct RewardDetailsView: View {
 
     var body: some View {
 		NavigationContainerView {
-			navigationBarRightView
-		} content: {
 			ContentView(viewModel: viewModel)
 		}
     }
-
-	@ViewBuilder
-	var navigationBarRightView: some View {
-		Button {
-			Logger.shared.trackEvent(.userAction, parameters: [.actionName: .rewardDetailsPopUp])
-
-			showPopOverMenu = true
-		} label: {
-			Text(FontIcon.threeDots.rawValue)
-				.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.mediumFontSize)))
-				.foregroundColor(Color(colorEnum: .primary))
-				.frame(width: 30.0, height: 30.0)
-		}
-		.wxmPopOver(show: $showPopOverMenu) {
-			VStack {
-				Button { [weak viewModel] in
-					showPopOverMenu = false
-					viewModel?.handleReadMoreTap()
-					Logger.shared.trackEvent(.selectContent, parameters: [.contentType: .rewardDetailsReadMore])
-				} label: {
-					Text(LocalizableString.RewardDetails.readMore.localized)
-						.font(.system(size: CGFloat(.mediumFontSize)))
-						.foregroundColor(Color(colorEnum: .text))
-				}
-			}
-			.padding()
-			.background(Color(colorEnum: .top).scaleEffect(2.0).ignoresSafeArea())
-		}
-	}
 }
 
 private struct ContentView: View {
@@ -227,7 +196,8 @@ private struct ContentView: View {
 
 	@ViewBuilder
 	var locationQualityGrid: some View {
-		LazyVGrid(columns: [.init(), .init()], spacing: CGFloat(.mediumSpacing)) {
+		LazyVGrid(columns: [.init(alignment: .top), .init(alignment: .top)],
+				  spacing: CGFloat(.mediumSpacing)) {
 			if let scoreObject = viewModel.locationQualityScoreObject {
 				RewardFieldView(title: LocalizableString.RewardDetails.locationQuality.localized,
 								score: scoreObject) {

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -114,7 +114,7 @@ private struct ContentView: View {
 				}
 				
 				HStack {
-					Text(LocalizableString.RewardDetails.earningsFor("").localized)
+					Text(viewModel.dateString)
 						.font(.system(size: CGFloat(.normalFontSize)))
 						.foregroundColor(Color(.darkGrey))
 					Spacer()

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -198,16 +198,39 @@ private struct ContentView: View {
 					}
 				}
 
-				VStack {
+				VStack(spacing: CGFloat(.mediumSpacing)) {
 					if let scoreObject = viewModel.dataQualityScoreObject {
 						RewardFieldView(title: LocalizableString.RewardDetails.dataQuality.localized,
 										score: scoreObject) {
 
 						}
+										.wxmShadow()
 					}
+
+					locationQualityGrid
 				}
 			}
 		} else{
+			EmptyView()
+		}
+	}
+
+	@ViewBuilder
+	var locationQualityGrid: some View {
+		if let scoreObject = viewModel.locationQualityScoreObject {
+			LazyVGrid(columns: [.init(), .init()], spacing: CGFloat(.mediumSpacing)) {
+				RewardFieldView(title: LocalizableString.RewardDetails.locationQuality.localized,
+								score: scoreObject) {
+
+				}
+								.wxmShadow()
+
+				RewardFieldView(title: LocalizableString.RewardDetails.dataQuality.localized,
+								score: scoreObject) {
+				}
+								.wxmShadow()
+			}
+		} else {
 			EmptyView()
 		}
 	}

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -258,6 +258,19 @@ private struct ContentView: View {
 					}
 				}
 			}
+
+			if let data = viewModel.rewardDetailsResponse?.boost?.data,
+			   !data.isEmpty {
+				ForEach(data, id: \.code) { boost in
+					BoostsView(title: boost.title ?? "",
+							   description: boost.description ?? "",
+							   rewards: boost.actualReward ?? 0.0,
+							   imageUrl: boost.imageUrl ?? "")
+					.wxmShadow()
+				}
+			} else {
+				NoBoostsView()
+			}
 		}
 	}
 }

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -64,7 +64,7 @@ private struct ContentView: View {
 	@ViewBuilder
 	var content: some View {
 		ZStack {
-			Color(colorEnum: .bg)
+			Color(colorEnum: .top)
 				.ignoresSafeArea()
 
 			TrackableScrollView { completion in
@@ -82,10 +82,13 @@ private struct ContentView: View {
 				.iPadMaxWidth()
 				.padding(.horizontal, CGFloat(.defaultSidePadding))
 			}
-			.fail(show: .init(get: { viewModel.state == .fail }, set: { _ in }), obj: viewModel.failObj)
+			.spinningLoader(show: .init(get: { viewModel.state == .loading }, set: { _ in }),
+							hideContent: true)
+			.fail(show: .init(get: { viewModel.state == .fail }, set: { _ in }), 
+				  obj: viewModel.failObj)
 			.onAppear {
 				navigationObject.titleColor = Color(colorEnum: .text)
-				navigationObject.navigationBarColor = Color(colorEnum: .bg)
+				navigationObject.navigationBarColor = Color(colorEnum: .top)
 
 				Logger.shared.trackScreen(.deviceRewardsDetails)
 			}

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -84,8 +84,6 @@ private struct ContentView: View {
 			}
 			.fail(show: .init(get: { viewModel.state == .fail }, set: { _ in }), obj: viewModel.failObj)
 			.onAppear {
-				navigationObject.title = LocalizableString.RewardDetails.title.localized
-				navigationObject.subtitle = viewModel.device.displayName
 				navigationObject.titleColor = Color(colorEnum: .text)
 				navigationObject.navigationBarColor = Color(colorEnum: .bg)
 

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -150,6 +150,22 @@ private struct ContentView: View {
 				Spacer()
 			}
 
+			if let mainAnnotation = viewModel.rewardDetailsResponse?.annotation?.mainAnnotation {
+				CardWarningView(type: mainAnnotation.warningType ?? .warning,
+								showIcon: false,
+								title: mainAnnotation.title ?? "",
+								message: mainAnnotation.message ?? "",
+								showBorder: true,
+								closeAction: nil) {
+					Button {
+
+					} label: {
+						Text(viewModel.issuesButtonTitle() ?? "")
+					}
+					.buttonStyle(WXMButtonStyle.transparent)
+					.padding(.top, CGFloat(.smallSidePadding))
+				}.wxmShadow()
+			}
 		}
 	}
 }

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -75,14 +75,7 @@ private struct ContentView: View {
 
 					issuesView
 
-					if viewModel.followState?.relation == .owned {
-						Button {
-							viewModel.handleContactSupportTap()
-						} label: {
-							Text(LocalizableString.RewardDetails.contactSupportButtonTitle.localized)
-						}
-						.buttonStyle(WXMButtonStyle.solid)
-					}
+					baseRewardView
 				}
 				.iPadMaxWidth()
 				.padding(.horizontal, CGFloat(.defaultSidePadding))
@@ -179,6 +172,42 @@ private struct ContentView: View {
 				}.wxmShadow()
 			}
 		} else {
+			EmptyView()
+		}
+	}
+
+	@ViewBuilder
+	var baseRewardView: some View {
+		if let base = viewModel.rewardDetailsResponse?.base {
+			VStack(spacing: CGFloat(.mediumSpacing)) {
+				VStack(spacing: CGFloat(.minimumSpacing)) {
+					HStack {
+						Text(LocalizableString.StationDetails.baseReward.localized)
+							.font(.system(size: CGFloat(.titleFontSize), weight: .bold))
+							.foregroundColor(Color(.text))
+						Spacer()
+					}
+
+					if let subtitle = viewModel.baseRewardSubtitle()?.attributedMarkdown {
+						HStack {
+							Text(subtitle)
+								.font(.system(size: CGFloat(.normalFontSize)))
+								.foregroundColor(Color(.darkGrey))
+							Spacer()
+						}
+					}
+				}
+
+				VStack {
+					if let scoreObject = viewModel.dataQualityScoreObject {
+						RewardFieldView(title: LocalizableString.RewardDetails.dataQuality.localized,
+										score: scoreObject) {
+
+						}
+					}
+				}
+			}
+		} else{
 			EmptyView()
 		}
 	}

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -81,6 +81,7 @@ private struct ContentView: View {
 				}
 				.iPadMaxWidth()
 				.padding(.horizontal, CGFloat(.defaultSidePadding))
+				.padding(.bottom, CGFloat(.smallSidePadding))
 			}
 			.spinningLoader(show: .init(get: { viewModel.state == .loading }, set: { _ in }),
 							hideContent: true)

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -285,6 +285,7 @@ private struct ContentView: View {
 		Color(colorEnum: .bg)
 		RewardDetailsView(viewModel: .init(device: device,
 										   followState: .init(deviceId: device.id!, relation: .owned),
+										   date: .now,
 										   tokenUseCase: SwinjectHelper.shared.getContainerForSwinject().resolve(RewardsTimelineUseCase.self)!))
 	}
 }

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -225,6 +225,14 @@ private struct ContentView: View {
 				}
 								.wxmShadow()
 			}
+
+			if let scoreObject = viewModel.cellPositionScoreObject {
+				RewardFieldView(title: LocalizableString.RewardDetails.cellPosition.localized,
+								score: scoreObject) {
+
+				}
+								.wxmShadow()
+			}
 		}
 	}
 }

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -217,21 +217,14 @@ private struct ContentView: View {
 
 	@ViewBuilder
 	var locationQualityGrid: some View {
-		if let scoreObject = viewModel.locationQualityScoreObject {
-			LazyVGrid(columns: [.init(), .init()], spacing: CGFloat(.mediumSpacing)) {
+		LazyVGrid(columns: [.init(), .init()], spacing: CGFloat(.mediumSpacing)) {
+			if let scoreObject = viewModel.locationQualityScoreObject {
 				RewardFieldView(title: LocalizableString.RewardDetails.locationQuality.localized,
 								score: scoreObject) {
 
 				}
 								.wxmShadow()
-
-				RewardFieldView(title: LocalizableString.RewardDetails.dataQuality.localized,
-								score: scoreObject) {
-				}
-								.wxmShadow()
 			}
-		} else {
-			EmptyView()
 		}
 	}
 }

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -143,11 +143,22 @@ private struct ContentView: View {
 	@ViewBuilder
 	var issuesView: some View {
 		VStack(spacing: CGFloat(.mediumSpacing)) {
-			HStack {
-				Text(LocalizableString.RewardDetails.issues.localized)
-					.font(.system(size: CGFloat(.titleFontSize), weight: .bold))
-					.foregroundColor(Color(.text))
-				Spacer()
+			VStack(spacing: CGFloat(.minimumSpacing)) {
+				HStack {
+					Text(LocalizableString.RewardDetails.issues.localized)
+						.font(.system(size: CGFloat(.titleFontSize), weight: .bold))
+						.foregroundColor(Color(.text))
+					Spacer()
+				}
+
+				if let subtitle = viewModel.issuesSubtitle()?.attributedMarkdown {
+					HStack {
+						Text(subtitle)
+							.font(.system(size: CGFloat(.normalFontSize)))
+							.foregroundColor(Color(.darkGrey))
+						Spacer()
+					}
+				}
 			}
 
 			if let mainAnnotation = viewModel.rewardDetailsResponse?.annotation?.mainAnnotation {

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -279,6 +279,7 @@ private struct ContentView: View {
 				}
 			} else {
 				NoBoostsView()
+					.wxmShadow()
 			}
 		}
 	}

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -92,6 +92,9 @@ private struct ContentView: View {
 				Logger.shared.trackScreen(.deviceRewardsDetails)
 			}
 		}
+		.bottomSheet(show: $viewModel.showInfo, fitContent: true) {
+			bottomInfoView(info: viewModel.info)
+		}
 	}
 
 	@ViewBuilder
@@ -103,7 +106,8 @@ private struct ContentView: View {
 						.font(.system(size: CGFloat(.titleFontSize), weight: .bold))
 						.foregroundColor(Color(.text))
 
-					Button{
+					Button {
+						viewModel.handleDailyRewardInfoTap()
 					} label: {
 						Text(FontIcon.infoCircle.rawValue)
 							.font(.fontAwesome(font: .FAPro, size: CGFloat(.mediumFontSize)))
@@ -204,7 +208,7 @@ private struct ContentView: View {
 					if let scoreObject = viewModel.dataQualityScoreObject {
 						RewardFieldView(title: LocalizableString.RewardDetails.dataQuality.localized,
 										score: scoreObject) {
-
+							viewModel.handleDataQualityInfoTap()
 						}
 										.wxmShadow()
 					}
@@ -223,7 +227,7 @@ private struct ContentView: View {
 			if let scoreObject = viewModel.locationQualityScoreObject {
 				RewardFieldView(title: LocalizableString.RewardDetails.locationQuality.localized,
 								score: scoreObject) {
-
+					viewModel.handleLocationQualityInfoTap()
 				}
 								.wxmShadow()
 			}
@@ -231,7 +235,7 @@ private struct ContentView: View {
 			if let scoreObject = viewModel.cellPositionScoreObject {
 				RewardFieldView(title: LocalizableString.RewardDetails.cellPosition.localized,
 								score: scoreObject) {
-
+					viewModel.handleCellPositionInfoTap()
 				}
 								.wxmShadow()
 			}

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -76,6 +76,8 @@ private struct ContentView: View {
 					issuesView
 
 					baseRewardView
+
+					boostsView
 				}
 				.iPadMaxWidth()
 				.padding(.horizontal, CGFloat(.defaultSidePadding))
@@ -232,6 +234,29 @@ private struct ContentView: View {
 
 				}
 								.wxmShadow()
+			}
+		}
+	}
+
+	@ViewBuilder
+	var boostsView: some View {
+		VStack(spacing: CGFloat(.mediumSpacing)) {
+			VStack(spacing: CGFloat(.minimumSpacing)) {
+				HStack {
+					Text(LocalizableString.RewardDetails.activeBoosts.localized)
+						.font(.system(size: CGFloat(.titleFontSize), weight: .bold))
+						.foregroundColor(Color(.text))
+					Spacer()
+				}
+
+				if let subtitle = viewModel.boostsSubtitle()?.attributedMarkdown {
+					HStack {
+						Text(subtitle)
+							.font(.system(size: CGFloat(.normalFontSize)))
+							.foregroundColor(Color(.darkGrey))
+						Spacer()
+					}
+				}
 			}
 		}
 	}

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -93,7 +93,7 @@ private struct ContentView: View {
 				Logger.shared.trackScreen(.deviceRewardsDetails)
 			}
 		}
-		.bottomSheet(show: $viewModel.showInfo, fitContent: true) {
+		.bottomSheet(show: $viewModel.showInfo) {
 			bottomInfoView(info: viewModel.info)
 		}
 	}

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -73,6 +73,8 @@ private struct ContentView: View {
 				VStack(spacing: CGFloat(.defaultSpacing)) {
 					titleView
 
+					issuesView
+
 					if viewModel.followState?.relation == .owned {
 						Button {
 							viewModel.handleContactSupportTap()
@@ -133,6 +135,19 @@ private struct ContentView: View {
 
 					Spacer()
 				}
+			}
+
+		}
+	}
+
+	@ViewBuilder
+	var issuesView: some View {
+		VStack(spacing: CGFloat(.mediumSpacing)) {
+			HStack {
+				Text(LocalizableString.RewardDetails.issues.localized)
+					.font(.system(size: CGFloat(.titleFontSize), weight: .bold))
+					.foregroundColor(Color(.text))
+				Spacer()
 			}
 
 		}

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -12,7 +12,6 @@ import Toolkit
 struct RewardDetailsView: View {
 
 	@StateObject var viewModel: RewardDetailsViewModel
-	@State private var showPopOverMenu: Bool = false
 
     var body: some View {
 		NavigationContainerView {

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -139,7 +139,7 @@ private struct ContentView: View {
 
 	@ViewBuilder
 	var issuesView: some View {
-		if let mainAnnotation = viewModel.rewardDetailsResponse?.annotation?.mainAnnotation {
+		if let mainAnnotation = viewModel.rewardDetailsResponse?.mainAnnotation {
 			VStack(spacing: CGFloat(.mediumSpacing)) {
 				VStack(spacing: CGFloat(.minimumSpacing)) {
 					HStack {

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -154,6 +154,7 @@ private struct ContentView: View {
 							Text(subtitle)
 								.font(.system(size: CGFloat(.normalFontSize)))
 								.foregroundColor(Color(.darkGrey))
+								.fixedSize(horizontal: false, vertical: true)
 							Spacer()
 						}
 					}
@@ -197,6 +198,7 @@ private struct ContentView: View {
 							Text(subtitle)
 								.font(.system(size: CGFloat(.normalFontSize)))
 								.foregroundColor(Color(.darkGrey))
+								.fixedSize(horizontal: false, vertical: true)
 							Spacer()
 						}
 					}
@@ -256,6 +258,7 @@ private struct ContentView: View {
 						Text(subtitle)
 							.font(.system(size: CGFloat(.normalFontSize)))
 							.foregroundColor(Color(.darkGrey))
+							.fixedSize(horizontal: false, vertical: true)
 						Spacer()
 					}
 				}

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsView.swift
@@ -142,26 +142,27 @@ private struct ContentView: View {
 
 	@ViewBuilder
 	var issuesView: some View {
-		VStack(spacing: CGFloat(.mediumSpacing)) {
-			VStack(spacing: CGFloat(.minimumSpacing)) {
-				HStack {
-					Text(LocalizableString.RewardDetails.issues.localized)
-						.font(.system(size: CGFloat(.titleFontSize), weight: .bold))
-						.foregroundColor(Color(.text))
-					Spacer()
-				}
-
-				if let subtitle = viewModel.issuesSubtitle()?.attributedMarkdown {
+		if let mainAnnotation = viewModel.rewardDetailsResponse?.annotation?.mainAnnotation {
+			VStack(spacing: CGFloat(.mediumSpacing)) {
+				VStack(spacing: CGFloat(.minimumSpacing)) {
 					HStack {
-						Text(subtitle)
-							.font(.system(size: CGFloat(.normalFontSize)))
-							.foregroundColor(Color(.darkGrey))
+						Text(LocalizableString.RewardDetails.issues.localized)
+							.font(.system(size: CGFloat(.titleFontSize), weight: .bold))
+							.foregroundColor(Color(.text))
 						Spacer()
 					}
-				}
-			}
 
-			if let mainAnnotation = viewModel.rewardDetailsResponse?.annotation?.mainAnnotation {
+					if let subtitle = viewModel.issuesSubtitle()?.attributedMarkdown {
+						HStack {
+							Text(subtitle)
+								.font(.system(size: CGFloat(.normalFontSize)))
+								.foregroundColor(Color(.darkGrey))
+							Spacer()
+						}
+					}
+				}
+
+
 				CardWarningView(type: mainAnnotation.warningType ?? .warning,
 								showIcon: false,
 								title: mainAnnotation.title ?? "",
@@ -169,7 +170,7 @@ private struct ContentView: View {
 								showBorder: true,
 								closeAction: nil) {
 					Button {
-
+						viewModel.handleIssueButtonTap()
 					} label: {
 						Text(viewModel.issuesButtonTitle() ?? "")
 					}
@@ -177,20 +178,6 @@ private struct ContentView: View {
 					.padding(.top, CGFloat(.smallSidePadding))
 				}.wxmShadow()
 			}
-		}
-	}
-}
-
-private extension ContentView {
-	@ViewBuilder
-	func errorActionView(for error: RewardAnnotation) -> some View {
-		if let title = viewModel.annotationActionButtonTile(for: error) {
-			Button {
-				viewModel.handleButtonTap(for: error)
-			} label: {
-				Text(title)
-			}
-			.buttonStyle(WXMButtonStyle.transparent)
 		} else {
 			EmptyView()
 		}

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
@@ -54,6 +54,15 @@ class RewardDetailsViewModel: ObservableObject {
 		}
 	}
 
+	func issuesButtonTitle() -> String? {
+		guard let summary = rewardDetailsResponse?.annotation?.summary,
+			  summary.count > 1 else {
+			return annotationActionButtonTile(for: rewardDetailsResponse?.annotation?.mainAnnotation)
+		}
+
+		return LocalizableString.RewardDetails.viewAllIssues.localized
+	}
+
 	func annotationActionButtonTile(for annotation: RewardAnnotation?) -> String? {
 		guard let group = annotation?.group else {
 			return nil

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
@@ -23,6 +23,9 @@ class RewardDetailsViewModel: ObservableObject {
 	var isDeviceOwned: Bool {
 		followState?.relation == .owned
 	}
+	var dateString: String {
+		LocalizableString.RewardDetails.earningsFor(rewardDetailsResponse?.timestamp?.getFormattedDate(format: .monthLiteralDayYear, timezone: .UTCTimezone, showTimeZoneIndication: true).capitalizedSentence ?? "").localized
+	}
 	var dataQualityScoreObject: RewardFieldView.Score? {
 		rewardDetailsResponse?.dataQualityScoreObject(followState: followState)
 	}

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
@@ -29,6 +29,9 @@ class RewardDetailsViewModel: ObservableObject {
 	var locationQualityScoreObject: RewardFieldView.Score? {
 		rewardDetailsResponse?.locationQualityScoreObject
 	}
+	var cellPositionScoreObject: RewardFieldView.Score? {
+		rewardDetailsResponse?.cellPositionScoreObject
+	}
 
 	init(device: DeviceDetails, followState: UserDeviceFollowState?, tokenUseCase: RewardsTimelineUseCase) {
 		self.device = device

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
@@ -24,7 +24,10 @@ class RewardDetailsViewModel: ObservableObject {
 		followState?.relation == .owned
 	}
 	var dataQualityScoreObject: RewardFieldView.Score? {
-		rewardDetailsResponse?.base?.scoreObject(followState: followState)
+		rewardDetailsResponse?.dataQualityScoreObject(followState: followState)
+	}
+	var locationQualityScoreObject: RewardFieldView.Score? {
+		rewardDetailsResponse?.locationQualityScoreObject
 	}
 
 	init(device: DeviceDetails, followState: UserDeviceFollowState?, tokenUseCase: RewardsTimelineUseCase) {
@@ -112,7 +115,7 @@ class RewardDetailsViewModel: ObservableObject {
 					return LocalizableString.RewardDetails.readMore.localized
 				}
 				return nil
-			case .unknown:
+			default:
 				if annotation?.docUrl != nil {
 					return LocalizableString.RewardDetails.readMore.localized
 				}
@@ -173,7 +176,7 @@ private extension RewardDetailsViewModel {
 						  let url = URL(string: docUrl) {
 					 UIApplication.shared.open(url)
 				 }
-			case .unknown:
+			default:
 				if let docUrl = annotation.docUrl,
 				   let url = URL(string: docUrl) {
 					UIApplication.shared.open(url)

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
@@ -13,8 +13,10 @@ import Toolkit
 class RewardDetailsViewModel: ObservableObject {
 
 	@Published var showInfo: Bool = false
+	private(set) var info: BottomSheetInfo?
 	@Published var state: ViewState = .loading
 	private(set) var failObj: FailSuccessStateObject?
+
 
 	let useCase: RewardsTimelineUseCase
 	var device: DeviceDetails
@@ -159,6 +161,46 @@ class RewardDetailsViewModel: ObservableObject {
 
 	func handleContactSupportTap() {
 		openContactSupport()
+	}
+
+	func handleDailyRewardInfoTap() {
+		let info = BottomSheetInfo(title: LocalizableString.RewardDetails.dailyReward.localized,
+								   description: LocalizableString.RewardDetails.dailyRewardInfoDescription.localized,
+								   buttonTitle: LocalizableString.RewardDetails.readMore.localized) {
+
+		}
+		self.info = info
+		showInfo = true
+	}
+
+	func handleDataQualityInfoTap() {
+		let info = BottomSheetInfo(title: LocalizableString.RewardDetails.dataQuality.localized,
+								   description: LocalizableString.RewardDetails.dataQualityInfoDescription.localized,
+								   buttonTitle: LocalizableString.RewardDetails.readMore.localized) {
+
+		}
+		self.info = info
+		showInfo = true
+	}
+
+	func handleLocationQualityInfoTap() {
+		let info = BottomSheetInfo(title: LocalizableString.RewardDetails.locationQuality.localized,
+								   description: LocalizableString.RewardDetails.locationQualityInfoDescription.localized,
+								   buttonTitle: LocalizableString.RewardDetails.readMore.localized) {
+
+		}
+		self.info = info
+		showInfo = true
+	}
+
+	func handleCellPositionInfoTap() {
+		let info = BottomSheetInfo(title: LocalizableString.RewardDetails.cellPosition.localized,
+								   description: LocalizableString.RewardDetails.cellPositionInfoDescription.localized,
+								   buttonTitle: LocalizableString.RewardDetails.readMore.localized) {
+
+		}
+		self.info = info
+		showInfo = true
 	}
 }
 

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
@@ -54,6 +54,22 @@ class RewardDetailsViewModel: ObservableObject {
 		}
 	}
 
+	func issuesSubtitle() -> String? {
+		guard let warningType = rewardDetailsResponse?.annotation?.mainAnnotation?.warningType,
+			  let count = rewardDetailsResponse?.annotation?.summary?.count else {
+			return nil
+		}
+
+		switch warningType {
+			case .error:
+				return LocalizableString.StationDetails.stationRewardErrorMessage(count).localized
+			case .warning:
+				return LocalizableString.StationDetails.stationRewardWarningMessage(count).localized
+			case .info:
+				return LocalizableString.StationDetails.stationRewardInfoMessage(count).localized
+		}
+	}
+
 	func issuesButtonTitle() -> String? {
 		guard let summary = rewardDetailsResponse?.annotation?.summary,
 			  summary.count > 1 else {
@@ -92,10 +108,13 @@ class RewardDetailsViewModel: ObservableObject {
 		}
 	}
 
-	func handleButtonTap(for error: RewardAnnotation) {
-		Logger.shared.trackEvent(.userAction, parameters: [.actionName: .rewardDetailsError,
-														   .itemId: .custom(error.group?.rawValue ?? "")])
-		handleRewardAnnotation(annotation: error)
+	func handleIssueButtonTap() {
+		guard let count = rewardDetailsResponse?.annotation?.summary?.count, count > 1 else {
+			handleRewardAnnotation(annotation: rewardDetailsResponse?.annotation?.mainAnnotation)
+			return
+		}
+
+		
 	}
 
 	func handleReadMoreTap() {
@@ -112,8 +131,9 @@ class RewardDetailsViewModel: ObservableObject {
 }
 
 private extension RewardDetailsViewModel {
-	func handleRewardAnnotation(annotation: RewardAnnotation) {
-		guard let group = annotation.group else {
+	func handleRewardAnnotation(annotation: RewardAnnotation?) {
+		guard let annotation,
+			  let group = annotation.group else {
 			return
 		}
 

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
@@ -23,6 +23,9 @@ class RewardDetailsViewModel: ObservableObject {
 	var isDeviceOwned: Bool {
 		followState?.relation == .owned
 	}
+	var dataQualityScoreObject: RewardFieldView.Score? {
+		rewardDetailsResponse?.base?.scoreObject(followState: followState)
+	}
 
 	init(device: DeviceDetails, followState: UserDeviceFollowState?, tokenUseCase: RewardsTimelineUseCase) {
 		self.device = device
@@ -77,6 +80,15 @@ class RewardDetailsViewModel: ObservableObject {
 		}
 
 		return LocalizableString.RewardDetails.viewAllIssues.localized
+	}
+
+	func baseRewardSubtitle() -> String? {
+		guard let actualReward = rewardDetailsResponse?.base?.actualReward,
+			  let maxReward = rewardDetailsResponse?.base?.maxReward else {
+			return nil
+		}
+		return LocalizableString.RewardDetails.earnedRewardDescription(actualReward.toWXMTokenPrecisionString,
+																	   maxReward.toWXMTokenPrecisionString).localized
 	}
 
 	func annotationActionButtonTile(for annotation: RewardAnnotation?) -> String? {

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
@@ -97,6 +97,13 @@ class RewardDetailsViewModel: ObservableObject {
 																	   maxReward.toWXMTokenPrecisionString).localized
 	}
 
+	func boostsSubtitle() -> String? {
+		guard let reward = rewardDetailsResponse?.boost?.totalReward else {
+			return nil
+		}
+		return LocalizableString.RewardDetails.earnedBoosts(reward.toWXMTokenPrecisionString).localized
+	}
+
 	func annotationActionButtonTile(for annotation: RewardAnnotation?) -> String? {
 		guard let group = annotation?.group else {
 			return nil

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
@@ -128,14 +128,6 @@ class RewardDetailsViewModel: ObservableObject {
 		Router.shared.navigateTo(.rewardAnnotations(rewardAnnotationsViewModel))
 	}
 
-	func handleReadMoreTap() {
-		guard let url = URL(string: DisplayedLinks.rewardMechanism.linkURL) else {
-			return
-		}
-
-		UIApplication.shared.open(url)
-	}
-
 	func handleDailyRewardInfoTap() {
 		let info = BottomSheetInfo(title: LocalizableString.RewardDetails.dailyReward.localized,
 								   description: LocalizableString.RewardDetails.dailyRewardInfoDescription.localized,

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
@@ -168,6 +168,7 @@ class RewardDetailsViewModel: ObservableObject {
 	func handleDailyRewardInfoTap() {
 		let info = BottomSheetInfo(title: LocalizableString.RewardDetails.dailyReward.localized,
 								   description: LocalizableString.RewardDetails.dailyRewardInfoDescription.localized,
+								   scrollable: true,
 								   buttonTitle: LocalizableString.RewardDetails.readMore.localized) {
 			guard let url = URL(string: DisplayedLinks.rewardMechanism.linkURL) else {
 				return
@@ -182,6 +183,7 @@ class RewardDetailsViewModel: ObservableObject {
 	func handleDataQualityInfoTap() {
 		let info = BottomSheetInfo(title: LocalizableString.RewardDetails.dataQuality.localized,
 								   description: LocalizableString.RewardDetails.dataQualityInfoDescription.localized,
+								   scrollable: true,
 								   buttonTitle: LocalizableString.RewardDetails.readMore.localized) {
 			guard let url = URL(string: DisplayedLinks.qodAlgorithm.linkURL) else {
 				return
@@ -196,6 +198,7 @@ class RewardDetailsViewModel: ObservableObject {
 	func handleLocationQualityInfoTap() {
 		let info = BottomSheetInfo(title: LocalizableString.RewardDetails.locationQuality.localized,
 								   description: LocalizableString.RewardDetails.locationQualityInfoDescription.localized,
+								   scrollable: true,
 								   buttonTitle: LocalizableString.RewardDetails.readMore.localized) {
 			guard let url = URL(string: DisplayedLinks.polAlgorithm.linkURL) else {
 				return
@@ -211,6 +214,7 @@ class RewardDetailsViewModel: ObservableObject {
 	func handleCellPositionInfoTap() {
 		let info = BottomSheetInfo(title: LocalizableString.RewardDetails.cellPosition.localized,
 								   description: LocalizableString.RewardDetails.cellPositionInfoDescription.localized,
+								   scrollable: true,
 								   buttonTitle: LocalizableString.RewardDetails.readMore.localized) {
 			guard let url = URL(string: DisplayedLinks.cellCapacity.linkURL) else {
 				return

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
@@ -167,7 +167,11 @@ class RewardDetailsViewModel: ObservableObject {
 		let info = BottomSheetInfo(title: LocalizableString.RewardDetails.dailyReward.localized,
 								   description: LocalizableString.RewardDetails.dailyRewardInfoDescription.localized,
 								   buttonTitle: LocalizableString.RewardDetails.readMore.localized) {
+			guard let url = URL(string: DisplayedLinks.rewardMechanism.linkURL) else {
+				return
+			}
 
+			UIApplication.shared.open(url)
 		}
 		self.info = info
 		showInfo = true
@@ -177,7 +181,11 @@ class RewardDetailsViewModel: ObservableObject {
 		let info = BottomSheetInfo(title: LocalizableString.RewardDetails.dataQuality.localized,
 								   description: LocalizableString.RewardDetails.dataQualityInfoDescription.localized,
 								   buttonTitle: LocalizableString.RewardDetails.readMore.localized) {
+			guard let url = URL(string: DisplayedLinks.qodAlgorithm.linkURL) else {
+				return
+			}
 
+			UIApplication.shared.open(url)
 		}
 		self.info = info
 		showInfo = true
@@ -187,6 +195,11 @@ class RewardDetailsViewModel: ObservableObject {
 		let info = BottomSheetInfo(title: LocalizableString.RewardDetails.locationQuality.localized,
 								   description: LocalizableString.RewardDetails.locationQualityInfoDescription.localized,
 								   buttonTitle: LocalizableString.RewardDetails.readMore.localized) {
+			guard let url = URL(string: DisplayedLinks.polAlgorithm.linkURL) else {
+				return
+			}
+
+			UIApplication.shared.open(url)
 
 		}
 		self.info = info
@@ -197,7 +210,11 @@ class RewardDetailsViewModel: ObservableObject {
 		let info = BottomSheetInfo(title: LocalizableString.RewardDetails.cellPosition.localized,
 								   description: LocalizableString.RewardDetails.cellPositionInfoDescription.localized,
 								   buttonTitle: LocalizableString.RewardDetails.readMore.localized) {
+			guard let url = URL(string: DisplayedLinks.cellCapacity.linkURL) else {
+				return
+			}
 
+			UIApplication.shared.open(url)
 		}
 		self.info = info
 		showInfo = true

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
@@ -75,8 +75,8 @@ class RewardDetailsViewModel: ObservableObject {
 	}
 
 	func issuesSubtitle() -> String? {
-		guard let warningType = rewardDetailsResponse?.annotation?.mainAnnotation?.warningType,
-			  let count = rewardDetailsResponse?.annotation?.summary?.count else {
+		guard let warningType = rewardDetailsResponse?.mainAnnotation?.warningType,
+			  let count = rewardDetailsResponse?.annotations?.count else {
 			return nil
 		}
 
@@ -91,9 +91,9 @@ class RewardDetailsViewModel: ObservableObject {
 	}
 
 	func issuesButtonTitle() -> String? {
-		guard let summary = rewardDetailsResponse?.annotation?.summary,
+		guard let summary = rewardDetailsResponse?.annotations,
 			  summary.count > 1 else {
-			return annotationActionButtonTile(for: rewardDetailsResponse?.annotation?.mainAnnotation)
+			return annotationActionButtonTile(for: rewardDetailsResponse?.mainAnnotation)
 		}
 
 		return LocalizableString.RewardDetails.viewAllIssues.localized
@@ -145,13 +145,13 @@ class RewardDetailsViewModel: ObservableObject {
 	}
 
 	func handleIssueButtonTap() {
-		guard let count = rewardDetailsResponse?.annotation?.summary?.count, count > 1 else {
-			handleRewardAnnotation(annotation: rewardDetailsResponse?.annotation?.mainAnnotation)
+		guard let count = rewardDetailsResponse?.annotations?.count, count > 1 else {
+			handleRewardAnnotation(annotation: rewardDetailsResponse?.mainAnnotation)
 			return
 		}
 
 		let rewardAnnotationsViewModel = ViewModelsFactory.getRewardAnnotationsViewModel(device: device,
-																						 annotations: rewardDetailsResponse?.annotation?.summary ?? [],
+																						 annotations: rewardDetailsResponse?.annotations ?? [],
 																						 followState: followState,
 																						 refDate: .now)
 		Router.shared.navigateTo(.rewardAnnotations(rewardAnnotationsViewModel))

--- a/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/Daily Rewards /RewardDetailsViewModel.swift
@@ -114,7 +114,11 @@ class RewardDetailsViewModel: ObservableObject {
 			return
 		}
 
-		
+		let rewardAnnotationsViewModel = ViewModelsFactory.getRewardAnnotationsViewModel(device: device,
+																						 annotations: rewardDetailsResponse?.annotation?.summary ?? [],
+																						 followState: followState,
+																						 refDate: .now)
+		Router.shared.navigateTo(.rewardAnnotations(rewardAnnotationsViewModel))
 	}
 
 	func handleReadMoreTap() {

--- a/PresentationLayer/UI Components/Screens/Network Statistics/NetworkStatsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/Network Statistics/NetworkStatsViewModel.swift
@@ -25,7 +25,7 @@ class NetworkStatsViewModel: ObservableObject {
     @Published var state: NetworkStatsView.State = .loading
     private(set) var failObj: FailSuccessStateObject?
 
-    private(set) var info: (title: String?, description: String)?
+    private(set) var info: BottomSheetInfo?
 
     private var isEmpty: Bool {
         dataDays == nil &&
@@ -66,7 +66,7 @@ class NetworkStatsViewModel: ObservableObject {
     }
 
     func showInfo(title: String?, description: String, analyticsItemId: ParameterValue?) {
-        info = (title, description)
+		info = .init(title: title, description: description)
         showInfo = true
 
         if let analyticsItemId {

--- a/PresentationLayer/UI Components/Screens/Profile/ProfileViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/Profile/ProfileViewModel.swift
@@ -22,7 +22,7 @@ class ProfileViewModel: ObservableObject {
 		}
 	}
 	@Published var showInfo: Bool = false
-	private(set) var info: (title: String?, description: String)?
+	private(set) var info: BottomSheetInfo?
 	@Published var userInfoResponse = NetworkUserInfoResponse() {
 		didSet {
 			updateUserInfoValues()
@@ -86,12 +86,14 @@ class ProfileViewModel: ObservableObject {
 	}
 
 	func handleTotalEarnedInfoTap() {
-		info = (LocalizableString.Profile.totalEarnedInfoTitle.localized, LocalizableString.Profile.totalEarnedInfoDescription.localized)
+		info = BottomSheetInfo(title: LocalizableString.Profile.totalEarnedInfoTitle.localized,
+							   description: LocalizableString.Profile.totalEarnedInfoDescription.localized)
 		showInfo = true
 	}
 
 	func handleTotalClaimedInfoTap() {
-		info = (LocalizableString.Profile.totalClaimedInfoTitle.localized, LocalizableString.Profile.totalClaimedInfoDescription.localized)
+		info = BottomSheetInfo(title: LocalizableString.Profile.totalClaimedInfoTitle.localized,
+							   description: LocalizableString.Profile.totalClaimedInfoDescription.localized)
 		showInfo = true
 	}
 

--- a/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotationsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotationsViewModel.swift
@@ -45,7 +45,7 @@ class RewardAnnotationsViewModel: ObservableObject {
 					return LocalizableString.RewardDetails.readMore.localized
 				}
 				return nil
-			case .unknown:
+			default:
 				if annotation?.docUrl != nil {
 					return LocalizableString.RewardDetails.readMore.localized
 				}
@@ -84,7 +84,7 @@ class RewardAnnotationsViewModel: ObservableObject {
 						  let url = URL(string: docUrl) {
 					 UIApplication.shared.open(url)
 				 }
-			case .unknown:
+			default:
 				if let docUrl = annotation.docUrl,
 				   let url = URL(string: docUrl) {
 					UIApplication.shared.open(url)

--- a/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotationsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/RewardAnnotations/RewardAnnotationsViewModel.swift
@@ -25,72 +25,16 @@ class RewardAnnotationsViewModel: ObservableObject {
 	}
 
 	func annotationActionButtonTile(for annotation: RewardAnnotation?) -> String? {
-		guard let group = annotation?.group else {
-			return nil
-		}
-
-		let isOwned = followState?.relation == .owned
-		switch group {
-			case .noWallet:
-				if MainScreenViewModel.shared.isWalletMissing, isOwned {
-					return LocalizableString.RewardDetails.noWalletProblemButtonTitle.localized
-				} else if annotation?.docUrl != nil {
-					return LocalizableString.RewardDetails.readMore.localized
-				}
-				return nil
-			case .locationNotVerified:
-				if isOwned {
-					return LocalizableString.RewardDetails.editLocation.localized
-				} else if annotation?.docUrl != nil {
-					return LocalizableString.RewardDetails.readMore.localized
-				}
-				return nil
-			default:
-				if annotation?.docUrl != nil {
-					return LocalizableString.RewardDetails.readMore.localized
-				}
-				return nil
-		}
+		annotation?.annotationActionButtonTile(with: followState)
 	}
 
 	func handleButtonTap(for error: RewardAnnotation) {
 		Logger.shared.trackEvent(.userAction, parameters: [.actionName: .rewardDetailsError,
 														   .itemId: .custom(error.group?.rawValue ?? "")])
-		handleRewardAnnotation(annotation: error)
+		
+		error.handleRewardAnnotationTap(with: device, followState: followState)
 	}
 
-	func handleRewardAnnotation(annotation: RewardAnnotation) {
-		guard let group = annotation.group else {
-			return
-		}
-
-		let isOwned = followState?.relation == .owned
-
-		switch group {
-			case .noWallet:
-				if MainScreenViewModel.shared.isWalletMissing, isOwned {
-					Router.shared.navigateTo(.wallet(ViewModelsFactory.getMyWalletViewModel()))
-				} else if let docUrl = annotation.docUrl,
-				   let url = URL(string: docUrl) {
-					UIApplication.shared.open(url)
-				}
-			case .locationNotVerified:
-				if isOwned {
-					let viewModel = ViewModelsFactory.getSelectLocationViewModel(device: device,
-																				 followState: followState,
-																				 delegate: nil)
-					Router.shared.navigateTo(.selectStationLocation(viewModel))
-				} else if let docUrl = annotation.docUrl,
-						  let url = URL(string: docUrl) {
-					 UIApplication.shared.open(url)
-				 }
-			default:
-				if let docUrl = annotation.docUrl,
-				   let url = URL(string: docUrl) {
-					UIApplication.shared.open(url)
-				}
-		}
-	}
 }
 
 extension RewardAnnotationsViewModel: HashableViewModel {

--- a/PresentationLayer/UI Components/Screens/WXMTransactionsDetails/RewardsTimelineViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/WXMTransactionsDetails/RewardsTimelineViewModel.swift
@@ -106,8 +106,13 @@ final class RewardsTimelineViewModel: ObservableObject {
 														   .contentType: .deviceRewardTransactions,
 														   .itemId: .custom(itemId)])
 
+		guard let timestamp = reward.timestamp else {
+			return
+		}
+
 		let viewModel = ViewModelsFactory.getRewardDetailsViewModel(device: device,
-																	followState: followState)
+																	followState: followState,
+																	date: timestamp)
 		Router.shared.navigateTo(.rewardDetails(viewModel))
 	}
 }

--- a/PresentationLayer/UI Components/Screens/WeatherStations/Station Details/Rewards/StationRewardsViewModel.swift
+++ b/PresentationLayer/UI Components/Screens/WeatherStations/Station Details/Rewards/StationRewardsViewModel.swift
@@ -48,12 +48,13 @@ class StationRewardsViewModel: ObservableObject {
     }
 
 	func handleViewDetailsTap() {
-		guard let device, let summary = response?.latest else {
+		guard let device, let timestamp = response?.latest?.timestamp else {
 			return
 		}
 
 		let viewModel = ViewModelsFactory.getRewardDetailsViewModel(device: device,
-																	followState: followState)
+																	followState: followState,
+																	date: timestamp)
 		Router.shared.navigateTo(.rewardDetails(viewModel))
 	}
 

--- a/PresentationLayer/UI Components/ViewModelsFactory.swift
+++ b/PresentationLayer/UI Components/ViewModelsFactory.swift
@@ -143,9 +143,10 @@ enum ViewModelsFactory {
 	}
 
 	static func getRewardDetailsViewModel(device: DeviceDetails,
-										  followState: UserDeviceFollowState?) -> RewardDetailsViewModel {
+										  followState: UserDeviceFollowState?,
+										  date: Date) -> RewardDetailsViewModel {
 		let useCase = SwinjectHelper.shared.getContainerForSwinject().resolve(RewardsTimelineUseCase.self)!
-		return RewardDetailsViewModel(device: device, followState: followState, tokenUseCase: useCase)
+		return RewardDetailsViewModel(device: device, followState: followState, date: date, tokenUseCase: useCase)
 	}
 
 	static func getSelectLocationViewModel(device: DeviceDetails,

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -408,10 +408,10 @@
 		26E9A5142AE26AFE003E0830 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E9A5132AE26AFE003E0830 /* View+.swift */; };
 		26F246362A278DAB0089D3E7 /* CustomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2664831829C31AF400748F9C /* CustomSheet.swift */; };
 		26FFAD682B8DF9C200BF0A6B /* LazyLoadingPager in Frameworks */ = {isa = PBXBuildFile; productRef = 26FFAD672B8DF9C200BF0A6B /* LazyLoadingPager */; };
-		26FFADD42B8F684C00BF0A6B /* RewardAnnotaionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFADD32B8F684C00BF0A6B /* RewardAnnotaionsView.swift */; };
-		26FFADD82B8F688900BF0A6B /* RewardAnnotationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFADD72B8F688900BF0A6B /* RewardAnnotationsViewModel.swift */; };
 		26FFAD792B8E12DC00BF0A6B /* RewardFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFAD782B8E12DC00BF0A6B /* RewardFieldView.swift */; };
 		26FFADA72B8F3D2700BF0A6B /* NetworkDeviceRewardDetailsResponse+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFADA62B8F3D2700BF0A6B /* NetworkDeviceRewardDetailsResponse+.swift */; };
+		26FFADD42B8F684C00BF0A6B /* RewardAnnotaionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFADD32B8F684C00BF0A6B /* RewardAnnotaionsView.swift */; };
+		26FFADD82B8F688900BF0A6B /* RewardAnnotationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFADD72B8F688900BF0A6B /* RewardAnnotationsViewModel.swift */; };
 		7423EC15283F81E2004E9B26 /* anim_weather_cloudy.json in Resources */ = {isa = PBXBuildFile; fileRef = 7423EBFE283F81E2004E9B26 /* anim_weather_cloudy.json */; };
 		7423EC16283F81E2004E9B26 /* anim_weather_clear_day.json in Resources */ = {isa = PBXBuildFile; fileRef = 7423EBFF283F81E2004E9B26 /* anim_weather_clear_day.json */; };
 		7423EC17283F81E2004E9B26 /* anim_not_available.json in Resources */ = {isa = PBXBuildFile; fileRef = 7423EC00283F81E2004E9B26 /* anim_not_available.json */; };
@@ -849,10 +849,10 @@
 		26E88AF429DD69930023BBD5 /* WXMShadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WXMShadow.swift; sourceTree = "<group>"; };
 		26E88AFE29E02F590023BBD5 /* anim_loader.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_loader.json; sourceTree = "<group>"; };
 		26E9A5132AE26AFE003E0830 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
-		26FFADD32B8F684C00BF0A6B /* RewardAnnotaionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAnnotaionsView.swift; sourceTree = "<group>"; };
-		26FFADD72B8F688900BF0A6B /* RewardAnnotationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAnnotationsViewModel.swift; sourceTree = "<group>"; };
 		26FFAD782B8E12DC00BF0A6B /* RewardFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardFieldView.swift; sourceTree = "<group>"; };
 		26FFADA62B8F3D2700BF0A6B /* NetworkDeviceRewardDetailsResponse+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkDeviceRewardDetailsResponse+.swift"; sourceTree = "<group>"; };
+		26FFADD32B8F684C00BF0A6B /* RewardAnnotaionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAnnotaionsView.swift; sourceTree = "<group>"; };
+		26FFADD72B8F688900BF0A6B /* RewardAnnotationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAnnotationsViewModel.swift; sourceTree = "<group>"; };
 		7423EBFE283F81E2004E9B26 /* anim_weather_cloudy.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_weather_cloudy.json; sourceTree = "<group>"; };
 		7423EBFF283F81E2004E9B26 /* anim_weather_clear_day.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_weather_clear_day.json; sourceTree = "<group>"; };
 		7423EC00283F81E2004E9B26 /* anim_not_available.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_not_available.json; sourceTree = "<group>"; };
@@ -2106,6 +2106,14 @@
 			path = "Station Details";
 			sourceTree = "<group>";
 		};
+		26FFAD772B8E125900BF0A6B /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				26FFAD782B8E12DC00BF0A6B /* RewardFieldView.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
 		26FFADD22B8F682D00BF0A6B /* RewardAnnotations */ = {
 			isa = PBXGroup;
 			children = (
@@ -2113,14 +2121,6 @@
 				26FFADD72B8F688900BF0A6B /* RewardAnnotationsViewModel.swift */,
 			);
 			path = RewardAnnotations;
-			sourceTree = "<group>";
-		};
-		26FFAD772B8E125900BF0A6B /* Components */ = {
-			isa = PBXGroup;
-			children = (
-				26FFAD782B8E12DC00BF0A6B /* RewardFieldView.swift */,
-			);
-			path = Components;
 			sourceTree = "<group>";
 		};
 		7423EBFD283F81E2004E9B26 /* LottieJSON */ = {

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -412,6 +412,8 @@
 		26FFADA72B8F3D2700BF0A6B /* NetworkDeviceRewardDetailsResponse+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFADA62B8F3D2700BF0A6B /* NetworkDeviceRewardDetailsResponse+.swift */; };
 		26FFADD42B8F684C00BF0A6B /* RewardAnnotaionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFADD32B8F684C00BF0A6B /* RewardAnnotaionsView.swift */; };
 		26FFADD82B8F688900BF0A6B /* RewardAnnotationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFADD72B8F688900BF0A6B /* RewardAnnotationsViewModel.swift */; };
+		26FFAE1C2B920A7300BF0A6B /* BoostsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFAE1B2B920A7300BF0A6B /* BoostsView.swift */; };
+		26FFAE1E2B92102000BF0A6B /* NoBoostsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFAE1D2B92102000BF0A6B /* NoBoostsView.swift */; };
 		7423EC15283F81E2004E9B26 /* anim_weather_cloudy.json in Resources */ = {isa = PBXBuildFile; fileRef = 7423EBFE283F81E2004E9B26 /* anim_weather_cloudy.json */; };
 		7423EC16283F81E2004E9B26 /* anim_weather_clear_day.json in Resources */ = {isa = PBXBuildFile; fileRef = 7423EBFF283F81E2004E9B26 /* anim_weather_clear_day.json */; };
 		7423EC17283F81E2004E9B26 /* anim_not_available.json in Resources */ = {isa = PBXBuildFile; fileRef = 7423EC00283F81E2004E9B26 /* anim_not_available.json */; };
@@ -853,6 +855,8 @@
 		26FFADA62B8F3D2700BF0A6B /* NetworkDeviceRewardDetailsResponse+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkDeviceRewardDetailsResponse+.swift"; sourceTree = "<group>"; };
 		26FFADD32B8F684C00BF0A6B /* RewardAnnotaionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAnnotaionsView.swift; sourceTree = "<group>"; };
 		26FFADD72B8F688900BF0A6B /* RewardAnnotationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAnnotationsViewModel.swift; sourceTree = "<group>"; };
+		26FFAE1B2B920A7300BF0A6B /* BoostsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoostsView.swift; sourceTree = "<group>"; };
+		26FFAE1D2B92102000BF0A6B /* NoBoostsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoBoostsView.swift; sourceTree = "<group>"; };
 		7423EBFE283F81E2004E9B26 /* anim_weather_cloudy.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_weather_cloudy.json; sourceTree = "<group>"; };
 		7423EBFF283F81E2004E9B26 /* anim_weather_clear_day.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_weather_clear_day.json; sourceTree = "<group>"; };
 		7423EC00283F81E2004E9B26 /* anim_not_available.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_not_available.json; sourceTree = "<group>"; };
@@ -2110,6 +2114,8 @@
 			isa = PBXGroup;
 			children = (
 				26FFAD782B8E12DC00BF0A6B /* RewardFieldView.swift */,
+				26FFAE1B2B920A7300BF0A6B /* BoostsView.swift */,
+				26FFAE1D2B92102000BF0A6B /* NoBoostsView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -2634,6 +2640,7 @@
 				26FFADD82B8F688900BF0A6B /* RewardAnnotationsViewModel.swift in Sources */,
 				26D47EA32A179CEB0078723A /* AnalyticsViewModel.swift in Sources */,
 				267548D529A91A87008BCF40 /* AnimationsEnums.swift in Sources */,
+				26FFAE1E2B92102000BF0A6B /* NoBoostsView.swift in Sources */,
 				B557E2152825212700E0BDCB /* AppDelegate.swift in Sources */,
 				267548D929A91A87008BCF40 /* AssetEnum.swift in Sources */,
 				2675480829A9181E008BCF40 /* AttributedLabel.swift in Sources */,
@@ -2891,6 +2898,7 @@
 				26AF27922A0CD6F60067A1B8 /* WeatherLineChart.swift in Sources */,
 				26A4116029B618CA00A2C10B /* WeatherOverviewView+Content.swift in Sources */,
 				26A4115D29B6160600A2C10B /* WeatherOverviewView.swift in Sources */,
+				26FFAE1C2B920A7300BF0A6B /* BoostsView.swift in Sources */,
 				267547FB29A9181E008BCF40 /* WeatherStationCard+Content.swift in Sources */,
 				267547FC29A9181E008BCF40 /* WeatherStationCard.swift in Sources */,
 				2675482129A9181E008BCF40 /* WeatherStationsHomeView.swift in Sources */,

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -410,6 +410,7 @@
 		26FFAD682B8DF9C200BF0A6B /* LazyLoadingPager in Frameworks */ = {isa = PBXBuildFile; productRef = 26FFAD672B8DF9C200BF0A6B /* LazyLoadingPager */; };
 		26FFADD42B8F684C00BF0A6B /* RewardAnnotaionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFADD32B8F684C00BF0A6B /* RewardAnnotaionsView.swift */; };
 		26FFADD82B8F688900BF0A6B /* RewardAnnotationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFADD72B8F688900BF0A6B /* RewardAnnotationsViewModel.swift */; };
+		26FFAD792B8E12DC00BF0A6B /* RewardFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFAD782B8E12DC00BF0A6B /* RewardFieldView.swift */; };
 		7423EC15283F81E2004E9B26 /* anim_weather_cloudy.json in Resources */ = {isa = PBXBuildFile; fileRef = 7423EBFE283F81E2004E9B26 /* anim_weather_cloudy.json */; };
 		7423EC16283F81E2004E9B26 /* anim_weather_clear_day.json in Resources */ = {isa = PBXBuildFile; fileRef = 7423EBFF283F81E2004E9B26 /* anim_weather_clear_day.json */; };
 		7423EC17283F81E2004E9B26 /* anim_not_available.json in Resources */ = {isa = PBXBuildFile; fileRef = 7423EC00283F81E2004E9B26 /* anim_not_available.json */; };
@@ -849,6 +850,7 @@
 		26E9A5132AE26AFE003E0830 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		26FFADD32B8F684C00BF0A6B /* RewardAnnotaionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAnnotaionsView.swift; sourceTree = "<group>"; };
 		26FFADD72B8F688900BF0A6B /* RewardAnnotationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAnnotationsViewModel.swift; sourceTree = "<group>"; };
+		26FFAD782B8E12DC00BF0A6B /* RewardFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardFieldView.swift; sourceTree = "<group>"; };
 		7423EBFE283F81E2004E9B26 /* anim_weather_cloudy.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_weather_cloudy.json; sourceTree = "<group>"; };
 		7423EBFF283F81E2004E9B26 /* anim_weather_clear_day.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_weather_clear_day.json; sourceTree = "<group>"; };
 		7423EC00283F81E2004E9B26 /* anim_not_available.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_not_available.json; sourceTree = "<group>"; };
@@ -956,6 +958,7 @@
 		2623FF8F2AF1467E00BCDAC6 /* Daily Rewards  */ = {
 			isa = PBXGroup;
 			children = (
+				26FFAD772B8E125900BF0A6B /* Components */,
 				2623FF902AF147A800BCDAC6 /* RewardDetailsView.swift */,
 				2623FF922AF14B4E00BCDAC6 /* RewardDetailsViewModel.swift */,
 			);
@@ -2109,6 +2112,14 @@
 			path = RewardAnnotations;
 			sourceTree = "<group>";
 		};
+		26FFAD772B8E125900BF0A6B /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				26FFAD782B8E12DC00BF0A6B /* RewardFieldView.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
 		7423EBFD283F81E2004E9B26 /* LottieJSON */ = {
 			isa = PBXGroup;
 			children = (
@@ -2638,6 +2649,7 @@
 				26AF27902A0CCD010067A1B8 /* ChartCardTypes.swift in Sources */,
 				266D17DD2AC6CF80007CDB06 /* WeatherStationCardView.swift in Sources */,
 				26AF278E2A0CCCE60067A1B8 /* ChartCardView.swift in Sources */,
+				26FFAD792B8E12DC00BF0A6B /* RewardFieldView.swift in Sources */,
 				267547D029A9181E008BCF40 /* ChartModifier.swift in Sources */,
 				267547C029A9181E008BCF40 /* ChartsContainer.swift in Sources */,
 				26AF276E2A0B815B0067A1B8 /* ChartsFactory.swift in Sources */,

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -411,6 +411,7 @@
 		26FFADD42B8F684C00BF0A6B /* RewardAnnotaionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFADD32B8F684C00BF0A6B /* RewardAnnotaionsView.swift */; };
 		26FFADD82B8F688900BF0A6B /* RewardAnnotationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFADD72B8F688900BF0A6B /* RewardAnnotationsViewModel.swift */; };
 		26FFAD792B8E12DC00BF0A6B /* RewardFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFAD782B8E12DC00BF0A6B /* RewardFieldView.swift */; };
+		26FFADA72B8F3D2700BF0A6B /* NetworkDeviceRewardDetailsResponse+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFADA62B8F3D2700BF0A6B /* NetworkDeviceRewardDetailsResponse+.swift */; };
 		7423EC15283F81E2004E9B26 /* anim_weather_cloudy.json in Resources */ = {isa = PBXBuildFile; fileRef = 7423EBFE283F81E2004E9B26 /* anim_weather_cloudy.json */; };
 		7423EC16283F81E2004E9B26 /* anim_weather_clear_day.json in Resources */ = {isa = PBXBuildFile; fileRef = 7423EBFF283F81E2004E9B26 /* anim_weather_clear_day.json */; };
 		7423EC17283F81E2004E9B26 /* anim_not_available.json in Resources */ = {isa = PBXBuildFile; fileRef = 7423EC00283F81E2004E9B26 /* anim_not_available.json */; };
@@ -851,6 +852,7 @@
 		26FFADD32B8F684C00BF0A6B /* RewardAnnotaionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAnnotaionsView.swift; sourceTree = "<group>"; };
 		26FFADD72B8F688900BF0A6B /* RewardAnnotationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAnnotationsViewModel.swift; sourceTree = "<group>"; };
 		26FFAD782B8E12DC00BF0A6B /* RewardFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardFieldView.swift; sourceTree = "<group>"; };
+		26FFADA62B8F3D2700BF0A6B /* NetworkDeviceRewardDetailsResponse+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkDeviceRewardDetailsResponse+.swift"; sourceTree = "<group>"; };
 		7423EBFE283F81E2004E9B26 /* anim_weather_cloudy.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_weather_cloudy.json; sourceTree = "<group>"; };
 		7423EBFF283F81E2004E9B26 /* anim_weather_clear_day.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_weather_clear_day.json; sourceTree = "<group>"; };
 		7423EC00283F81E2004E9B26 /* anim_not_available.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_not_available.json; sourceTree = "<group>"; };
@@ -1709,6 +1711,7 @@
 				26AF277D2A0B91200067A1B8 /* UnitsProtocol+.swift */,
 				266D17DF2AC6D0A1007CDB06 /* Firmware+.swift */,
 				266B01CC2B84FB59007AC689 /* NetworkDeviceRewardsSummaryResponse+.swift */,
+				26FFADA62B8F3D2700BF0A6B /* NetworkDeviceRewardDetailsResponse+.swift */,
 			);
 			path = "Domain Extensions";
 			sourceTree = "<group>";
@@ -2724,6 +2727,7 @@
 				26AF276F2A0B815B0067A1B8 /* HistoryChartModels.swift in Sources */,
 				26A3B3DC2B18D2480002F35F /* TabBarVisibilityHandler.swift in Sources */,
 				2672C77A2AA9BBEB00E1FDCC /* HistoryContainerView.swift in Sources */,
+				26FFADA72B8F3D2700BF0A6B /* NetworkDeviceRewardDetailsResponse+.swift in Sources */,
 				2672C77E2AA9BCFE00E1FDCC /* HistoryContainerViewModel.swift in Sources */,
 				267547C229A9181E008BCF40 /* HistoryView.swift in Sources */,
 				26A3B3C52B178F630002F35F /* LocalizableString+Profile.swift in Sources */,

--- a/wxm-ios/DataLayer/DataLayer/Networking/ApiRequestBuilders/DevicesApiRequestBuilder.swift
+++ b/wxm-ios/DataLayer/DataLayer/Networking/ApiRequestBuilders/DevicesApiRequestBuilder.swift
@@ -40,7 +40,7 @@ enum DevicesApiRequestBuilder: URLRequestConvertible {
     case deviceById(deviceId: String)
 	case deviceRewardsById(deviceId: String)
 	case deviceRewardsTimeline(deviceId: String, page: Int, pageSize: Int?, timezone: String, fromDate: String, toDate: String?)
-	case deviceRewardsDetailsById(deviceId: String)
+	case deviceRewardsDetailsById(deviceId: String, date: String)
 
     // MARK: - HttpMethod
 
@@ -62,11 +62,11 @@ enum DevicesApiRequestBuilder: URLRequestConvertible {
 			case let .deviceById(deviceId):
 				return "devices/\(deviceId)"
 			case let .deviceRewardsById(deviceId):
-				return "devices/\(deviceId)/tokens"
+				return "devices/\(deviceId)/rewards"
 			case let .deviceRewardsTimeline(deviceId, _, _, _, _, _):
-				return "devices/\(deviceId)/tokens/timeline"
-			case let .deviceRewardsDetailsById(deviceId):
-				return "devices/\(deviceId)/tokens/details"
+				return "devices/\(deviceId)/rewards/timeline"
+			case let .deviceRewardsDetailsById(deviceId, _):
+				return "devices/\(deviceId)/rewards/details"
 		}
     }
 
@@ -91,6 +91,8 @@ enum DevicesApiRequestBuilder: URLRequestConvertible {
                 }
 
                 return params
+			case let .deviceRewardsDetailsById(_, date):
+				return [ParameterConstants.Devices.date: date]
             default: return nil
         }
     }

--- a/wxm-ios/DataLayer/DataLayer/Networking/Constants/ParameterConstants.swift
+++ b/wxm-ios/DataLayer/DataLayer/Networking/Constants/ParameterConstants.swift
@@ -34,4 +34,8 @@ struct ParameterConstants {
 		static let lat = "lat"
 		static let lon = "lon"
     }
+
+	enum Devices {
+		static let date = "date"
+	}
 }

--- a/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/get_reward_details.json
+++ b/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/get_reward_details.json
@@ -1,45 +1,46 @@
 {
-  "total_daily_reward": 55.55,
-  "base": {
-    "actual_reward": 54.32,
-    "reward_score": 50,
-    "max_reward": 108.64,
-	"qod_score": 42,
-	"cell_capacity": 10,
-	"cell_position": 1
-  },
-  "boost": {
-    "total_daily_reward": 1.23,
-    "data": [
-      {
-		  "code": "beta_rewards",
-		  "title": "Beta Reward",
-		  "description": "Rewarded for participating in our beta reward program.",
-		  "img_url": "https://i0.wp.com/weatherxm.com/wp-content/uploads/2023/12/Home-header-image-1200-x-1200-px-2.png",
-		  "doc_url": "https://docs.weatherxm.com",
-		  "actual_reward": 1.23,
-		  "reward_score": 50,
-		  "max_reward": 2.46
-      }
-    ]
-  },
-  "annotation": {
-    "score": 0,
-    "summary": [
-      {
-        "severity_level": "INFO",
-        "group": "NO_WALLET",
-        "title": "Minor Sensor Issues",
-        "message": "Station is doing great! Minor issues detected during our data quality checks, that may be related to occasional sensor inaccuracies. That can happen once in a while.",
-        "doc_url": "https://docs.weatherxm.com/project/rewards-troubleshooting#sensor-problems"
-      },
-	  {
-		"severity_level": "ERROR",
-		"group": "NO_WALLET",
-		"title": "Minor Sensor Issues",
-		"message": "Station is doing great! Minor issues detected during our data quality checks, that may be related to occasional sensor inaccuracies. That can happen once in a while.",
-		"doc_url": "https://docs.weatherxm.com/project/rewards-troubleshooting#sensor-problems"
-	  }
-    ]
-  }
+	"timestamp": "2024-03-01T10:09:04.249Z",
+	"total_daily_reward": 55.55,
+	"base": {
+		"actual_reward": 54.32,
+		"reward_score": 50,
+		"max_reward": 108.64,
+		"qod_score": 42,
+		"cell_capacity": 10,
+		"cell_position": 1
+	},
+	"boost": {
+		"total_daily_reward": 1.23,
+		"data": [
+			{
+				"code": "beta_rewards",
+				"title": "Beta Reward",
+				"description": "Rewarded for participating in our beta reward program.",
+				"img_url": "https://i0.wp.com/weatherxm.com/wp-content/uploads/2023/12/Home-header-image-1200-x-1200-px-2.png",
+				"doc_url": "https://docs.weatherxm.com",
+				"actual_reward": 1.23,
+				"reward_score": 50,
+				"max_reward": 2.46
+			}
+		]
+	},
+	"annotation": {
+		"score": 0,
+		"summary": [
+			{
+				"severity_level": "INFO",
+				"group": "NO_WALLET",
+				"title": "Minor Sensor Issues",
+				"message": "Station is doing great! Minor issues detected during our data quality checks, that may be related to occasional sensor inaccuracies. That can happen once in a while.",
+				"doc_url": "https://docs.weatherxm.com/project/rewards-troubleshooting#sensor-problems"
+			},
+			{
+				"severity_level": "ERROR",
+				"group": "NO_WALLET",
+				"title": "Minor Sensor Issues",
+				"message": "Station is doing great! Minor issues detected during our data quality checks, that may be related to occasional sensor inaccuracies. That can happen once in a while.",
+				"doc_url": "https://docs.weatherxm.com/project/rewards-troubleshooting#sensor-problems"
+			}
+		]
+	}
 }

--- a/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/get_reward_details.json
+++ b/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/get_reward_details.json
@@ -32,7 +32,14 @@
         "title": "Minor Sensor Issues",
         "message": "Station is doing great! Minor issues detected during our data quality checks, that may be related to occasional sensor inaccuracies. That can happen once in a while.",
         "doc_url": "https://docs.weatherxm.com/project/rewards-troubleshooting#sensor-problems"
-      }
+      },
+	  {
+		"severity_level": "ERROR",
+		"group": "NO_WALLET",
+		"title": "Minor Sensor Issues",
+		"message": "Station is doing great! Minor issues detected during our data quality checks, that may be related to occasional sensor inaccuracies. That can happen once in a while.",
+		"doc_url": "https://docs.weatherxm.com/project/rewards-troubleshooting#sensor-problems"
+	  }
     ]
   }
 }

--- a/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/get_reward_details.json
+++ b/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/get_reward_details.json
@@ -24,23 +24,20 @@
 			}
 		]
 	},
-	"annotation": {
-		"score": 0,
-		"summary": [
-			{
-				"severity_level": "INFO",
-				"group": "NO_WALLET",
-				"title": "Minor Sensor Issues",
-				"message": "Station is doing great! Minor issues detected during our data quality checks, that may be related to occasional sensor inaccuracies. That can happen once in a while.",
-				"doc_url": "https://docs.weatherxm.com/project/rewards-troubleshooting#sensor-problems"
-			},
-			{
-				"severity_level": "ERROR",
-				"group": "NO_WALLET",
-				"title": "Minor Sensor Issues",
-				"message": "Station is doing great! Minor issues detected during our data quality checks, that may be related to occasional sensor inaccuracies. That can happen once in a while.",
-				"doc_url": "https://docs.weatherxm.com/project/rewards-troubleshooting#sensor-problems"
-			}
-		]
-	}
+	"annotation_summary": [
+		{
+			"severity_level": "INFO",
+			"group": "NO_WALLET",
+			"title": "Minor Sensor Issues",
+			"message": "Station is doing great! Minor issues detected during our data quality checks, that may be related to occasional sensor inaccuracies. That can happen once in a while.",
+			"doc_url": "https://docs.weatherxm.com/project/rewards-troubleshooting#sensor-problems"
+		},
+		{
+			"severity_level": "ERROR",
+			"group": "NO_WALLET",
+			"title": "Minor Sensor Issues",
+			"message": "Station is doing great! Minor issues detected during our data quality checks, that may be related to occasional sensor inaccuracies. That can happen once in a while.",
+			"doc_url": "https://docs.weatherxm.com/project/rewards-troubleshooting#sensor-problems"
+		}
+	]
 }

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/DevicesRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/DevicesRepositoryImpl.swift
@@ -39,7 +39,7 @@ public struct DevicesRepositoryImpl: DevicesRepository {
 	}
 
 	public func deviceRewardsDetails(deviceId: String) throws -> AnyPublisher<DataResponse<NetworkDeviceRewardDetailsResponse, NetworkErrorResponse>, Never> {
-		let builder =  DevicesApiRequestBuilder.deviceRewardsById(deviceId: deviceId)
+		let builder =  DevicesApiRequestBuilder.deviceRewardsDetailsById(deviceId: deviceId)
 		let urlRequest = try builder.asURLRequest()
 		return ApiClient.shared.requestCodable(urlRequest, mockFileName: builder.mockFileName)
 	}

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/DevicesRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/DevicesRepositoryImpl.swift
@@ -38,8 +38,8 @@ public struct DevicesRepositoryImpl: DevicesRepository {
 		return ApiClient.shared.requestCodable(urlRequest, mockFileName: builder.mockFileName)
 	}
 
-	public func deviceRewardsDetails(deviceId: String) throws -> AnyPublisher<DataResponse<NetworkDeviceRewardDetailsResponse, NetworkErrorResponse>, Never> {
-		let builder =  DevicesApiRequestBuilder.deviceRewardsDetailsById(deviceId: deviceId)
+	public func deviceRewardsDetails(deviceId: String, date: String) throws -> AnyPublisher<DataResponse<NetworkDeviceRewardDetailsResponse, NetworkErrorResponse>, Never> {
+		let builder =  DevicesApiRequestBuilder.deviceRewardsDetailsById(deviceId: deviceId, date: date)
 		let urlRequest = try builder.asURLRequest()
 		return ApiClient.shared.requestCodable(urlRequest, mockFileName: builder.mockFileName)
 	}

--- a/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/DevicesRepository.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/DevicesRepository.swift
@@ -13,5 +13,5 @@ public protocol DevicesRepository {
     func deviceById(deviceId: String) throws -> AnyPublisher<DataResponse<NetworkDevicesResponse, NetworkErrorResponse>, Never>
 	func deviceRewardsTimeline(deviceId: String, page: Int, pageSize: Int?, timezone: String, fromDate: String, toDate: String?) throws -> AnyPublisher<DataResponse<NetworkDeviceRewardsTimelineResponse, NetworkErrorResponse>, Never>
 	func deviceRewardsSummary(deviceId: String) throws -> AnyPublisher<DataResponse<NetworkDeviceRewardsSummaryResponse, NetworkErrorResponse>, Never>
-	func deviceRewardsDetails(deviceId: String) throws -> AnyPublisher<DataResponse<NetworkDeviceRewardDetailsResponse, NetworkErrorResponse>, Never>
+	func deviceRewardsDetails(deviceId: String, date: String) throws -> AnyPublisher<DataResponse<NetworkDeviceRewardDetailsResponse, NetworkErrorResponse>, Never>
 }

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Me/Network/NetworkDeviceRewardDetailsResponse.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Me/Network/NetworkDeviceRewardDetailsResponse.swift
@@ -53,7 +53,7 @@ public extension NetworkDeviceRewardDetailsResponse {
 	}
 
 	struct BoostReward: Codable, Hashable {
-		public let code: String?
+		public let code: BoostCode?
 		public let title: String?
 		public let description: String?
 		public let imageUrl: String?
@@ -71,6 +71,29 @@ public extension NetworkDeviceRewardDetailsResponse {
 			case actualReward = "actual_reward"
 			case rewardScore = "reward_score"
 			case maxReward = "max_reward"
+		}
+
+		public enum BoostCode: Codable, RawRepresentable, Hashable {
+			case betaReward
+			case unknown(String)
+
+			public init?(rawValue: String) {
+				switch rawValue {
+					case "beta_rewards":
+						self = .betaReward
+					default:
+						self = .unknown(rawValue)
+				}
+			}
+
+			public var rawValue: String {
+				switch self {
+					case .betaReward:
+						return "beta_reward"
+					case .unknown(let raw):
+						return raw
+				}
+			}
 		}
 	}
 }

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/RewardAnnotation.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/RewardAnnotation.swift
@@ -59,6 +59,8 @@ public extension RewardAnnotation {
 					self = .noLocationData
 				case "USER_RELOCATION_PENALTY":
 					self = .userRelocationPenalty
+				case "CELL_CAPACITY_REACHED":
+					self = .cellCapacityReached
 				default:
 					self = .unknown(rawValue)
 			}
@@ -68,6 +70,7 @@ public extension RewardAnnotation {
 		case locationNotVerified
 		case noLocationData
 		case userRelocationPenalty
+		case cellCapacityReached
 		case unknown(String)
 
 		public var rawValue: String {
@@ -80,6 +83,8 @@ public extension RewardAnnotation {
 					"NO_LOCATION_DATA"
 				case .userRelocationPenalty:
 					"USER_RELOCATION_PENALTY"
+				case .cellCapacityReached:
+					"CELL_CAPACITY_REACHED"
 				case .unknown(let value):
 					value
 			}

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/RewardAnnotation.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/RewardAnnotation.swift
@@ -55,6 +55,10 @@ public extension RewardAnnotation {
 					self = .noWallet
 				case "LOCATION_NOT_VERIFIED":
 					self = .locationNotVerified
+				case "NO_LOCATION_DATA":
+					self = .noLocationData
+				case "USER_RELOCATION_PENALTY":
+					self = .userRelocationPenalty
 				default:
 					self = .unknown(rawValue)
 			}
@@ -62,6 +66,8 @@ public extension RewardAnnotation {
 		
 		case noWallet
 		case locationNotVerified
+		case noLocationData
+		case userRelocationPenalty
 		case unknown(String)
 
 		public var rawValue: String {
@@ -70,6 +76,10 @@ public extension RewardAnnotation {
 					"NO_WALLET"
 				case .locationNotVerified:
 					"LOCATION_NOT_VERIFIED"
+				case .noLocationData:
+					"NO_LOCATION_DATA"
+				case .userRelocationPenalty:
+					"USER_RELOCATION_PENALTY"
 				case .unknown(let value):
 					value
 			}

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/RewardsTimelineUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/RewardsTimelineUseCase.swift
@@ -42,8 +42,8 @@ public class RewardsTimelineUseCase {
 		try await meRepository.getDeviceFollowState(deviceId: deviceId)
 	}
 
-	public func getRewardDetails(deviceId: String) async throws -> Result<NetworkDeviceRewardDetailsResponse?, NetworkErrorResponse> {
-		let publisher = try repository.deviceRewardsDetails(deviceId: deviceId)
+	public func getRewardDetails(deviceId: String, date: String) async throws -> Result<NetworkDeviceRewardDetailsResponse?, NetworkErrorResponse> {
+		let publisher = try repository.deviceRewardsDetails(deviceId: deviceId, date: date)
 
 		return await withUnsafeContinuation { continuation in
 			publisher.sink { response in

--- a/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
+++ b/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
@@ -32,6 +32,10 @@ extension LocalizableString {
 		case dataQualityPublicVeryLowMessage(Int)
 		case dataQualityLostMessage
 		case dataQualityNoInfoMessage
+		case noLocationData
+		case locationNotVerified
+		case recentlyRelocated
+		case locationVerified
 		case problemsTitle
 		case problemsDescription(String)
 		case zeroLostProblemsDescription
@@ -136,7 +140,14 @@ extension LocalizableString.RewardDetails: WXMLocalizable {
 				return "reward_details_data_quality_lost_message"
 			case .dataQualityNoInfoMessage:
 				return "reward_details_data_quality_no_info_message"
-
+			case .noLocationData:
+				return "reward_details_no_location_data"
+			case .locationNotVerified:
+				return "reward_details_location_not_verified"
+			case .recentlyRelocated:
+				return "reward_details_recently_relocated"
+			case .locationVerified:
+				return "reward_details_location_verified"
 			case .problemsDescription:
 				return "reward_problems_description_format"
 			case .zeroLostProblemsDescription:

--- a/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
+++ b/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
@@ -32,6 +32,7 @@ extension LocalizableString {
 		case dataQualityPublicVeryLowMessage(Int)
 		case dataQualityLostMessage
 		case dataQualityNoInfoMessage
+		case cellPositionSuccessMessage
 		case noLocationData
 		case locationNotVerified
 		case recentlyRelocated
@@ -140,6 +141,8 @@ extension LocalizableString.RewardDetails: WXMLocalizable {
 				return "reward_details_data_quality_lost_message"
 			case .dataQualityNoInfoMessage:
 				return "reward_details_data_quality_no_info_message"
+			case .cellPositionSuccessMessage:
+				return "reward_details_cell_position_success_message"
 			case .noLocationData:
 				return "reward_details_no_location_data"
 			case .locationNotVerified:

--- a/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
+++ b/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
@@ -41,6 +41,10 @@ extension LocalizableString {
 		case earnedBoosts(String)
 		case noActiveBoostsTitle
 		case noActiveBoostsDescription
+		case dailyRewardInfoDescription
+		case dataQualityInfoDescription
+		case locationQualityInfoDescription
+		case cellPositionInfoDescription
 		case problemsTitle
 		case problemsDescription(String)
 		case zeroLostProblemsDescription
@@ -164,6 +168,14 @@ extension LocalizableString.RewardDetails: WXMLocalizable {
 				return "reward_details_no_active_boosts_title"
 			case .noActiveBoostsDescription:
 				return "reward_details_no_active_boosts_description"
+			case .dailyRewardInfoDescription:
+				return "reward_details_daily_reward_info_description"
+			case .dataQualityInfoDescription:
+				return "reward_details_data_quality_info_description"
+			case .locationQualityInfoDescription:
+				return "reward_details_location_quality_info_description"
+			case .cellPositionInfoDescription:
+				return "reward_details_cell_quality_info_description"
 			case .problemsDescription:
 				return "reward_problems_description_format"
 			case .zeroLostProblemsDescription:

--- a/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
+++ b/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
@@ -37,6 +37,8 @@ extension LocalizableString {
 		case locationNotVerified
 		case recentlyRelocated
 		case locationVerified
+		case activeBoosts
+		case earnedBoosts(String)
 		case problemsTitle
 		case problemsDescription(String)
 		case zeroLostProblemsDescription
@@ -79,7 +81,8 @@ extension LocalizableString.RewardDetails: WXMLocalizable {
 					.rewardScoreInfoDescription(let text),
 					.maxRewardsInfoDescription(let text),
 					.reportFor(let text),
-					.earningsFor(let text):
+					.earningsFor(let text),
+					.earnedBoosts(let text):
 				localized = String(format: localized, text)
 			case .earnedRewardDescription(let earned, let dailyMax):
 				localized = String(format: localized, arguments: [earned, dailyMax].compactMap { $0 })
@@ -151,6 +154,10 @@ extension LocalizableString.RewardDetails: WXMLocalizable {
 				return "reward_details_recently_relocated"
 			case .locationVerified:
 				return "reward_details_location_verified"
+			case .activeBoosts:
+				return "reward_details_active_boosts"
+			case .earnedBoosts:
+				return "reward_details_earned_boosts_format"
 			case .problemsDescription:
 				return "reward_problems_description_format"
 			case .zeroLostProblemsDescription:

--- a/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
+++ b/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
@@ -39,6 +39,8 @@ extension LocalizableString {
 		case locationVerified
 		case activeBoosts
 		case earnedBoosts(String)
+		case noActiveBoostsTitle
+		case noActiveBoostsDescription
 		case problemsTitle
 		case problemsDescription(String)
 		case zeroLostProblemsDescription
@@ -158,6 +160,10 @@ extension LocalizableString.RewardDetails: WXMLocalizable {
 				return "reward_details_active_boosts"
 			case .earnedBoosts:
 				return "reward_details_earned_boosts_format"
+			case .noActiveBoostsTitle:
+				return "reward_details_no_active_boosts_title"
+			case .noActiveBoostsDescription:
+				return "reward_details_no_active_boosts_description"
 			case .problemsDescription:
 				return "reward_problems_description_format"
 			case .zeroLostProblemsDescription:

--- a/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
+++ b/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
@@ -13,6 +13,7 @@ extension LocalizableString {
 		case dailyReward
 		case issues
 		case earningsFor(String)
+		case viewAllIssues
 		case problemsTitle
 		case problemsDescription(String)
 		case zeroLostProblemsDescription
@@ -64,6 +65,8 @@ extension LocalizableString.RewardDetails: WXMLocalizable {
 				return "reward_details_earnings_for_format"
 			case .problemsTitle:
 				return "reward_problems_title"
+			case .viewAllIssues:
+				return "reward_details_view_all_issues"
 			case .problemsDescription:
 				return "reward_problems_description_format"
 			case .zeroLostProblemsDescription:

--- a/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
+++ b/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
@@ -11,6 +11,7 @@ extension LocalizableString {
 	enum RewardDetails {
 		case title
 		case dailyReward
+		case issues
 		case earningsFor(String)
 		case problemsTitle
 		case problemsDescription(String)
@@ -57,6 +58,8 @@ extension LocalizableString.RewardDetails: WXMLocalizable {
 				return "reward_details_title"
 			case .dailyReward:
 				return "reward_details_daily_reward"
+			case .issues:
+				return "reward_details_issues"
 			case .earningsFor:
 				return "reward_details_earnings_for_format"
 			case .problemsTitle:

--- a/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
+++ b/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
@@ -10,6 +10,8 @@ import Foundation
 extension LocalizableString {
 	enum RewardDetails {
 		case title
+		case dailyReward
+		case earningsFor(String)
 		case problemsTitle
 		case problemsDescription(String)
 		case zeroLostProblemsDescription
@@ -38,7 +40,8 @@ extension LocalizableString.RewardDetails: WXMLocalizable {
 			case .problemsDescription(let text),
 					.rewardScoreInfoDescription(let text),
 					.maxRewardsInfoDescription(let text),
-					.reportFor(let text):
+					.reportFor(let text),
+					.earningsFor(let text):
 				localized = String(format: localized, text)
 			case .timelineInfoDescription(let timezoneOffset, let url):
 				localized = String(format: localized, arguments: [timezoneOffset, url].compactMap { $0 })
@@ -52,6 +55,10 @@ extension LocalizableString.RewardDetails: WXMLocalizable {
 		switch self {
 			case .title:
 				return "reward_details_title"
+			case .dailyReward:
+				return "reward_details_daily_reward"
+			case .earningsFor:
+				return "reward_details_earnings_for_format"
 			case .problemsTitle:
 				return "reward_problems_title"
 			case .problemsDescription:

--- a/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
+++ b/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
@@ -14,6 +14,24 @@ extension LocalizableString {
 		case issues
 		case earningsFor(String)
 		case viewAllIssues
+		case earnedRewardDescription(String, String)
+		case dataQuality
+		case locationQuality
+		case cellPosition
+		case dataQualitySolidMessage(Int)
+		case dataQualityAlmostPerfectMessage(Int)
+		case dataQualityGreatMessage(Int)
+		case dataQualityPublicGreatMessage(Int)
+		case dataQualityOkMessage(Int)
+		case dataQualityPublicOkMessage(Int)
+		case dataQualityAverageMessage(Int)
+		case dataQualityPublicAverageMessage(Int)
+		case dataQualityLowMessage(Int)
+		case dataQualityPublicLowMessage(Int)
+		case dataQualityVeryLowMessage(Int)
+		case dataQualityPublicVeryLowMessage(Int)
+		case dataQualityLostMessage
+		case dataQualityNoInfoMessage
 		case problemsTitle
 		case problemsDescription(String)
 		case zeroLostProblemsDescription
@@ -39,12 +57,27 @@ extension LocalizableString.RewardDetails: WXMLocalizable {
 	var localized: String {
 		var localized = NSLocalizedString(key, comment: "")
 		switch self {
+			case .dataQualitySolidMessage(let count),
+					.dataQualityAlmostPerfectMessage(let count),
+					.dataQualityGreatMessage(let count),
+					.dataQualityPublicGreatMessage(let count),
+					.dataQualityOkMessage(let count),
+					.dataQualityPublicOkMessage(let count),
+					.dataQualityAverageMessage(let count),
+					.dataQualityPublicAverageMessage(let count),
+					.dataQualityLowMessage(let count),
+					.dataQualityPublicLowMessage(let count),
+					.dataQualityVeryLowMessage(let count),
+					.dataQualityPublicVeryLowMessage(let count):
+				localized = String(format: localized, count)
 			case .problemsDescription(let text),
 					.rewardScoreInfoDescription(let text),
 					.maxRewardsInfoDescription(let text),
 					.reportFor(let text),
 					.earningsFor(let text):
 				localized = String(format: localized, text)
+			case .earnedRewardDescription(let earned, let dailyMax):
+				localized = String(format: localized, arguments: [earned, dailyMax].compactMap { $0 })
 			case .timelineInfoDescription(let timezoneOffset, let url):
 				localized = String(format: localized, arguments: [timezoneOffset, url].compactMap { $0 })
 			default: break
@@ -67,6 +100,43 @@ extension LocalizableString.RewardDetails: WXMLocalizable {
 				return "reward_problems_title"
 			case .viewAllIssues:
 				return "reward_details_view_all_issues"
+			case .earnedRewardDescription:
+				return "reward_details_earned_reward_description_format"
+			case .dataQuality:
+				return "reward_details_data_quality"
+			case .locationQuality:
+				return "reward_details_location_quality"
+			case .cellPosition:
+				return "reward_details_cell_position"
+			case .dataQualitySolidMessage:
+				return "reward_details_data_quality_solid_message"
+			case .dataQualityAlmostPerfectMessage:
+				return "reward_details_data_quality_perfect_message"
+			case .dataQualityGreatMessage:
+				return "reward_details_data_quality_great_message"
+			case .dataQualityPublicGreatMessage:
+				return "reward_details_data_quality_public_great_message"
+			case .dataQualityOkMessage:
+				return "reward_details_data_quality_ok_message"
+			case .dataQualityPublicOkMessage:
+				return "reward_details_data_quality_public_ok_message"
+			case .dataQualityAverageMessage:
+				return "reward_details_data_quality_average_message"
+			case .dataQualityPublicAverageMessage:
+				return "reward_details_data_quality_public_average_message"
+			case .dataQualityLowMessage:
+				return "reward_details_data_quality_low_message"
+			case .dataQualityPublicLowMessage:
+				return "reward_details_data_quality_public_low_message"
+			case .dataQualityVeryLowMessage:
+				return "reward_details_data_quality_very_low_message"
+			case .dataQualityPublicVeryLowMessage:
+				return "reward_details_data_quality_public_very_low_message"
+			case .dataQualityLostMessage:
+				return "reward_details_data_quality_lost_message"
+			case .dataQualityNoInfoMessage:
+				return "reward_details_data_quality_no_info_message"
+
 			case .problemsDescription:
 				return "reward_problems_description_format"
 			case .zeroLostProblemsDescription:

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -5113,6 +5113,28 @@
         }
       }
     },
+    "reward_details_no_active_boosts_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "More reward boosts coming soon."
+          }
+        }
+      }
+    },
+    "reward_details_no_active_boosts_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No active boosts for this station at the moment"
+          }
+        }
+      }
+    },
     "reward_details_no_location_data" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -4824,6 +4824,17 @@
         }
       }
     },
+    "reward_details_issues" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Issues"
+          }
+        }
+      }
+    },
     "reward_details_max_rewards_info_description_format" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -4791,6 +4791,28 @@
         }
       }
     },
+    "reward_details_daily_reward" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daily Reward"
+          }
+        }
+      }
+    },
+    "reward_details_earnings_for_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Earnings for %@"
+          }
+        }
+      }
+    },
     "reward_details_edit_location" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -4956,6 +4956,17 @@
         }
       }
     },
+    "reward_details_view_all_issues" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View all issues"
+          }
+        }
+      }
+    },
     "reward_details_view_transaction" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -3834,6 +3834,9 @@
         }
       }
     },
+    "Key" : {
+      "extractionState" : "manual"
+    },
     "last_name" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -4780,6 +4783,17 @@
         }
       }
     },
+    "reward_details_cell_position" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cell Position"
+          }
+        }
+      }
+    },
     "reward_details_contact_support_button_title" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -4798,6 +4812,182 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Daily Reward"
+          }
+        }
+      }
+    },
+    "reward_details_data_quality" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data Quality"
+          }
+        }
+      }
+    },
+    "reward_details_data_quality_average_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data quality is average! Got %d%%. Fix any pending issues to earn more rewards."
+          }
+        }
+      }
+    },
+    "reward_details_data_quality_great_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data quality is great! Got %d%%. Fix any pending issues to earn more rewards."
+          }
+        }
+      }
+    },
+    "reward_details_data_quality_lost_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station lost all rewards because of data quality issues."
+          }
+        }
+      }
+    },
+    "reward_details_data_quality_low_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data quality is low! Got only %d%%. Fix any pending issues to earn more rewards."
+          }
+        }
+      }
+    },
+    "reward_details_data_quality_no_info_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No information about data quality is available at the moment."
+          }
+        }
+      }
+    },
+    "reward_details_data_quality_ok_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data quality is ok! Got %d%%. Fix any pending issues to earn more rewards."
+          }
+        }
+      }
+    },
+    "reward_details_data_quality_perfect_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Almost perfect! Got %d%%!"
+          }
+        }
+      }
+    },
+    "reward_details_data_quality_public_average_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data quality is average! Got %d%%."
+          }
+        }
+      }
+    },
+    "reward_details_data_quality_public_great_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data quality is great! Got %d%%."
+          }
+        }
+      }
+    },
+    "reward_details_data_quality_public_low_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data quality is low! Got only %d%%."
+          }
+        }
+      }
+    },
+    "reward_details_data_quality_public_ok_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data quality is ok! Got %d%%."
+          }
+        }
+      }
+    },
+    "reward_details_data_quality_public_very_low_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data quality is very low!  Got only %d%%."
+          }
+        }
+      }
+    },
+    "reward_details_data_quality_solid_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Good job! A solid %d%%."
+          }
+        }
+      }
+    },
+    "reward_details_data_quality_very_low_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data quality is very low!  Got only %d%%. Fix any pending issues to earn more rewards."
+          }
+        }
+      }
+    },
+    "reward_details_earned_reward_description_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Earned **+%@ $WXM** of the %@ $WXM Daily Max."
           }
         }
       }
@@ -4831,6 +5021,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Issues"
+          }
+        }
+      }
+    },
+    "reward_details_location_quality" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Location Quality"
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -5025,6 +5025,17 @@
         }
       }
     },
+    "reward_details_location_not_verified" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Location could not be verified."
+          }
+        }
+      }
+    },
     "reward_details_location_quality" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -5032,6 +5043,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Location Quality"
+          }
+        }
+      }
+    },
+    "reward_details_location_verified" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station location is verified!"
           }
         }
       }
@@ -5058,6 +5080,17 @@
         }
       }
     },
+    "reward_details_no_location_data" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No location data."
+          }
+        }
+      }
+    },
     "reward_details_read_more" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -5065,6 +5098,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Read more"
+          }
+        }
+      }
+    },
+    "reward_details_recently_relocated" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station was recently relocated."
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -4794,6 +4794,17 @@
         }
       }
     },
+    "reward_details_cell_position_success_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cell position is great!"
+          }
+        }
+      }
+    },
     "reward_details_contact_support_button_title" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -4816,6 +4816,17 @@
         }
       }
     },
+    "reward_details_cell_quality_info_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cell capacity is a parameter that is used to define the maximum number of stations that may receive rewards in a specific cell - a hexagonal area on the planet covering a surface area of ~5 square kilometers. Each cell has a predefined cell capacity that depends on its geospatial characteristics. The cell's capacity indicates the maximum number of stations that may receive rewards.\n\nAs long as a station's position is above the maximum capacity it will be rewarded, whereas getting below this threshold will lead to zero rewards. A station's position in a cell is calculated using its reward score and its seniority as criteria.\n\nRead more about how our Cell Capacity algorithm works."
+          }
+        }
+      }
+    },
     "reward_details_contact_support_button_title" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -4834,6 +4845,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Daily Reward"
+          }
+        }
+      }
+    },
+    "reward_details_daily_reward_info_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WeatherXM’s goal is to become an open, decentralized ecosystem structured in such a way that network growth, and thereby balanced global weather coverage, is incentivised and every participant (weather station owners and service providers) is fairly and organically rewarded in accordance to the value they contribute to the network.\n\nStation owners are responsible for deploying and maintaining their stations and ensuring the best possible quality of weather data following the Network’s guidelines of deployment. In return they are rewarded, in the Network’s token, called $WXM.\n\nEvery day, our reward algorithm assesses the performance of all weather stations, calculates the Base Reward and any additional rewards originating from various active “Boosts”, and allocates the total reward amount to each user’s connected wallet.\n\nRead more about how our Reward Mechanism works."
           }
         }
       }
@@ -4867,6 +4889,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Data quality is great! Got %d%%. Fix any pending issues to earn more rewards."
+          }
+        }
+      }
+    },
+    "reward_details_data_quality_info_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The Network is as good as its data and we need our data to be meaningful and usable. The Quality-of-Data (QoD) score is an attempt to quantify this metric. The end goal is to encourage weather station owners to do their best to comply with the Network's guidelines in order to consistently achieve the best data quality possible.\n\nA weather station's daily reward is affected by its QoD score. To calculate the QoD score, we have created an open source algorithm that evaluates the quality of the weather data using various methods. The calculated score indicates the confidence level in the quality of the weather data received from the station.\n\nRead more about how our Quality-of-Data algorithm works."
           }
         }
       }
@@ -5076,6 +5109,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Location Quality"
+          }
+        }
+      }
+    },
+    "reward_details_location_quality_info_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "It is important for the Network that a station remains at the same location throughout its lifetime.\n\nThe Proof-of-Location algorithm evaluates location data associated with the station, their accuracy, and consistency. It generates a score which is a confidence indicator about the station’s location.\n\nRead more about how our Proof-of-Location algorithm works."
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -4783,6 +4783,17 @@
         }
       }
     },
+    "reward_details_active_boosts" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Active Boosts"
+          }
+        }
+      }
+    },
     "reward_details_cell_position" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -4988,6 +4999,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Data quality is very low!  Got only %d%%. Fix any pending issues to earn more rewards."
+          }
+        }
+      }
+    },
+    "reward_details_earned_boosts_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Earned **+%@ $WXM** additional rewards from boosts."
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -4800,7 +4800,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cell Position"
+            "value" : "Cell Ranking"
           }
         }
       }
@@ -4811,7 +4811,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cell position is great!"
+            "value" : "Station ranking is great!"
           }
         }
       }
@@ -4822,7 +4822,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cell capacity is a parameter that is used to define the maximum number of stations that may receive rewards in a specific cell - a hexagonal area on the planet covering a surface area of ~5 square kilometers. Each cell has a predefined cell capacity that depends on its geospatial characteristics. The cell's capacity indicates the maximum number of stations that may receive rewards.\n\nAs long as a station's position is above the maximum capacity it will be rewarded, whereas getting below this threshold will lead to zero rewards. A station's position in a cell is calculated using its reward score and its seniority as criteria.\n\nRead more about how our Cell Capacity algorithm works."
+            "value" : "Cell ranking is a measure of a station's performance relative to others within the same cell - a hexagonal area, covering approximately 5 square kilometers (2 square miles) on the planet.\n\nCell capacity is a parameter that is used to define the maximum number of stations that are eligible for rewards in a specific cell. Every cell has a predefined capacity that depends on its geospatial characteristics*.\n\nEvery station is ranked in its cell daily, based on its reward score and its seniority. As long as the station's ranking is above the capacity threshold, it will be rewarded, whereas getting below it will lead to zero rewards. For example, in a cell with a max capacity of 5 stations, if a station is ranked 3rd it will get rewarded, but if it is ranked 7th, it won’t receive any rewards.\n\nRead more about how our Cell Capacity algorithm works.  * The cell capacity is currently set to the fixed value of 10 rewardable stations, for every cell."
           }
         }
       }
@@ -4855,7 +4855,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "WeatherXM’s goal is to become an open, decentralized ecosystem structured in such a way that network growth, and thereby balanced global weather coverage, is incentivised and every participant (weather station owners and service providers) is fairly and organically rewarded in accordance to the value they contribute to the network.\n\nStation owners are responsible for deploying and maintaining their stations and ensuring the best possible quality of weather data following the Network’s guidelines of deployment. In return they are rewarded, in the Network’s token, called $WXM.\n\nEvery day, our reward algorithm assesses the performance of all weather stations, calculates the Base Reward and any additional rewards originating from various active “Boosts”, and allocates the total reward amount to each user’s connected wallet.\n\nRead more about how our Reward Mechanism works."
+            "value" : "WeatherXM’s goal is to become an open, decentralized ecosystem structured in such a way that network growth, and thereby balanced global weather coverage, is incentivised and every participant (weather station owners and service providers) is fairly and organically rewarded in accordance to the value they contribute to the network.\n\nStation owners are responsible for deploying and maintaining their stations and ensuring the best possible quality of weather data following the Network’s guidelines of deployment. In return, they are rewarded, in the Network’s token, called $WXM.\n\nEvery day, our reward algorithm assesses the performance of all weather stations, calculates the Base Reward and any additional rewards originating from various active “Boosts”, and allocates the total reward amount to each user’s connected wallet.\n\nRead more about how our Reward Mechanism works."
           }
         }
       }
@@ -4899,7 +4899,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The Network is as good as its data and we need our data to be meaningful and usable. The Quality-of-Data (QoD) score is an attempt to quantify this metric. The end goal is to encourage weather station owners to do their best to comply with the Network's guidelines in order to consistently achieve the best data quality possible.\n\nA weather station's daily reward is affected by its QoD score. To calculate the QoD score, we have created an open source algorithm that evaluates the quality of the weather data using various methods. The calculated score indicates the confidence level in the quality of the weather data received from the station.\n\nRead more about how our Quality-of-Data algorithm works."
+            "value" : "The Network is as good as its data and we need our data to be meaningful and usable. The Quality-of-Data (QoD) score is the quantification of this metric. The end goal is to encourage weather station owners to do their best to comply with the Network's guidelines in order to consistently achieve the best data quality possible.\n\nA weather station's daily reward is affected by its QoD score. To calculate the QoD score, we have created an open source algorithm that evaluates the quality of the weather data using various methods. The calculated score indicates the confidence level in the quality of the weather data received from the station.\n\nRead more about how our Quality-of-Data algorithm works."
           }
         }
       }


### PR DESCRIPTION
## **Why?**
The reward details screen
### **How?**
- `RewardDetailsViewModel` contains the business logic of the screen
- `NetworkDeviceRewardDetailsResponse+` is an extension of the domain object with functionality for the UI
- The generic modifier `BottomSheetModifier` can support scrollable content with a flag
### **Testing**
Use dev server and make sure the screen is presented properly
### **Additional context**
The navigation to the boost details screen is not implemented yet. So the handling of unknown boost code will be implemented in the next PR
fixes fe-653
