### PR TITLE
Default background color in boost details

### DIFF
--- a/PresentationLayer/Constants/ColorEnum.swift
+++ b/PresentationLayer/Constants/ColorEnum.swift
@@ -56,4 +56,5 @@ public enum ColorEnum: String {
 	case darkBg
 	case infoIndication
 	case trasnparentButtonBg
+	case remoteImagePlaceholder
 }

--- a/PresentationLayer/UIComponents/BaseComponents/WXMRemoteImageView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WXMRemoteImageView.swift
@@ -1,0 +1,32 @@
+//
+//  WXMRemoteImageView.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 26/3/24.
+//
+
+import SwiftUI
+import NukeUI
+
+struct WXMRemoteImageView: View {
+	let imageUrl: String?
+
+    var body: some View {
+		ZStack {
+			Color(colorEnum: .remoteImagePlaceholder)
+
+			if let imageUrl {
+				LazyImage(url: URL(string: imageUrl)) { state in
+					if let image = state.image {
+						image.resizable()
+							.transition(AnyTransition.opacity.animation(.easeIn(duration: 0.2)))
+					}
+				}
+			}
+		}
+    }
+}
+
+#Preview {
+    WXMRemoteImageView(imageUrl: "https://weatherxm.s3.eu-west-1.amazonaws.com/resources/public/BetaRewardsBoostImg.png")
+}

--- a/PresentationLayer/UIComponents/Screens/DailyRewards /Components/BoostsView.swift
+++ b/PresentationLayer/UIComponents/Screens/DailyRewards /Components/BoostsView.swift
@@ -37,20 +37,7 @@ struct BoostsView: View {
 		}
 		.padding(CGFloat(.defaultSidePadding))
 		.background {
-			ZStack {
-				Color(colorEnum: .darkBg)
-
-				if let imageUrl {
-					LazyImage(url: URL(string: imageUrl)) { state in
-						if let image = state.image {
-							image.resizable()
-						} else if state.isLoading {
-							ProgressView()
-								.tint(Color(colorEnum: .white))
-						}
-					}
-				}
-			}
+			WXMRemoteImageView(imageUrl: imageUrl)
 		}
 		.WXMCardStyle(insideHorizontalPadding: 0.0, insideVerticalPadding: 0.0)
 		.contentShape(Rectangle())

--- a/PresentationLayer/UIComponents/Screens/RewardBoosts/Components/BoostCardView.swift
+++ b/PresentationLayer/UIComponents/Screens/RewardBoosts/Components/BoostCardView.swift
@@ -42,22 +42,10 @@ struct BoostCardView: View {
 		}
 		.padding(CGFloat(.defaultSidePadding))
 		.background {
-			ZStack {
-				Color(colorEnum: .darkBg)
-
-				if let imageUrl = boost.imageUrl {
-					LazyImage(url: URL(string: imageUrl)) { state in
-						if let image = state.image {
-							image.resizable()
-						} else if state.isLoading {
-							ProgressView()
-								.tint(Color(colorEnum: .white))
-						}
-					}
-				}
-			}
+			WXMRemoteImageView(imageUrl: boost.imageUrl)
 		}
-		.WXMCardStyle(insideHorizontalPadding: 0.0, insideVerticalPadding: 0.0)
+		.WXMCardStyle(insideHorizontalPadding: 0.0, 
+					  insideVerticalPadding: 0.0)
 		.contentShape(Rectangle())
     }
 }
@@ -112,6 +100,6 @@ private extension BoostCardView {
 							   date: .now,
 							   score: 90,
 							   lostRewardString: LocalizableString.Boosts.lostTokens(1.4353452.toWXMTokenPrecisionString).localized,
-							   imageUrl: "https://s3-alpha-sig.figma.com/img/eb97/5518/24aa70629514355d092dfc646d9b51bd?Expires=1710720000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=OVc-UV-lBgXfX~Nl1VFoL-JijJx72Wld-L40tKQBLBo2afCyJijAJWkRicakQ~celi0ACIuP8W~N2Ixev1roqtO9JAl2IW0u55fOQdITuhDYq0pcqW-Nen7vzvATzti9A-c-pm6IDE37Md7gc0dYgnM55HhR1GAM4FlEIx4~RWOYmOI5rOgXQl6wN7YCB1gv3WI3JvmA1YgZKxLoei0Adny6PVGOlmQYXacN3WMcy6EfPFUO4rVvk~lrgQIOBJi8bSOnVX8RFHZ0RMW9lPljynCPKgbpuwUl0X6djRmdku-ntEnlCCsFp0LF0d~Y-qEK-edLpT96KdG4MM7TS64Qsg__"))
+							   imageUrl: "https://weatherxm.s3.eu-west-1.amazonaws.com/resources/public/BetaRewardsBoostImg.png"))
 	.padding()
 }

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2612AC1C2AB45B2800285896 /* FilterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2612AC1B2AB45B2800285896 /* FilterViewModel.swift */; };
 		2612AC3A2AB47BA200285896 /* LocalizableString+Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2612AC392AB47BA200285896 /* LocalizableString+Filters.swift */; };
 		2612AC482AB49E4000285896 /* Filters+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2612AC472AB49E4000285896 /* Filters+.swift */; };
+		261672472BB310D9009C3DB1 /* WXMRemoteImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261672462BB310D9009C3DB1 /* WXMRemoteImageView.swift */; };
 		2618A6E72A1E440F00983B7B /* ExplorerLocationError+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618A6E62A1E440F00983B7B /* ExplorerLocationError+.swift */; };
 		2618A7142A20FFCA00983B7B /* MultipleAlertsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618A7132A20FFCA00983B7B /* MultipleAlertsView.swift */; };
 		2618A7162A21014200983B7B /* AlertsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618A7152A21014200983B7B /* AlertsViewModel.swift */; };
@@ -523,6 +524,7 @@
 		2612AC1B2AB45B2800285896 /* FilterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterViewModel.swift; sourceTree = "<group>"; };
 		2612AC392AB47BA200285896 /* LocalizableString+Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalizableString+Filters.swift"; sourceTree = "<group>"; };
 		2612AC472AB49E4000285896 /* Filters+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Filters+.swift"; sourceTree = "<group>"; };
+		261672462BB310D9009C3DB1 /* WXMRemoteImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WXMRemoteImageView.swift; sourceTree = "<group>"; };
 		2618A6E62A1E440F00983B7B /* ExplorerLocationError+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ExplorerLocationError+.swift"; sourceTree = "<group>"; };
 		2618A7132A20FFCA00983B7B /* MultipleAlertsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleAlertsView.swift; sourceTree = "<group>"; };
 		2618A7152A21014200983B7B /* AlertsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertsViewModel.swift; sourceTree = "<group>"; };
@@ -1547,6 +1549,7 @@
 				2675474829A9181E008BCF40 /* UberTextField.swift */,
 				26E5B0BF29F8078C00834899 /* WXMDivider.swift */,
 				2674017D2A38C2AE00E54E35 /* WXMEmptyView.swift */,
+				261672462BB310D9009C3DB1 /* WXMRemoteImageView.swift */,
 			);
 			path = BaseComponents;
 			sourceTree = "<group>";
@@ -2900,6 +2903,7 @@
 				267548CD29A91A87008BCF40 /* TabSelectionEnum.swift in Sources */,
 				262A4D862A94D89300A4BC17 /* TabViewWrapper.swift in Sources */,
 				268D07952B2B1B85002BD77E /* SelectStationLocationViewModel.swift in Sources */,
+				261672472BB310D9009C3DB1 /* WXMRemoteImageView.swift in Sources */,
 				26FFADD42B8F684C00BF0A6B /* RewardAnnotaionsView.swift in Sources */,
 				267548F429A91A87008BCF40 /* Text+.swift in Sources */,
 				26348DF82A42F430000846C6 /* TextfieldClearButton.swift in Sources */,

--- a/wxm-ios/Resources/Colors.xcassets/remoteImagePlaceholder.colorset/Contents.json
+++ b/wxm-ios/Resources/Colors.xcassets/remoteImagePlaceholder.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x80",
+          "red" : "0x27"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## **Why?**
Placeholder color for remote images 
### **How?**
Declared a new component (`WXMRemoteImageView`) to encapsulate the loading functionality
### **Testing**
Make sure the reward Boosts are rendered properly
### **Additional context**
Fixes fe-735
