### PR TITLE
Station forecast tab

### DIFF
--- a/PresentationLayer/Extensions/DomainExtensions/Common/CurrentWeather+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/Common/CurrentWeather+.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import DomainLayer
+import Toolkit
 
 extension CurrentWeather: Identifiable {
     public var id: String {
@@ -21,10 +22,11 @@ extension CurrentWeather: Identifiable {
         return LocalizableString.lastUpdated(date.localizedDateString()).localized
     }
 	#if MAIN_APP
-	func toMiniCardItem(with timeZone: TimeZone) -> StationForecastMiniCardView.Item {
+	func toMiniCardItem(with timeZone: TimeZone, action: VoidCallback? = nil) -> StationForecastMiniCardView.Item {
 		.init(time: timestamp?.timestampToDate(timeZone: timeZone).transactionsTimeFormat() ?? "",
 			  animationString: icon?.getAnimationString(),
-			  temperature: temperature?.toTemeratureString(for: WeatherUnitsManager.default.temperatureUnit) ?? "")
+			  temperature: temperature?.toTemeratureString(for: WeatherUnitsManager.default.temperatureUnit) ?? "",
+			  action: action)
 	}
 	#endif
 }

--- a/PresentationLayer/Extensions/DomainExtensions/Common/CurrentWeather+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/Common/CurrentWeather+.swift
@@ -23,7 +23,7 @@ extension CurrentWeather: Identifiable {
     }
 	#if MAIN_APP
 	func toMiniCardItem(with timeZone: TimeZone, action: VoidCallback? = nil) -> StationForecastMiniCardView.Item {
-		.init(time: timestamp?.timestampToDate(timeZone: timeZone).transactionsTimeFormat() ?? "",
+		.init(time: timestamp?.timestampToDate(timeZone: timeZone).transactionsTimeFormat(timeZone: timeZone) ?? "",
 			  animationString: icon?.getAnimationString(),
 			  temperature: temperature?.toTemeratureString(for: WeatherUnitsManager.default.temperatureUnit, decimals: 1) ?? "",
 			  action: action)

--- a/PresentationLayer/Extensions/DomainExtensions/Common/CurrentWeather+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/Common/CurrentWeather+.swift
@@ -25,7 +25,7 @@ extension CurrentWeather: Identifiable {
 	func toMiniCardItem(with timeZone: TimeZone, action: VoidCallback? = nil) -> StationForecastMiniCardView.Item {
 		.init(time: timestamp?.timestampToDate(timeZone: timeZone).transactionsTimeFormat() ?? "",
 			  animationString: icon?.getAnimationString(),
-			  temperature: temperature?.toTemeratureString(for: WeatherUnitsManager.default.temperatureUnit) ?? "",
+			  temperature: temperature?.toTemeratureString(for: WeatherUnitsManager.default.temperatureUnit, decimals: 1) ?? "",
 			  action: action)
 	}
 	#endif

--- a/PresentationLayer/Extensions/DomainExtensions/Common/CurrentWeather+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/Common/CurrentWeather+.swift
@@ -20,6 +20,13 @@ extension CurrentWeather: Identifiable {
 
         return LocalizableString.lastUpdated(date.localizedDateString()).localized
     }
+	#if MAIN_APP
+	func toMiniCardItem(with timeZone: TimeZone) -> StationForecastMiniCardView.Item {
+		.init(time: timestamp?.timestampToDate(timeZone: timeZone).transactionsTimeFormat() ?? "",
+			  animationString: icon?.getAnimationString(),
+			  temperature: temperature?.toTemeratureString(for: WeatherUnitsManager.default.temperatureUnit) ?? "")
+	}
+	#endif
 }
 
 // MARK: - Mock

--- a/PresentationLayer/Extensions/Numeric/Double+.swift
+++ b/PresentationLayer/Extensions/Numeric/Double+.swift
@@ -51,13 +51,19 @@ extension Double {
         }
     }
 
-    func toTemeratureString(for unit: TemperatureUnitsEnum) -> String {
-        let value = Int(toTemeratureUnit(unit).rounded(toPlaces: 0))
+	func toTemeratureString(for unit: TemperatureUnitsEnum, decimals: Int = 0) -> String {
+        let value = toTemeratureUnit(unit).rounded(toPlaces: decimals)
+
+		let formatter = NumberFormatter()
+		formatter.minimumFractionDigits = 0
+		formatter.maximumFractionDigits = decimals
+		formatter.numberStyle = .decimal
+		let valueStr = formatter.string(for: value) ?? ""
         switch unit {
             case .celsius:
-                return "\(value)\(LocalizableString.celsiusSymbol.localized)"
+                return "\(valueStr)\(LocalizableString.celsiusSymbol.localized)"
             case .fahrenheit:
-                return "\(value)\(LocalizableString.fahrenheitSymbol.localized)"
+                return "\(valueStr)\(LocalizableString.fahrenheitSymbol.localized)"
         }
     }
 }

--- a/PresentationLayer/Extensions/Numeric/Double+.swift
+++ b/PresentationLayer/Extensions/Numeric/Double+.swift
@@ -57,6 +57,7 @@ extension Double {
 		let formatter = NumberFormatter()
 		formatter.minimumFractionDigits = 0
 		formatter.maximumFractionDigits = decimals
+		formatter.roundingMode = .halfUp
 		formatter.numberStyle = .decimal
 		let valueStr = formatter.string(for: value) ?? ""
         switch unit {

--- a/PresentationLayer/Extensions/String+.swift
+++ b/PresentationLayer/Extensions/String+.swift
@@ -131,13 +131,22 @@ extension String {
     func getWeekDayAndDate() -> String {
         let date = timestampToDate()
         let dayFormatter = DateFormatter()
-        dayFormatter.doesRelativeDateFormatting = true
-        dayFormatter.dateStyle = .medium
-        if !date.isToday && !date.isTomorrow {
-            dayFormatter.setLocalizedDateFormatFromTemplate("EEEE dd/MM")
-        }
-        let dayStr = dayFormatter.string(from: date)
-        return dayStr
+		dayFormatter.locale = .current
+		dayFormatter.setLocalizedDateFormatFromTemplate("EEEE dd/MM")
+        var str = dayFormatter.string(from: date)
+		/// Because of localization, in some cases the system adds commas (,)
+		/// So we have to remove them
+		str = str.replacingOccurrences(of: ",", with: "")
+
+		if date.isToday || date.isTomorrow {
+			let formatter = DateFormatter()
+			formatter.doesRelativeDateFormatting = true
+			formatter.dateStyle = .medium
+			let relativeStr = formatter.string(from: date)
+			str = "\(relativeStr), \(str)"
+		}
+
+        return str
     }
 
     func getTimeForLatestDateWeatherDetail() -> String {

--- a/PresentationLayer/Extensions/String+.swift
+++ b/PresentationLayer/Extensions/String+.swift
@@ -26,6 +26,10 @@ extension Optional where Wrapped == String {
 
 extension String {
 
+	var toTimezone: TimeZone? {
+		TimeZone(identifier: self)
+	}
+
     var convertedDeviceIdentifier: String {
         replacingOccurrences(of: ":", with: "")
     }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/CustomRangeSlider.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/CustomRangeSlider.swift
@@ -44,7 +44,7 @@ private extension CustomRangeSlider {
     func shapeFor(size: CGSize) -> some View {
         HStack {
             Rectangle()
-                .fill(Color(colorEnum: .primary))
+                .fill(Color(colorEnum: .crypto))
                 .frame(width: (diff * size.width) / totalRange,
                        height: sliderHeight)
                 .cornerRadius(CGFloat(.cardCornerRadius))

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/CustomRangeSlider.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/CustomRangeSlider.swift
@@ -37,7 +37,7 @@ private extension CustomRangeSlider {
     }
 
     var offset: CGFloat {
-        minDailyTemp - minWeeklyTemp
+		maxWeeklyTemp - maxDailyTemp
     }
 
     @ViewBuilder
@@ -57,6 +57,6 @@ private extension CustomRangeSlider {
 
 struct Previews_CustomRangeSlider_Previews: PreviewProvider {
     static var previews: some View {
-        CustomRangeSlider(minWeeklyTemp: 8.0, maxWeeklyTemp: 19.0, minDailyTemp: 13, maxDailyTemp: 19)
+		CustomRangeSlider(minWeeklyTemp: 7.0, maxWeeklyTemp: 19.0, minDailyTemp: 9.0, maxDailyTemp: 18)
     }
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForeCastCardView+Content.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForeCastCardView+Content.swift
@@ -71,7 +71,7 @@ private extension StationForecastCardView {
                 Image(asset: field.hourlyIcon())
 					.resizable()
                     .renderingMode(.template)
-                    .foregroundColor(Color(colorEnum: .darkestBlue))
+                    .foregroundColor(Color(colorEnum: .darkGrey))
 					.frame(width: 20.0, height: 20.0)
 					.rotationEffect(Angle(degrees: field.iconRotation(from: weather)))
 

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForeCastCardView+Content.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForeCastCardView+Content.swift
@@ -68,11 +68,12 @@ private extension StationForecastCardView {
     func fieldView(for field: WeatherField) -> some View {
         if let weather = forecast.daily {
             HStack(spacing: 0.0) {
-                Image(asset: field.icon)
+                Image(asset: field.hourlyIcon())
 					.resizable()
                     .renderingMode(.template)
                     .foregroundColor(Color(colorEnum: .darkestBlue))
-					.frame(width: 15.0, height: 15.0)
+					.frame(width: 20.0, height: 20.0)
+					.rotationEffect(Angle(degrees: field.iconRotation(from: weather)))
 
                 Text(getFieldText(weatherField: field,
                                   weather: weather,

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForeCastCardView+Content.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForeCastCardView+Content.swift
@@ -28,18 +28,6 @@ extension StationForecastCardView {
             }
         }
     }
-
-    @ViewBuilder
-    var hourlyView: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            LazyHStack(spacing: CGFloat(.mediumSpacing)) {
-                ForEach(forecast.hourly ?? []) { weather in
-                    hourlyWeatherView(weather: weather)
-                }
-            }
-        }
-        .padding(.horizontal, CGFloat(.defaultSidePadding))
-    }
 }
 
 private extension StationForecastCardView {
@@ -61,15 +49,19 @@ private extension StationForecastCardView {
 
     @ViewBuilder
     var temperatureBar: some View {
-        HStack(spacing: CGFloat(.minimumSpacing)) {
-            Text("\(forecast.daily?.temperatureMin?.toTemeratureString(for: unitsManager.temperatureUnit) ?? "")")
+        HStack(spacing: CGFloat(.smallSpacing)) {
+            Text("\(forecast.daily?.temperatureMax?.toTemeratureString(for: unitsManager.temperatureUnit) ?? "")")
+				.font(.system(size: CGFloat(.largeTitleFontSize), weight: .bold))
+
+
             CustomRangeSlider(minWeeklyTemp: minWeekTemperature.toTemeratureUnit(unitsManager.temperatureUnit).rounded(toPlaces: 0),
                               maxWeeklyTemp: maxWeekTemperature.toTemeratureUnit(unitsManager.temperatureUnit).rounded(toPlaces: 0),
                               minDailyTemp: forecast.daily?.temperatureMin?.toTemeratureUnit(unitsManager.temperatureUnit).rounded(toPlaces: 0) ?? 0.0,
                               maxDailyTemp: forecast.daily?.temperatureMax?.toTemeratureUnit(unitsManager.temperatureUnit).rounded(toPlaces: 0) ?? 0.0)
-            Text("\(forecast.daily?.temperatureMax?.toTemeratureString(for: unitsManager.temperatureUnit) ?? "")")
+            
+			Text("\(forecast.daily?.temperatureMin?.toTemeratureString(for: unitsManager.temperatureUnit) ?? "")")
+				.font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
         }
-        .font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
     }
 
     @ViewBuilder
@@ -80,13 +72,12 @@ private extension StationForecastCardView {
 					.resizable()
                     .renderingMode(.template)
                     .foregroundColor(Color(colorEnum: .darkestBlue))
-					.frame(width: 25.0, height: 25.0)
+					.frame(width: 15.0, height: 15.0)
 
                 Text(getFieldText(weatherField: field,
                                   weather: weather,
                                   unitsManager: unitsManager))
-                .font(.system(size: CGFloat(.caption),
-                              weight: .bold))
+                .font(.system(size: CGFloat(.caption)))
                 .foregroundColor(Color(colorEnum: .text))
                 .fixedSize(horizontal: false, vertical: true)
             }
@@ -100,55 +91,5 @@ private extension StationForecastCardView {
                       unitsManager: WeatherUnitsManager) -> String {
         let literals = weatherField.weatherLiterals(from: weather, unitsManager: unitsManager)
         return "\(literals?.value ?? "")\(weatherField.shouldHaveSpaceWithUnit ? " " : "")\(literals?.unit ?? "")"
-    }
-
-    @ViewBuilder
-    func hourlyWeatherView(weather: CurrentWeather) -> some View {
-        VStack(alignment: .center, spacing: 0.0) {
-            Text(weather.timestamp?.getTimeForLatestDateWeatherDetail() ?? "")
-                .foregroundColor(Color(colorEnum: .darkestBlue))
-                .font(.system(size: CGFloat(.caption)))
-            LottieView(animationCase: weather.icon?.getAnimationString() ?? "", loopMode: .loop)
-                .frame(width: forecastHoulrlyScrollerImageSize,
-                       height: forecastHoulrlyScrollerImageSize)
-
-            let temperature = WeatherField.temperature.weatherLiterals(from: weather, unitsManager: unitsManager)
-            Text("\(temperature?.value ?? "")\(temperature?.unit ?? "")")
-                .foregroundColor(Color(colorEnum: .darkestBlue))
-                .font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
-
-            let feelsLikeTemperature = WeatherField.feelsLike.weatherLiterals(from: weather, unitsManager: unitsManager)
-            Text("\(LocalizableString.feelsLike.localized) **\(feelsLikeTemperature?.value ?? "")°**".attributedMarkdown ?? "")
-                .foregroundColor(Color(colorEnum: .darkestBlue))
-                .font(.system(size: CGFloat(.caption)))
-
-            VStack(alignment: .leading, spacing: CGFloat(.smallSpacing)) {
-                ForEach(WeatherField.hourlyFields, id: \.self) { field in
-                    hourlyWeatherFieldView(weather: weather, field: field)
-                }
-            }
-			.padding(.top, CGFloat(.smallSidePadding))
-        }
-    }
-
-    @ViewBuilder
-    func hourlyWeatherFieldView(weather: CurrentWeather, field: WeatherField) -> some View {
-        if let literals = field.weatherLiterals(from: weather,
-                                                unitsManager: unitsManager,
-                                                includeDirection: false,
-                                                isForHourlyForecast: true) {
-            HStack(spacing: 0.0) {
-                Image(asset: field.hourlyIcon())
-                    .renderingMode(.template)
-                    .foregroundColor(Color(colorEnum: .darkestBlue))
-                    .rotationEffect(.degrees(field.iconRotation(from: weather)))
-
-                Text("**\(literals.value)**\(field.shouldHaveSpaceWithUnit ? " " : "")\(literals.unit)")
-                    .foregroundColor(Color(colorEnum: .darkestBlue))
-                    .font(.system(size: CGFloat(.mediumFontSize)))
-            }
-        } else {
-            EmptyView()
-        }
     }
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastCardView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastCardView.swift
@@ -15,50 +15,25 @@ struct StationForecastCardView: View {
     let forecast: NetworkDeviceForecastResponse
     let minWeekTemperature: Double
     let maxWeekTemperature: Double
-    @Binding var isExpanded: Bool
-    let isExpandable: Bool
-
-    let forecastHoulrlyScrollerImageSize: CGFloat = 50.0
-    let weatherIconDimensions: CGFloat = 70.0
+	
+    let weatherIconDimensions: CGFloat = 50.0
 
     var body: some View {
         VStack(spacing: CGFloat(.defaultSpacing)) {
-            VStack(spacing: CGFloat(.minimumSpacing)) {
-                HStack {
-                    Text(forecast.daily?.timestamp?.getWeekDayAndDate() ?? "-")
-                        .foregroundColor(Color(colorEnum: .primary))
-                        .font(.system(size: CGFloat(.normalFontSize)))
+            VStack(spacing: CGFloat(.smallToMediumSpacing)) {
+				HStack {
+					Text(forecast.daily?.timestamp?.getWeekDayAndDate() ?? "-")
+						.foregroundColor(Color(colorEnum: .primary))
+						.font(.system(size: CGFloat(.normalFontSize)))
 
-                    Spacer()
+					Spacer()
 
-                    Image(asset: .downArrow)
-                        .renderingMode(.template)
-                        .foregroundColor(Color(colorEnum: .primary))
-                        .rotationEffect(.degrees(isExpanded ? 180.0 : 0.0))
-                }
-				.padding(.horizontal, CGFloat(.defaultSidePadding))
+				}
 
                 dailyView
-                    .WXMCardStyle(backgroundColor: Color(colorEnum: .top),
-                                  insideHorizontalPadding: CGFloat(.defaultSidePadding),
-                                  insideVerticalPadding: CGFloat(.defaultSidePadding),
-								  cornerRadius: CGFloat(.cardCornerRadius))
-            }
-
-            if isExpanded {
-                hourlyView
-                    .padding(.bottom, CGFloat(.smallSidePadding))
             }
         }
-		.padding(.top, CGFloat(.smallSidePadding))
-        .WXMCardStyle(backgroundColor: Color(colorEnum: .layer1),
-                      insideHorizontalPadding: 0.0,
-                      insideVerticalPadding: 0.0,
-					  cornerRadius: CGFloat(.cardCornerRadius))
-        .onTapGesture {
-            isExpanded.toggle()
-        }
-        .allowsHitTesting(isExpandable)
+        .WXMCardStyle()
     }
 }
 
@@ -70,8 +45,6 @@ struct StationForecastCardView_Previews: PreviewProvider {
         forecast.daily = CurrentWeather.mockInstance
         return StationForecastCardView(forecast: forecast,
                                        minWeekTemperature: 8.0,
-                                       maxWeekTemperature: 20.0,
-                                       isExpanded: .constant(true),
-                                       isExpandable: true)
+                                       maxWeekTemperature: 20.0)
     }
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastMiniCardView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastMiniCardView.swift
@@ -20,14 +20,19 @@ struct StationForecastMiniCardView: View {
 				Text(item.time)
 					.foregroundColor(Color(colorEnum: .darkestBlue))
 					.font(.system(size: CGFloat(.caption)))
+					.minimumScaleFactor(0.8)
+					.lineLimit(1)
 
 				weatherImage
 
 				Text(item.temperature)
 					.foregroundColor(Color(colorEnum: .darkestBlue))
 					.font(.system(size: CGFloat(.normalFontSize), weight: .bold))
+					.minimumScaleFactor(0.8)
+					.lineLimit(1)
 			}
-			.WXMCardStyle()
+			.WXMCardStyle(insideHorizontalPadding: CGFloat(.mediumSidePadding),
+						  insideVerticalPadding: CGFloat(.mediumSidePadding))
 		}
 		.allowsHitTesting(item.action != nil)
     }
@@ -45,14 +50,20 @@ extension StationForecastMiniCardView {
 private extension StationForecastMiniCardView {
 	@ViewBuilder
 	var weatherImage: some View {
-		Group {
-			if let animationStr = item.animationString {
-				LottieView(animationCase: animationStr, loopMode: .loop)
-			} else {
-				LottieView(animationCase: "anim_not_available", loopMode: .loop)
+		HStack {
+			Spacer(minLength: 0.0)
+			
+			Group {
+				if let animationStr = item.animationString {
+					LottieView(animationCase: animationStr, loopMode: .loop)
+				} else {
+					LottieView(animationCase: "anim_not_available", loopMode: .loop)
+				}
 			}
+			.frame(width: 40.0, height: 40.0)
+
+			Spacer(minLength: 0.0)
 		}
-		.frame(width: 40.0, height: 40.0)
 	}
 }
 

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastMiniCardView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastMiniCardView.swift
@@ -1,0 +1,18 @@
+//
+//  StationForecastMiniCardView.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 12/4/24.
+//
+
+import SwiftUI
+
+struct StationForecastMiniCardView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    StationForecastMiniCardView()
+}

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastMiniCardView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastMiniCardView.swift
@@ -6,13 +6,50 @@
 //
 
 import SwiftUI
+import DomainLayer
 
 struct StationForecastMiniCardView: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+	let item: Item
+
+	var body: some View {
+		VStack(spacing: CGFloat(.smallSpacing)) {
+			Text(item.time)
+				.foregroundColor(Color(colorEnum: .darkestBlue))
+				.font(.system(size: CGFloat(.caption)))
+
+			weatherImage
+
+			Text(item.temperature)
+				.foregroundColor(Color(colorEnum: .darkestBlue))
+				.font(.system(size: CGFloat(.normalFontSize), weight: .bold))
+		}
+		.WXMCardStyle()
     }
 }
 
+extension StationForecastMiniCardView {
+	struct Item {
+		let time: String
+		let animationString: String?
+		let temperature: String
+	}
+}
+
+private extension StationForecastMiniCardView {
+	@ViewBuilder
+	var weatherImage: some View {
+		Group {
+			if let animationStr = item.animationString {
+				LottieView(animationCase: animationStr, loopMode: .loop)
+			} else {
+				LottieView(animationCase: "anim_not_available", loopMode: .loop)
+			}
+		}
+		.frame(width: 40.0, height: 40.0)
+	}
+}
+
 #Preview {
-    StationForecastMiniCardView()
+	StationForecastMiniCardView(item: CurrentWeather.mockInstance.toMiniCardItem(with: .current))
+		.wxmShadow()
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastMiniCardView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastMiniCardView.swift
@@ -7,23 +7,29 @@
 
 import SwiftUI
 import DomainLayer
+import Toolkit
 
 struct StationForecastMiniCardView: View {
 	let item: Item
 
 	var body: some View {
-		VStack(spacing: CGFloat(.smallSpacing)) {
-			Text(item.time)
-				.foregroundColor(Color(colorEnum: .darkestBlue))
-				.font(.system(size: CGFloat(.caption)))
+		Button {
+			item.action?()
+		} label: {
+			VStack(spacing: CGFloat(.smallSpacing)) {
+				Text(item.time)
+					.foregroundColor(Color(colorEnum: .darkestBlue))
+					.font(.system(size: CGFloat(.caption)))
 
-			weatherImage
+				weatherImage
 
-			Text(item.temperature)
-				.foregroundColor(Color(colorEnum: .darkestBlue))
-				.font(.system(size: CGFloat(.normalFontSize), weight: .bold))
+				Text(item.temperature)
+					.foregroundColor(Color(colorEnum: .darkestBlue))
+					.font(.system(size: CGFloat(.normalFontSize), weight: .bold))
+			}
+			.WXMCardStyle()
 		}
-		.WXMCardStyle()
+		.allowsHitTesting(item.action != nil)
     }
 }
 
@@ -32,6 +38,7 @@ extension StationForecastMiniCardView {
 		let time: String
 		let animationString: String?
 		let temperature: String
+		var action: VoidCallback?
 	}
 }
 

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
@@ -34,10 +34,14 @@ struct StationForecastView: View {
 						}
 
                         ForEach(viewModel.forecasts, id: \.date) { forecast in
-                            StationForecastCardView(forecast: forecast,
-                                                    minWeekTemperature: viewModel.overallMinTemperature ?? 0.0,
-                                                    maxWeekTemperature: viewModel.overallMaxTemperature ?? 0.0)
-                            .wxmShadow()
+							Button {
+								viewModel.handleForecastTap(forecast: forecast)
+							} label: {
+								StationForecastCardView(forecast: forecast,
+														minWeekTemperature: viewModel.overallMinTemperature ?? 0.0,
+														maxWeekTemperature: viewModel.overallMaxTemperature ?? 0.0)
+								.wxmShadow()
+							}
                         }
                     }
 					.iPadMaxWidth()

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
@@ -34,17 +34,20 @@ struct StationForecastView: View {
 						}
 						.padding(.horizontal)
 
-                        ForEach(viewModel.forecasts, id: \.date) { forecast in
-							Button {
-								viewModel.handleForecastTap(forecast: forecast)
-							} label: {
-								StationForecastCardView(forecast: forecast,
-														minWeekTemperature: viewModel.overallMinTemperature ?? 0.0,
-														maxWeekTemperature: viewModel.overallMaxTemperature ?? 0.0)
-								.wxmShadow()
+						VStack(spacing: CGFloat(.mediumSpacing)) {
+							ForEach(viewModel.forecasts, id: \.date) { forecast in
+								Button {
+									viewModel.handleForecastTap(forecast: forecast)
+								} label: {
+									StationForecastCardView(forecast: forecast,
+															minWeekTemperature: viewModel.overallMinTemperature ?? 0.0,
+															maxWeekTemperature: viewModel.overallMaxTemperature ?? 0.0)
+									.wxmShadow()
+								}
 							}
-                        }
-						.padding(.horizontal)
+							.padding(.horizontal)
+						}
+						.padding(.bottom)
                     }
 					.clipped()
 					.iPadMaxWidth()

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
@@ -79,6 +79,7 @@ private extension StationForecastView {
 							let item = viewModel.hourlyItems[index]
 							StationForecastMiniCardView(item: item)
 								.wxmShadow()
+								.frame(width: 80.0)
 						}
 					}
 				}

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
@@ -32,6 +32,7 @@ struct StationForecastView: View {
 
 							Spacer()
 						}
+						.padding(.horizontal)
 
                         ForEach(viewModel.forecasts, id: \.date) { forecast in
 							Button {
@@ -43,9 +44,11 @@ struct StationForecastView: View {
 								.wxmShadow()
 							}
                         }
+						.padding(.horizontal)
                     }
+					.clipped()
 					.iPadMaxWidth()
-                    .padding()
+					.padding(.vertical)
                 }
             }
         }
@@ -55,7 +58,6 @@ struct StationForecastView: View {
         .onAppear {
             Logger.shared.trackScreen(.forecast)
         }
-		.clipped()
     }
 }
 
@@ -71,7 +73,7 @@ private extension StationForecastView {
 						.foregroundColor(Color(colorEnum: .darkestBlue))
 
 					Spacer()
-				}
+				}.padding(.horizontal)
 
 				ScrollView(.horizontal, showsIndicators: false) {
 					LazyHStack(spacing: CGFloat(.smallSpacing)) {
@@ -81,7 +83,7 @@ private extension StationForecastView {
 								.wxmShadow()
 								.frame(width: 80.0)
 						}
-					}
+					}.padding(.horizontal)
 				}
 
 			}

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
@@ -15,26 +15,18 @@ struct StationForecastView: View {
 
     var body: some View {
         ZStack {
+			Color(colorEnum: .bg)
+				.ignoresSafeArea()
+			
             ScrollViewReader { proxy in
                 TrackableScrollView(showIndicators: false, offsetObject: viewModel.offsetObject) { completion in
                     viewModel.refresh(completion: completion)
                 } content: {
-                    VStack(spacing: CGFloat(.smallSpacing)) {
+                    VStack(spacing: CGFloat(.mediumSpacing)) {
                         ForEach(viewModel.forecasts, id: \.date) { forecast in
                             StationForecastCardView(forecast: forecast,
                                                     minWeekTemperature: viewModel.overallMinTemperature ?? 0.0,
-                                                    maxWeekTemperature: viewModel.overallMaxTemperature ?? 0.0,
-                                                    isExpanded: Binding(get: { expandedForecasts?.contains(forecast.date) == true },
-                                                                        set: { _ in
-                                withAnimation(.easeIn(duration: 0.3)) {
-                                    let isExpanded = expandCollapseCard(for: forecast.date)
-                                    if  isExpanded {
-                                        proxy.scrollTo(forecast.date, anchor: .top)
-                                    }
-                                    viewModel.trackSelectContentEvent(forecast: forecast, isOpen: isExpanded)
-                                }
-                            }),
-                                                    isExpandable: forecast.hourly?.isEmpty == false)
+                                                    maxWeekTemperature: viewModel.overallMaxTemperature ?? 0.0)
                             .wxmShadow()
                         }
                     }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
@@ -23,6 +23,22 @@ struct StationForecastView: View {
                     viewModel.refresh(completion: completion)
                 } content: {
                     VStack(spacing: CGFloat(.mediumSpacing)) {
+						HStack {
+							Text(LocalizableString.Forecast.nextTwentyFourHours.localized)
+								.font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
+								.foregroundColor(Color(colorEnum: .darkestBlue))
+
+							Spacer()
+						}
+
+						HStack {
+							Text(LocalizableString.Forecast.nextSevenDays.localized)
+								.font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
+								.foregroundColor(Color(colorEnum: .darkestBlue))
+
+							Spacer()
+						}
+
                         ForEach(viewModel.forecasts, id: \.date) { forecast in
                             StationForecastCardView(forecast: forecast,
                                                     minWeekTemperature: viewModel.overallMinTemperature ?? 0.0,

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastViewModel.swift
@@ -53,6 +53,10 @@ class StationForecastViewModel: ObservableObject {
         refresh {}
     }
 
+	func handleForecastTap(forecast: NetworkDeviceForecastResponse) {
+		print("Will handle tap for \(forecast)")
+	}
+
     func trackSelectContentEvent(forecast: NetworkDeviceForecastResponse, isOpen: Bool) {
         var params: [Parameter: ParameterValue] = [.contentType: .forecastDay,
                                                    .itemId: .custom(device?.id ?? ""),
@@ -141,7 +145,15 @@ private extension StationForecastViewModel {
 		let hourly = forecasts.map { $0.hourly }.compactMap { $0 }.flatMap { $0 }
 		let filtered = hourly.filter { ($0.timestamp?.timestampToDate(timeZone: timezone) ?? .distantPast) >= Date.now &&  ($0.timestamp?.timestampToDate(timeZone: timezone) ?? .distantPast) < Date.now.advancedByHours(hours: 24) }
 
-		hourlyItems = filtered.map { $0.toMiniCardItem(with: timezone) }
+		hourlyItems = filtered.map { weather in
+			return weather.toMiniCardItem(with: timezone, action: { [weak  self] in
+				self?.handleTap(for: weather)
+			})
+		}
+	}
+
+	func handleTap(for weather: CurrentWeather) {
+		print("Will handle tap for \(weather)")
 	}
 }
 

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastViewModel.swift
@@ -13,8 +13,14 @@ import Combine
 class StationForecastViewModel: ObservableObject {
     weak var containerDelegate: StationDetailsViewModelDelegate?
     let offsetObject: TrackableScrollOffsetObject = TrackableScrollOffsetObject()
-    @Published private(set) var forecasts: [NetworkDeviceForecastResponse] = []
+	@Published private(set) var forecasts: [NetworkDeviceForecastResponse] = [] {
+		didSet {
+			updateHourlyItems()
+		}
+	}
     @Published private(set) var viewState: ViewState = .loading
+	@Published private(set) var hourlyItems: [StationForecastMiniCardView.Item] = []
+
     var overallMinTemperature: Double? {
         forecasts.min { ($0.daily?.temperatureMin ?? 0.0) < ($1.daily?.temperatureMin ?? 0.0) }?.daily?.temperatureMin
     }
@@ -125,6 +131,18 @@ private extension StationForecastViewModel {
     func getCurrentDateInStringForForecast() -> String {
         Date.now.getFormattedDate(format: .onlyDate)
     }
+
+	func updateHourlyItems() {
+		guard let timezone = forecasts.first?.tz.toTimezone else {
+			hourlyItems = []
+			return
+		}
+
+		let hourly = forecasts.map { $0.hourly }.compactMap { $0 }.flatMap { $0 }
+		let filtered = hourly.filter { ($0.timestamp?.timestampToDate(timeZone: timezone) ?? .distantPast) >= Date.now &&  ($0.timestamp?.timestampToDate(timeZone: timezone) ?? .distantPast) < Date.now.advancedByHours(hours: 24) }
+
+		hourlyItems = filtered.map { $0.toMiniCardItem(with: timezone) }
+	}
 }
 
 // MARK: - StationDetailsViewModelChild

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -98,6 +98,8 @@
 		2664833F29C8953E00748F9C /* SpinningLoaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2664833E29C8953E00748F9C /* SpinningLoaderView.swift */; };
 		2664834329C89F8A00748F9C /* StationDetailsTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2664834229C89F8A00748F9C /* StationDetailsTypes.swift */; };
 		2666D50A2BBC4E80003B30C0 /* StationChipsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2666D5092BBC4E80003B30C0 /* StationChipsView.swift */; };
+		2666D57D2BC96077003B30C0 /* LocalizableString+Forecast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2666D57C2BC96077003B30C0 /* LocalizableString+Forecast.swift */; };
+		2666D57F2BC977D0003B30C0 /* StationForecastMiniCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2666D57E2BC977D0003B30C0 /* StationForecastMiniCardView.swift */; };
 		266B018F2B836EC6007AC689 /* NoRewardsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266B018E2B836EC6007AC689 /* NoRewardsView.swift */; };
 		266B01912B836FE6007AC689 /* anim_rocket.json in Resources */ = {isa = PBXBuildFile; fileRef = 266B01902B836FE6007AC689 /* anim_rocket.json */; };
 		266B01932B8380FA007AC689 /* AnnouncementCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266B01922B8380FA007AC689 /* AnnouncementCardView.swift */; };
@@ -600,6 +602,8 @@
 		2664833E29C8953E00748F9C /* SpinningLoaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinningLoaderView.swift; sourceTree = "<group>"; };
 		2664834229C89F8A00748F9C /* StationDetailsTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationDetailsTypes.swift; sourceTree = "<group>"; };
 		2666D5092BBC4E80003B30C0 /* StationChipsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationChipsView.swift; sourceTree = "<group>"; };
+		2666D57C2BC96077003B30C0 /* LocalizableString+Forecast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalizableString+Forecast.swift"; sourceTree = "<group>"; };
+		2666D57E2BC977D0003B30C0 /* StationForecastMiniCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationForecastMiniCardView.swift; sourceTree = "<group>"; };
 		266B018E2B836EC6007AC689 /* NoRewardsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoRewardsView.swift; sourceTree = "<group>"; };
 		266B01902B836FE6007AC689 /* anim_rocket.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = anim_rocket.json; sourceTree = "<group>"; };
 		266B01922B8380FA007AC689 /* AnnouncementCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementCardView.swift; sourceTree = "<group>"; };
@@ -1229,6 +1233,7 @@
 				2675479029A9181E008BCF40 /* CustomRangeSlider.swift */,
 				2664832F29C36B0900748F9C /* StationForeCastCardView+Content.swift */,
 				2664832D29C364FE00748F9C /* StationForecastCardView.swift */,
+				2666D57E2BC977D0003B30C0 /* StationForecastMiniCardView.swift */,
 				2664832829C35AF400748F9C /* StationForecastView.swift */,
 				2664832A29C35C0300748F9C /* StationForecastViewModel.swift */,
 			);
@@ -1894,6 +1899,7 @@
 			children = (
 				26D6119C2A9E1CDC0099117C /* Localizable.xcstrings */,
 				26D611AA2A9E21080099117C /* LocalizableConstants.swift */,
+				2666D57C2BC96077003B30C0 /* LocalizableString+Forecast.swift */,
 				268D07962B2B1E81002BD77E /* LocalizableString+SelectStationLocation.swift */,
 				264DD5072B9F3BCB002691FF /* LocalizableString+ExplorerList.swift */,
 				266BAF542AA88631004F5DE0 /* LocalizableString+Analytics.swift */,
@@ -2734,6 +2740,7 @@
 				267547B729A9181E008BCF40 /* DeleteAccountView.swift in Sources */,
 				267547AC29A9181E008BCF40 /* DeleteAccountViewModel.swift in Sources */,
 				26C904C92A77EF980047A388 /* DeviceDetails+.swift in Sources */,
+				2666D57F2BC977D0003B30C0 /* StationForecastMiniCardView.swift in Sources */,
 				26A4116F29B74B7000A2C10B /* DeviceInfoRowView.swift in Sources */,
 				26A4116B29B744E100A2C10B /* DeviceInfoView.swift in Sources */,
 				262B03072B20BC7B00C31FE7 /* AppUpdateView.swift in Sources */,
@@ -2930,6 +2937,7 @@
 				267547D529A9181E008BCF40 /* UpdateFirmwareView.swift in Sources */,
 				267547A229A9181E008BCF40 /* UpdateFirmwareViewModel.swift in Sources */,
 				26AB9F582A822DB500855912 /* UserDeviceFollowState+.swift in Sources */,
+				2666D57D2BC96077003B30C0 /* LocalizableString+Forecast.swift in Sources */,
 				267548F029A91A87008BCF40 /* View+.swift in Sources */,
 				26A4114A29B5ED5D00A2C10B /* ViewModelsFactory.swift in Sources */,
 				26AF27712A0B815B0067A1B8 /* WeatherChartDataModel.swift in Sources */,

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -3771,6 +3771,28 @@
         }
       }
     },
+    "forecast_next_seven_days" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next 7 days"
+          }
+        }
+      }
+    },
+    "forecast_next_twenty_four_hours" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next 24 hours"
+          }
+        }
+      }
+    },
     "forgot_password" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -7,16 +7,6 @@
     "-" : {
 
     },
-    "**%@**%@%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**%1$@**%2$@%3$@"
-          }
-        }
-      }
-    },
     "%.2f %@" : {
       "localizations" : {
         "en" : {
@@ -40,32 +30,12 @@
         }
       }
     },
-    "%@ **%@°**" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ **%2$@°**"
-          }
-        }
-      }
-    },
     "%@ %@" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%1$@ %2$@"
-          }
-        }
-      }
-    },
-    "%@%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@%2$@"
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/LocalizableString+Forecast.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+Forecast.swift
@@ -1,0 +1,31 @@
+//
+//  LocalizableString+Forecast.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 12/4/24.
+//
+
+import Foundation
+
+extension LocalizableString {
+	enum Forecast {
+		case nextSevenDays
+		case nextTwentyFourHours
+	}
+}
+
+extension LocalizableString.Forecast: WXMLocalizable {
+	var localized: String {
+		var localized = NSLocalizedString(key, comment: "")
+		return localized
+	}
+
+	var key: String {
+		switch self {
+			case .nextSevenDays:
+				return "forecast_next_seven_days"
+			case .nextTwentyFourHours:
+				return "forecast_next_twenty_four_hours"
+		}
+	}
+}

--- a/wxm-ios/Toolkit/Toolkit/Utils/DateExtension.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/DateExtension.swift
@@ -207,8 +207,12 @@ public extension Date {
     }
 
     func advancedByDays(days: Int) -> Date {
-        Calendar.current.date(byAdding: .day, value: days, to: .now)!
+        Calendar.current.date(byAdding: .day, value: days, to: self)!
     }
+
+	func advancedByHours(hours: Int) -> Date {
+		Calendar.current.date(byAdding: .hour, value: hours, to: self)!
+	}
 }
 
 public extension TimeInterval {

--- a/wxm-ios/Toolkit/Toolkit/Utils/DateExtension.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/DateExtension.swift
@@ -135,8 +135,9 @@ public extension Date {
         return dateFormatter.string(from: self)
     }
 
-    func transactionsTimeFormat() -> String {
+    func transactionsTimeFormat(timeZone: TimeZone = .current) -> String {
         let dateFormatter = DateFormatter()
+		dateFormatter.timeZone = timeZone
         dateFormatter.dateStyle = .none
         dateFormatter.timeStyle = .short
         return dateFormatter.string(from: self)


### PR DESCRIPTION
## **Why?**
Updated forecast tab in station details
### **How?**
- Updated forecast cards
- Declared new view (`StationForecastMiniCardView`) to show the hourly area
### **Testing**
Make sure everything is rendered properly. Check stations with different timezone
### **Additional context**
fixes fe-787
Navigation to details will be implemented in upcoming task
