### PR TITLE
Truncated text in empty state of rewards tab

### DIFF
--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Rewards/Components/NoRewardsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Rewards/Components/NoRewardsView.swift
@@ -32,10 +32,12 @@ struct NoRewardsView: View {
 					Text(LocalizableString.StationDetails.noRewardsTitle.localized)
 						.font(.system(size: CGFloat(.largeTitleFontSize), weight: .bold))
 						.foregroundColor(Color(colorEnum: .text))
+					
 					Text(LocalizableString.StationDetails.noRewardsDescription.localized)
 						.font(.system(size: CGFloat(.normalFontSize)))
 						.foregroundColor(Color(colorEnum: .text))
 						.multilineTextAlignment(.center)
+						.fixedSize(horizontal: false, vertical: true)
 				}
 			}
 
@@ -64,6 +66,7 @@ private extension NoRewardsView {
 				Text(LocalizableString.StationDetails.proTipDescription.localized)
 					.foregroundColor(Color(colorEnum: .text))
 					.font(.system(size: CGFloat(.caption)))
+					.fixedSize(horizontal: false, vertical: true)
 
 				Spacer()
 			}


### PR DESCRIPTION
## **Why?**
For some reason (maybe internal implementation of `SwiftUI`), when the mainnet banner is visible, the texts on the `Rewards Coming Soon!` card are truncated
### **How?**
Enforce texts to be rendered properly with `fixedSize` modifier
### **Testing**
Make sure the card is rendered as expected in the following cases:
- When mainnet banner is visible (disable `-WXMAnalyticsDisabled YES` launch argument)
- When mainnet banner is hidden (`-WXMAnalyticsDisabled YES` is checked, as is by default)
### **Additional context**
Fixes fe-881
