### PR TITLE
Fixed versioning script

### DIFF
--- a/Scripts/git_version.sh
+++ b/Scripts/git_version.sh
@@ -9,7 +9,7 @@
 VERSION_CONFIG_PATH=$1;
 echo $VERSION_CONFIG_PATH
 
-TAG=$(git describe --tags --abbrev=0)
+TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
 echo $TAG
 LATEST_VERSION=$TAG
 if [[ $TAG == RC* ]]


### PR DESCRIPTION
## **Why?**
The release jobs used to fail.
### **How?**
Fixed the command to fetch the repo tags in `git_version` script
