### PR TITLE
Fixed alignment in grids

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCard.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCard.swift
@@ -25,6 +25,7 @@ struct WeatherStationCard: View {
 						.cornerRadius(CGFloat(.cardCornerRadius))
 				}
 		}
+		.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
 		.WXMCardStyle(backgroundColor: Color(colorEnum: .top),
 					  insideHorizontalPadding: .zero,
 					  insideVerticalPadding: .zero,

--- a/PresentationLayer/UIComponents/Screens/DailyRewards /Components/RewardFieldView.swift
+++ b/PresentationLayer/UIComponents/Screens/DailyRewards /Components/RewardFieldView.swift
@@ -57,6 +57,7 @@ struct RewardFieldView: View {
 
 			}
 		}
+		.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
 		.WXMCardStyle()
 		.indication(show: .constant(score.showIndication),
 					borderColor: Color(colorEnum: score.color),

--- a/PresentationLayer/UIComponents/Screens/ForecastDetails/Components/ForecastFieldCardView.swift
+++ b/PresentationLayer/UIComponents/Screens/ForecastDetails/Components/ForecastFieldCardView.swift
@@ -37,6 +37,7 @@ struct ForecastFieldCardView: View {
 
 			Spacer()
 		}
+		.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
 		.WXMCardStyle()
     }
 }

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel+Factory.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel+Factory.swift
@@ -67,7 +67,7 @@ extension NetworkStatsViewModel {
 			guard let txHashUrl = tokens.lastTxHashUrl else {
 				return
 			}
-			Logger.shared.trackEvent(.selectContent, parameters: [.contentType: .lastRunHash])
+			WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .lastRunHash])
 
 			HelperFunctions().openUrl(txHashUrl)
 		},
@@ -88,7 +88,7 @@ extension NetworkStatsViewModel {
                              title: LocalizableString.NetStats.wxmRewardsTitle.localized,
 							 description: rewardsDescription,
 							 showExternalLinkIcon: true,
-							 externalLinkTapAction: { Logger.shared.trackEvent(.selectContent, parameters: [.contentType: .rewardContract]) },
+							 externalLinkTapAction: { WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .rewardContract]) },
                              accessory: accessory,
                              additionalStats: [total, lastDay],
                              analyticsItemId: .allocatedRewards)
@@ -130,7 +130,7 @@ extension NetworkStatsViewModel {
 							 title: LocalizableString.NetStats.wxmTokenTitle.localized,
 							 description: tokenDescription,
 							 showExternalLinkIcon: true,
-							 externalLinkTapAction: { Logger.shared.trackEvent(.selectContent, parameters: [.contentType: .tokenContract]) },
+							 externalLinkTapAction: { WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .tokenContract]) },
 							 accessory: nil,
 							 additionalStats: [totalSupply, circulatingSupply],
 							 analyticsItemId: nil)

--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileView.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileView.swift
@@ -260,6 +260,7 @@ private struct ContentView: View {
 				Spacer()
 			}
 		}
+		.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
 		.WXMCardStyle(backgroundColor: Color(colorEnum: .blueTint))
 	}
 }


### PR DESCRIPTION
## **Why?**
Make the grid layouts render the cells with equal height per row
### **How?**
Updated the cells rendered in the following screens
- The forecast details screen (daily conditions section)
- The profile screen header ($WXM area)
- Reward details (Location Quality - Cell ranking)
- Home (grid layout in iPad)
### **Testing**
Check the screens mentioned above on a regular device and iPad
### **Additional context**
Fixes fe-864
