### PR TITLE
Handle case of no qod score

### DIFF
--- a/PresentationLayer/Extensions/DomainExtensions/NetworkDeviceRewardDetailsResponse+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/NetworkDeviceRewardDetailsResponse+.swift
@@ -25,7 +25,7 @@ extension NetworkDeviceRewardDetailsResponse {
 extension NetworkDeviceRewardDetailsResponse {
 	func dataQualityScoreObject(followState: UserDeviceFollowState?) -> RewardFieldView.Score {
 		.init(fontIcon: dataQualityfontIcon,
-			  score: Float(base?.qodScore ?? 0),
+			  score: base?.qodScore?.toFloat,
 			  color: dataQualityColor,
 			  message: dataQualityMessage(followState: followState),
 			  showIndication: dataQualityColor != .success )
@@ -80,9 +80,9 @@ extension NetworkDeviceRewardDetailsResponse {
 		return qodScore.rewardScoreColor
 	}
 
-	private var dataQualityfontIcon: FontIcon {
+	private var dataQualityfontIcon: FontIcon? {
 		guard let qodScore = base?.qodScore else {
-			return .hexagonExclamation
+			return nil
 		}
 		return qodScore.rewardScoreFontIcon
 	}

--- a/PresentationLayer/UIComponents/Screens/DailyRewards /Components/RewardFieldView.swift
+++ b/PresentationLayer/UIComponents/Screens/DailyRewards /Components/RewardFieldView.swift
@@ -32,9 +32,11 @@ struct RewardFieldView: View {
 
 			VStack(spacing: CGFloat(.mediumSpacing)) {
 				HStack(spacing: CGFloat(.smallSpacing)) {
-					Text(score.fontIcon.rawValue)
-						.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.smallTitleFontSize)))
-						.foregroundColor(Color(colorEnum: score.color))
+					if let fontIcon = score.fontIcon {
+						Text(fontIcon.rawValue)
+							.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.smallTitleFontSize)))
+							.foregroundColor(Color(colorEnum: score.color))
+					}
 
 					Text(score.message)
 						.foregroundColor(Color(colorEnum: .darkGrey))
@@ -64,7 +66,7 @@ struct RewardFieldView: View {
 
 extension RewardFieldView {
 	struct Score {
-		let fontIcon: FontIcon
+		let fontIcon: FontIcon?
 		let score: Float?
 		let color: ColorEnum
 		let message: String

--- a/wxm-ios/Toolkit/Toolkit/Utils/FoundationExtensions.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/FoundationExtensions.swift
@@ -193,3 +193,9 @@ public extension FileManager {
 		return urls.first
 	}
 }
+
+public extension Int {
+	var toFloat: Float {
+		Float(self)
+	}
+}


### PR DESCRIPTION
## **Why?**
UI layout issue in reward details when there is no QOD
### **How?**
If there is no QOD score we hide the progress bar along with the icon
### **Testing**
Choose Rural Iris Water station go to the first entry without QOD in timeline (earlier than March 12)
### **Screenshots (if applicable)**
![simulator_screenshot_395A9472-F5FA-44CF-ABF7-D7CEC7616B8C](https://github.com/WeatherXM/wxm-ios/assets/10021503/8b49ae4a-e362-416d-8dcc-607a21eeffd2)
