### PR TITLE
Add a helpful indication in the available tokens card in the

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScrollView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScrollView.swift
@@ -70,6 +70,7 @@ struct TrackableScrollView<Content>: View where Content: View {
             ScrollView(showsIndicators: false) {
                 content()
             }
+			.clipped()
             .modify { view in
                 if refreshAction != nil {
                     view.refreshable {
@@ -88,6 +89,7 @@ struct TrackableScrollView<Content>: View where Content: View {
             } content: {
                 content()
             }
+			.clipped()
             .modify { view in
                 if #available(iOS 16.0, *) {
                     view.scrollContentBackground(.hidden)

--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileTypes.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileTypes.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 enum ProfileField: CaseIterable {
 	case rewards
@@ -31,6 +32,20 @@ enum ProfileField: CaseIterable {
 				return LocalizableString.Profile.myWallet.localized
 			case .settings:
 				return LocalizableString.Profile.prefsSettings.localized
+		}
+	}
+}
+
+enum RewardsIndication {
+	case buyStation
+	case claimWeb
+
+	var showBorder: Bool {
+		switch self {
+			case .buyStation:
+				true
+			case .claimWeb:
+				false
 		}
 	}
 }

--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileView.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileView.swift
@@ -30,6 +30,7 @@ private struct ContentView: View {
 	var body: some View {
 		VStack(spacing: 0.0) {
 			titleView
+				.zIndex(1)
 
 			TrackableScrollView(offsetObject: viewModel.scrollOffsetObject) { completion in
 				viewModel.refresh(completion: completion)
@@ -39,6 +40,7 @@ private struct ContentView: View {
 					.padding(.bottom, tabBarItemsSize.height)
 					.fail(show: $viewModel.isFailed, obj: viewModel.failObj)
 			}
+			.zIndex(0)
 		}
 		.spinningLoader(show: $viewModel.isLoading, hideContent: true)
 		.bottomSheet(show: $viewModel.showInfo, fitContent: true) {

--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileView.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileView.swift
@@ -105,9 +105,16 @@ private struct ContentView: View {
 		}
 		.WXMCardStyle()
 		.indication(show: $viewModel.showRewardsIndication,
-					borderColor: Color(colorEnum: .primary),
+					borderColor: Color(colorEnum: viewModel.rewardsIndicationType.showBorder ? .primary : .clear),
 					bgColor: Color(colorEnum: .blueTint)) {
-			claimWebView
+			Group {
+				switch viewModel.rewardsIndicationType {
+					case .buyStation:
+						buyStationView
+					case .claimWeb:
+						claimWebView
+				}
+			}
 		}
 					.wxmShadow()
 	}

--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileView.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileView.swift
@@ -104,36 +104,51 @@ private struct ContentView: View {
 			}
 		}
 		.WXMCardStyle()
-		.indication(show: $viewModel.showBuyStation,
+		.indication(show: $viewModel.showRewardsIndication,
 					borderColor: Color(colorEnum: .primary),
 					bgColor: Color(colorEnum: .blueTint)) {
-			CardWarningView(type: .info,
-							showIcon: false,
-							title: LocalizableString.Profile.noRewardsWarningTitle.localized,
-							message: LocalizableString.Profile.noRewardsWarningDescription.localized,
-							showContentFullWidth: true,
-							closeAction: nil) {
-				Button {
-					viewModel.handleBuyStationTap()
-				} label: {
-					ZStack {
-						HStack {
-							Text(FontIcon.cart.rawValue)
-								.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.mediumFontSize)))
-
-							Spacer()
-						}
-
-						Text(LocalizableString.Profile.noRewardsWarningButtonTitle.localized)
-					}
-					.padding(.horizontal, CGFloat(.defaultSidePadding))
-				}
-				.buttonStyle(WXMButtonStyle.filled())
-			}
+			claimWebView
 		}
 					.wxmShadow()
 	}
 
+	@ViewBuilder
+	var buyStationView: some View {
+		CardWarningView(type: .info,
+						showIcon: false,
+						title: LocalizableString.Profile.noRewardsWarningTitle.localized,
+						message: LocalizableString.Profile.noRewardsWarningDescription.localized,
+						showContentFullWidth: true,
+						closeAction: nil) {
+			Button {
+				viewModel.handleBuyStationTap()
+			} label: {
+				ZStack {
+					HStack {
+						Text(FontIcon.cart.rawValue)
+							.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.mediumFontSize)))
+
+						Spacer()
+					}
+
+					Text(LocalizableString.Profile.noRewardsWarningButtonTitle.localized)
+				}
+				.padding(.horizontal, CGFloat(.defaultSidePadding))
+			}
+			.buttonStyle(WXMButtonStyle.filled())
+		}
+	}
+
+	@ViewBuilder
+	var claimWebView: some View {
+		CardWarningView(type: .info,
+						showIcon: false,
+						title: nil,
+						message: LocalizableString.Profile.claimFromWebDescription(viewModel.claimWebAppUrl).localized,
+						closeAction: nil) { EmptyView() }
+	}
+
+	@ViewBuilder
 	var walletAddressView: some View {
 		Button {
 			Router.shared.navigateTo(.wallet(ViewModelsFactory.getMyWalletViewModel()))

--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
@@ -28,7 +28,7 @@ class ProfileViewModel: ObservableObject {
 			updateUserInfoValues()
 		}
 	}
-	@Published var showBuyStation: Bool = true
+	@Published var showRewardsIndication: Bool = true
 	@Published var showMissingWalletError: Bool = false
 	@Published var isTabBarVisible: Bool = true
 	@Published var totalEarned: String = 0.0.toWXMTokenPrecisionString
@@ -38,6 +38,12 @@ class ProfileViewModel: ObservableObject {
 	@Published var isLoading: Bool = true
 	@Published var isFailed: Bool = false
 	var failObj: FailSuccessStateObject?
+
+	var claimWebAppUrl: String {
+		let urlString = DisplayedLinks.claimToken.linkURL
+		let url = URL(string: urlString)
+		return url?.host ?? "-"
+	}
 
     public init(meUseCase: MeUseCase) {
         self.meUseCase = meUseCase
@@ -186,7 +192,7 @@ private extension ProfileViewModel {
 			guard let self = self  else {
 				return
 			}
-			self.showBuyStation = await !self.meUseCase.hasOwnedDevices()
+			self.showRewardsIndication = await !self.meUseCase.hasOwnedDevices()
 		}
 	}
 }

--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
@@ -19,6 +19,7 @@ class ProfileViewModel: ObservableObject {
 	private var userRewardsResponse: NetworkUserRewardsResponse? {
 		didSet {
 			updateRewards()
+			updateUserInfoValues()
 		}
 	}
 	@Published var showInfo: Bool = false
@@ -29,6 +30,7 @@ class ProfileViewModel: ObservableObject {
 		}
 	}
 	@Published var showRewardsIndication: Bool = true
+	var rewardsIndicationType: RewardsIndication = .claimWeb
 	@Published var showMissingWalletError: Bool = false
 	@Published var isTabBarVisible: Bool = true
 	@Published var totalEarned: String = 0.0.toWXMTokenPrecisionString
@@ -192,7 +194,9 @@ private extension ProfileViewModel {
 			guard let self = self  else {
 				return
 			}
-			self.showRewardsIndication = await !self.meUseCase.hasOwnedDevices()
+			let hasDevices = await self.meUseCase.hasOwnedDevices()
+			self.rewardsIndicationType = self.isClaimAvailable ? .claimWeb : .buyStation
+			self.showRewardsIndication = !hasDevices || self.isClaimAvailable
 		}
 	}
 }

--- a/wxm-ios/DataLayer/DataLayer.xcodeproj/project.pbxproj
+++ b/wxm-ios/DataLayer/DataLayer.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		2674017A2A386DA700E54E35 /* get_network_stats.json in Resources */ = {isa = PBXBuildFile; fileRef = 267401792A386DA700E54E35 /* get_network_stats.json */; };
 		2674EDCE2A3C4C3800616285 /* get_network_stats_alt.json in Resources */ = {isa = PBXBuildFile; fileRef = 2674EDCD2A3C4C3800616285 /* get_network_stats_alt.json */; };
 		267A37872AEBEBBA00469126 /* get_user_device_rewards.json in Resources */ = {isa = PBXBuildFile; fileRef = 267A37862AEBEBBA00469126 /* get_user_device_rewards.json */; };
+		267CA6EF2C1314E300ABE599 /* get_user.json in Resources */ = {isa = PBXBuildFile; fileRef = 267CA6EE2C1314E200ABE599 /* get_user.json */; };
 		2683A4C42ADECF3100D5C205 /* countries_information.json in Resources */ = {isa = PBXBuildFile; fileRef = 2683A4C32ADECBA800D5C205 /* countries_information.json */; };
 		2692D88B2A4DB2B50060CB3C /* DBExplorerAddress+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2692D8852A4DB2B50060CB3C /* DBExplorerAddress+CoreDataClass.swift */; };
 		2692D88C2A4DB2B50060CB3C /* DBExplorerAddress+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2692D8862A4DB2B50060CB3C /* DBExplorerAddress+CoreDataProperties.swift */; };
@@ -119,6 +120,7 @@
 		267401792A386DA700E54E35 /* get_network_stats.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = get_network_stats.json; sourceTree = "<group>"; };
 		2674EDCD2A3C4C3800616285 /* get_network_stats_alt.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = get_network_stats_alt.json; sourceTree = "<group>"; };
 		267A37862AEBEBBA00469126 /* get_user_device_rewards.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = get_user_device_rewards.json; sourceTree = "<group>"; };
+		267CA6EE2C1314E200ABE599 /* get_user.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = get_user.json; sourceTree = "<group>"; };
 		2683A4C32ADECBA800D5C205 /* countries_information.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = countries_information.json; sourceTree = "<group>"; };
 		2692D8852A4DB2B50060CB3C /* DBExplorerAddress+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBExplorerAddress+CoreDataClass.swift"; sourceTree = "<group>"; };
 		2692D8862A4DB2B50060CB3C /* DBExplorerAddress+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBExplorerAddress+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 				2646FCB42995018800EBB61B /* get_user_device_just_claimed.json */,
 				26DD42D129AFAF26008E277E /* get_user_devices.json */,
 				26B3D2B329E43D14006913E0 /* get_user_wallet.json */,
+				267CA6EE2C1314E200ABE599 /* get_user.json */,
 			);
 			path = Jsons;
 			sourceTree = "<group>";
@@ -491,6 +494,7 @@
 				266B01CF2B861B10007AC689 /* get_device_rewards_summary_empty.json in Resources */,
 				2631872C29A4E2D400FA1691 /* get_device_history.json in Resources */,
 				2683A4C42ADECF3100D5C205 /* countries_information.json in Resources */,
+				267CA6EF2C1314E300ABE599 /* get_user.json in Resources */,
 				2618A6F12A1F61FD00983B7B /* get_device_history_24_samples.json in Resources */,
 				2646D8E829C8B4310000237F /* get_device_info_helium.json in Resources */,
 				266B01C52B84E7F6007AC689 /* get_device_rewards_timeline.json in Resources */,

--- a/wxm-ios/DataLayer/DataLayer/Networking/ApiRequestBuilders/MeApiRequestBuilder.swift
+++ b/wxm-ios/DataLayer/DataLayer/Networking/ApiRequestBuilders/MeApiRequestBuilder.swift
@@ -179,6 +179,8 @@ extension MeApiRequestBuilder: MockResponseBuilder {
                 return "get_user_wallet"
             case .getUserDeviceForecastById:
                 return "get_user_device_forecast"
+			case .getUser:
+				return "get_user"
             default:
                 return nil
         }

--- a/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/get_user.json
+++ b/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/get_user.json
@@ -1,0 +1,11 @@
+{
+	"id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+	"email": "user@example.com",
+	"name": "TestUser",
+	"firstname": "Test",
+	"lastname": "User",
+	"wallet": {
+		"address": "0x389aadA0E2ccdd1f0e146a8ff47886dCbb5C0000",
+		"updatedAt": 1665653413335
+	}
+}

--- a/wxm-ios/DataLayer/UserInfoService.swift
+++ b/wxm-ios/DataLayer/UserInfoService.swift
@@ -28,8 +28,9 @@ public class UserInfoService {
 	}
 
 	public func getUser() throws -> AnyPublisher<DataResponse<NetworkUserInfoResponse, NetworkErrorResponse>, Never> {
-		let urlRequest = try MeApiRequestBuilder.getUser.asURLRequest()
-		let publisher: AnyPublisher<DataResponse<NetworkUserInfoResponse, NetworkErrorResponse>, Never> = ApiClient.shared.requestCodableAuthorized(urlRequest).share().eraseToAnyPublisher()
+		let builder = MeApiRequestBuilder.getUser
+		let urlRequest = try builder.asURLRequest()
+		let publisher: AnyPublisher<DataResponse<NetworkUserInfoResponse, NetworkErrorResponse>, Never> = ApiClient.shared.requestCodableAuthorized(urlRequest, mockFileName: builder.mockFileName).share().eraseToAnyPublisher()
 		publisher.sink { [weak self] response in
 			guard let value = response.value else {
 				return

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -5251,6 +5251,17 @@
         }
       }
     },
+    "profile_claim_from_web_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can also claim your allocated rewards by visiting **%@** from a desktop web browser."
+          }
+        }
+      }
+    },
     "profile_my_wallet" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/LocalizableString+Profile.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+Profile.swift
@@ -15,6 +15,7 @@ extension LocalizableString {
 		case noRewardsWarningTitle
 		case noRewardsWarningDescription
 		case noRewardsWarningButtonTitle
+		case claimFromWebDescription(String)
 		case myWallet
 		case noWalletAddressDescription
 		case noWalletAddressErrorTitle
@@ -34,7 +35,13 @@ extension LocalizableString {
 
 extension LocalizableString.Profile: WXMLocalizable {
 	var localized: String {
-		let localized = NSLocalizedString(self.key, comment: "")
+		var localized = NSLocalizedString(self.key, comment: "")
+		switch self {
+			case .claimFromWebDescription(let text):
+				localized = String(format: localized, text)
+			default:
+				break
+		}
 
 		return localized
 	}
@@ -53,6 +60,8 @@ extension LocalizableString.Profile: WXMLocalizable {
 				return "profile_no_rewards_warning_description"
 			case .noRewardsWarningButtonTitle:
 				return "profile_no_rewards_warning_button_title"
+			case .claimFromWebDescription:
+				return "profile_claim_from_web_description"
 			case .myWallet:
 				return "profile_my_wallet"
 			case .noWalletAddressDescription:


### PR DESCRIPTION
## **Why?**
Indication on rewards card in profile view 
### **How?**
`If` there are allocated rewards to claim `then` show claim app indication
`else if` there are no owned devices `then` show buy station indication
`else` show nothing
### **Testing**
Make sure the indications are shown according to the "How?"
### **Additional context**
fixes fe-905
