### PR TITLE
Theme option in phone settings doesnt work

### DIFF
--- a/PresentationLayer/UIComponents/Screens/Settings/SettingsView.swift
+++ b/PresentationLayer/UIComponents/Screens/Settings/SettingsView.swift
@@ -10,7 +10,7 @@ import Toolkit
 
 struct SettingsView: View {
     @StateObject var settingsViewModel: SettingsViewModel
-	private let mainScreenViewModel: MainScreenViewModel = .shared
+	@ObservedObject private var mainScreenViewModel: MainScreenViewModel = .shared
 
     var body: some View {
         ZStack {

--- a/wxm-ios/Settings.bundle/Root.plist
+++ b/wxm-ios/Settings.bundle/Root.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ApplicationGroupContainerIdentifier</key>
+	<string>group.com.weatherxm.app</string>
 	<key>StringsTable</key>
 	<string>Root</string>
 	<key>PreferenceSpecifiers</key>


### PR DESCRIPTION
## **Why?**
The theme option from phone settings didn't work
### **How?**
Added the user defaults group ID in settings plist to write in the correct container from phone settings 
### **Testing**
- Change the theme from **phone** settings and make sure the theme changes properly 
- Go to **App** settings then to **phone** settings, change the theme go back to the app and make sure the **Theme** option is updated
### **Screenshots (if applicable)**
![Simulator Screenshot - iPhone 15 - 2024-03-19 at 13 44 48](https://github.com/WeatherXM/wxm-ios/assets/10021503/8a6bc1fc-a513-42e6-baa0-434e26f9a514)
![Simulator Screenshot - iPhone 15 - 2024-03-19 at 13 45 17](https://github.com/WeatherXM/wxm-ios/assets/10021503/1040ebd4-dc82-4dcb-8ad8-53045d98c8bd)

### **Additional context**
fixes fe-714
Add any other context about the PR here.
