### PR TITLE
Updated empty rewards text

### DIFF
--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -6428,7 +6428,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Your station hasn’t received any rewards yet. Sit back and relax, while our systems are validating the station’s location and data. You should start seeing rewards in the next couple of days."
+            "value" : "Station hasn’t received any rewards yet. Sit back and relax, while our systems are validating the station’s location and data. The station should start receiving rewards in the next couple of days."
           }
         }
       }


### PR DESCRIPTION
## **Why?**
Updated text for empty rewards tab
### **How?**
Updated the localized string
### **Testing**
Run mock scheme and change the mock file name from `get_device_rewards_summary` to `get_device_rewards_summary_empty` (DevicesApiRequestBuilder: ln 108)
### **Additional context**
fixes fe-765
