### PR TITLE
Scroll issues for devices with notch and ios 15

### DIFF
--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Station Details/StationDetailsContainerView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Station Details/StationDetailsContainerView.swift
@@ -192,6 +192,7 @@ private struct StationDetailsView: View {
     }
 }
 
+/// Container for different layout according to iOS version
 private struct ConditionalOSContainer<Content: View>: View {
 	let content: () -> Content
 
@@ -208,6 +209,7 @@ private struct ConditionalOSContainer<Content: View>: View {
 	}
 }
 
+/// Modify safe area inset according to iOS version
 private struct SafeAreaInsetModifier: ViewModifier {
 	let inset: CGFloat
 


### PR DESCRIPTION
## **Why?**
The header in station details overlaps content in iOS 15 devices with notch
### **How?**
- The content is encapsulated in a container with iOS version check
- Used a modifier which adds safe area insets in versions >=16.0
### **Testing**
Run the app in the following devices and make sure everything is ok
Devices to test 
- with notch (eg iPhone 12) with iOS 15 - 16 - 17
- without notch (eg iPhone SE (3rd generation)) with iOS 15 - 16 - 17
### **Additional context**
fixes fe-768