### PR TITLE
Boost details data quality score text changes

### DIFF
--- a/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
+++ b/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
@@ -237,13 +237,16 @@ extension NetworkDeviceRewardDetailsResponse.BoostReward {
 			  imageUrl: imageUrl)
 	}
 
-	private var lostRewardString: String {
-		let lostAmount = ((maxReward ?? 0.0) - (actualReward ?? 0.0)).toWXMTokenPrecisionString
+	private var lostRewardString: String? {
+		let lostAmount = ((maxReward ?? 0.0) - (actualReward ?? 0.0))
 		switch code {
 			case .betaReward:
-				return LocalizableString.Boosts.lostTokensBecauseOfQod(lostAmount).localized
+				if lostAmount > 0 {
+					return LocalizableString.Boosts.lostTokensBecauseOfQod(lostAmount.toWXMTokenPrecisionString).localized
+				}
+				return LocalizableString.Boosts.gotAllBetaRewards.localized
 			default:
-				return LocalizableString.Boosts.lostTokens(lostAmount).localized
+				return nil
 		}
 	}
 }

--- a/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
+++ b/PresentationLayer/Extensions/Domain Extensions/NetworkDeviceRewardDetailsResponse+.swift
@@ -238,10 +238,14 @@ extension NetworkDeviceRewardDetailsResponse.BoostReward {
 	}
 
 	private var lostRewardString: String? {
+		guard let rewardScore else {
+			return nil
+		}
 		let lostAmount = ((maxReward ?? 0.0) - (actualReward ?? 0.0))
+		
 		switch code {
 			case .betaReward:
-				if lostAmount > 0 {
+				if rewardScore < 100 {
 					return LocalizableString.Boosts.lostTokensBecauseOfQod(lostAmount.toWXMTokenPrecisionString).localized
 				}
 				return LocalizableString.Boosts.gotAllBetaRewards.localized

--- a/PresentationLayer/UI Components/Screens/RewardBoosts/Components/BoostCardView.swift
+++ b/PresentationLayer/UI Components/Screens/RewardBoosts/Components/BoostCardView.swift
@@ -56,12 +56,6 @@ struct BoostCardView: View {
 					}
 				}
 			}
-//			AsyncImage(url: URL(string: boost.imageUrl!)!) { image in
-//				image
-//					.resizable()
-//			} placeholder: {
-//				ProgressView()
-//			}
 		}
 		.WXMCardStyle(insideHorizontalPadding: 0.0, insideVerticalPadding: 0.0)
 		.contentShape(Rectangle())
@@ -74,7 +68,7 @@ extension BoostCardView {
 		let reward: Double
 		let date: Date?
 		let score: Int?
-		let lostRewardString: String
+		let lostRewardString: String?
 		let imageUrl: String?
 	}
 }
@@ -82,23 +76,25 @@ extension BoostCardView {
 private extension BoostCardView {
 	@ViewBuilder
 	var bottomView: some View {
-		if let score = boost.score {
+		if let score = boost.score,
+		   let lostRewardString = boost.lostRewardString {
 			VStack(spacing: CGFloat(.smallSpacing)) {
 				HStack {
 					Text(LocalizableString.Boosts.dailyBoostScore.localized)
 						.font(.system(size: CGFloat(.normalFontSize)))
 						.foregroundColor(Color(colorEnum: .white))
+					
 					Spacer()
 					
 					Text(LocalizableString.percentage(Float(score)).localized)
 						.font(.system(size: CGFloat(.normalFontSize)))
 						.foregroundColor(Color(colorEnum: .white))
 				}
-				
+
 				Divider().overlay(Color(colorEnum: .top))
-				
+
 				HStack {
-					Text(boost.lostRewardString)
+					Text(lostRewardString)
 						.font(.system(size: CGFloat(.normalFontSize)))
 						.foregroundColor(Color(colorEnum: .white))
 					Spacer()

--- a/wxm-ios/Resources/Localizable/Localizable+Boosts.swift
+++ b/wxm-ios/Resources/Localizable/Localizable+Boosts.swift
@@ -13,6 +13,7 @@ extension LocalizableString {
 		case dailyBoostScore
 		case lostTokens(String)
 		case lostTokensBecauseOfQod(String)
+		case gotAllBetaRewards
 		case boostDetails
 		case boostDetailsDescription(String, String)
 		case rewardableStationHours
@@ -49,6 +50,8 @@ extension LocalizableString.Boosts: WXMLocalizable {
 				"boosts_lost_tokens_format"
 			case .lostTokensBecauseOfQod:
 				"boosts_lost_tokens_because_of_qod_format"
+			case .gotAllBetaRewards:
+				"boosts_got_all_beta_rewards"
 			case .boostDetails:
 				"boosts_boost_details"
 			case .boostDetailsDescription:

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -487,6 +487,17 @@
         }
       }
     },
+    "boosts_got_all_beta_rewards" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Great! Got all beta rewards for this day!"
+          }
+        }
+      }
+    },
     "boosts_lost_tokens_because_of_qod_format" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## **Why?**
Text updates in the boost details screen
### **How?**
Handle the cases
- `boost_score` == 100
- `boost_score` < 100
- `boost_score` is null or boost code is `beta_reward`
### **Testing**
Check the cases mentioned above
### **Additional context**
fixes fe-698
