### PR TITLE
Fixed re-rendering of lottie view

### DIFF
--- a/PresentationLayer/UI Components/Base Components/Lottie/LottieView.swift
+++ b/PresentationLayer/UI Components/Base Components/Lottie/LottieView.swift
@@ -8,13 +8,23 @@
 import Lottie
 import SwiftUI
 
-struct LottieView: UIViewRepresentable {
+struct LottieView: View {
+	var animationCase: String
+	var loopMode: LottieLoopMode
+
+	var body: some View {
+		LottieViewRepresentable(animationCase: animationCase, loopMode: loopMode)
+			.id(animationCase)
+	}
+}
+
+private struct LottieViewRepresentable: UIViewRepresentable {
     typealias UIViewType = UIView
 
     var animationCase: String
     var loopMode: LottieLoopMode
 
-    func makeUIView(context _: UIViewRepresentableContext<LottieView>) -> UIView {
+    func makeUIView(context _: UIViewRepresentableContext<LottieViewRepresentable>) -> UIView {
         let view = UIView(frame: .zero)
         let animationView = LottieAnimationView()
         let animation = LottieAnimation.named(animationCase)
@@ -34,5 +44,5 @@ struct LottieView: UIViewRepresentable {
         return view
     }
 
-    func updateUIView(_: UIView, context _: UIViewRepresentableContext<LottieView>) {}
+    func updateUIView(_: UIView, context _: UIViewRepresentableContext<LottieViewRepresentable>) {}
 }

--- a/PresentationLayer/UI Components/Screens/WeatherStations/Station Details/Rewards/Components/NoRewardsView.swift
+++ b/PresentationLayer/UI Components/Screens/WeatherStations/Station Details/Rewards/Components/NoRewardsView.swift
@@ -27,7 +27,6 @@ struct NoRewardsView: View {
 				LottieView(animationCase: animation.animationString,
 						   loopMode: .loop)
 				.frame(width: iconDimensions, height: iconDimensions)
-				.id(animation.animationString)
 
 				VStack(spacing: CGFloat(.smallSpacing)) {
 					Text(LocalizableString.StationDetails.noRewardsTitle.localized)


### PR DESCRIPTION
## **Why?**
There were some issues with re-renderings of the `LottieView`.
### **How?**
Enforce re-rendering on every `animationCase` using the `id` modifier
### **Testing**
Just like [this PR](https://github.com/WeatherXM/wxm-ios/pull/30), change the `mockFileName` for `deviceRewardsById` with `get_device_rewards_summary_empty` (`DevicesApiRequestBuilder.swift: ln103`) and make sure the rocket animation changes properly on theme change.
### **Additional context**
fixes fe-687