### PR TITLE
Add an error popup when a user unsuccessfully navigates back

### DIFF
--- a/PresentationLayer/Navigation/Router.swift
+++ b/PresentationLayer/Navigation/Router.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import Toolkit
 
 enum Route: Hashable, Equatable {
 	static func == (lhs: Route, rhs: Route) -> Bool {
@@ -49,7 +50,7 @@ enum Route: Hashable, Equatable {
 				hasher.combine(vm)
 			case .rewardDetails(let vm):
 				hasher.combine(vm)
-			case .webView(let title, let url, let params, _):
+			case .webView(let title, let url, let params, _, _):
 				hasher.combine("\(title)-\(url)-\(params)")
 			case .selectStationLocation(let vm):
 				hasher.combine(vm)
@@ -141,7 +142,7 @@ enum Route: Hashable, Equatable {
 	case resetPassword(ResetPasswordViewModel)
 	case explorerList(ExplorerStationsListViewModel)
 	case rewardDetails(RewardDetailsViewModel)
-	case webView(String, String, [DisplayLinkParams: String]?, DeepLinkHandler.QueryParamsCallBack?)
+	case webView(String, String, [DisplayLinkParams: String]?, VoidCallback?, DeepLinkHandler.QueryParamsCallBack?)
 	case selectStationLocation(SelectStationLocationViewModel)
 	case rewardAnnotations(RewardAnnotationsViewModel)
 	case rewardBoosts(RewardBoostsViewModel)
@@ -212,8 +213,12 @@ extension Route {
 				ExplorerStationsListView(viewModel: explorerListViewModel)
 			case .rewardDetails(let rewardDetailsViewModel):
 				RewardDetailsView(viewModel: rewardDetailsViewModel)
-			case .webView(let title, let url, let params, let callback):
-				WebContainerView(title: title, url: url, params: params, redirectParamsCallback: callback)
+			case .webView(let title, let url, let params, let backButtonCallback, let callback):
+				WebContainerView(title: title, 
+								 url: url,
+								 params: params,
+								 backButtonCallback: backButtonCallback,
+								 redirectParamsCallback: callback)
 			case .selectStationLocation(let selectStationLocationViewModel):
 				NavigationContainerView {
 					SelectStationLocationView(viewModel: selectStationLocationViewModel)

--- a/PresentationLayer/UIComponents/BaseComponents/Toast/ToastView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/Toast/ToastView.swift
@@ -12,6 +12,7 @@ struct ToastView: View {
     let text: AttributedString
     var type: ToastType = .error
     var dismissInterval = 3.0
+	var retryButtonTitle: String = LocalizableString.retry.localized
     var dismissCompletion: VoidCallback?
     let retryAction: VoidCallback?
 
@@ -35,7 +36,7 @@ struct ToastView: View {
                         retryAction()
                     }
                 } label: {
-                    Text(LocalizableString.retry.localized)
+                    Text(retryButtonTitle)
                         .foregroundColor(Color(colorEnum: type.textColor))
                         .font(.system(size: CGFloat(.normalFontSize), weight: .bold))
                 }

--- a/PresentationLayer/UIComponents/BaseComponents/WebView/WebContainerView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WebView/WebContainerView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import WebKit
+import Toolkit
 
 private let disableZoomScript = "var meta = document.createElement('meta');" +
 "meta.name = 'viewport';" +
@@ -18,6 +19,7 @@ struct WebContainerView: View {
 	let title: String
 	let url: String
 	var params: [DisplayLinkParams: String]?
+	var backButtonCallback: VoidCallback?
 	var redirectParamsCallback: DeepLinkHandler.QueryParamsCallBack?
 	@State private var isLoading: Bool = false
 
@@ -27,6 +29,7 @@ struct WebContainerView: View {
 					   title: title,
 					   url: url,
 					   params: params,
+					   backButtonCallback: backButtonCallback,
 					   redirectParamsCallback: redirectParamsCallback)
 			.spinningLoader(show: $isLoading, hideContent: false)
 		}
@@ -38,6 +41,7 @@ private struct WXMWebView: UIViewRepresentable {
 	let title: String
 	let url: String
 	var params: [DisplayLinkParams: String]?
+	var backButtonCallback: VoidCallback?
 	var redirectParamsCallback: DeepLinkHandler.QueryParamsCallBack?
 
 	@EnvironmentObject var navigationObject: NavigationObject
@@ -74,6 +78,11 @@ private struct WXMWebView: UIViewRepresentable {
 
 		DispatchQueue.main.async {
 			navigationObject.title = title
+		}
+
+		navigationObject.shouldDismissAction = {
+			backButtonCallback?()
+			return true
 		}
 
 		return webView

--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
@@ -123,12 +123,25 @@ class ProfileViewModel: ObservableObject {
 			params += [.redirectUrl: "\(urlScheme)://\(DeepLinkHandler.tokenClaim)"]
 		}
 
+		let backButtonCallback = { [weak self] in
+			guard let self, let text = LocalizableString.Profile.claimFromWebAlertMessage(claimWebAppUrl).localized.attributedMarkdown else {
+				return
+			}
+
+			Toast.shared.show(text: text, type: .info)
+		}
+
 		let callback: DeepLinkHandler.QueryParamsCallBack = { [weak self] params in
 			if let amount = params?[DisplayLinkParams.claimedAmount.rawValue] {
 				self?.updateRewards(additionalClaimed: amount)
 			}
 		}
-		Router.shared.navigateTo(.webView(LocalizableString.Profile.claimFlowTitle.localized, url, params, callback))
+
+		Router.shared.navigateTo(.webView(LocalizableString.Profile.claimFlowTitle.localized,
+										  url,
+										  params,
+										  backButtonCallback,
+										  callback))
 	}
 
 	@MainActor

--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
@@ -128,7 +128,7 @@ class ProfileViewModel: ObservableObject {
 				return
 			}
 
-			Toast.shared.show(text: text, type: .info)
+			Toast.shared.show(text: text, type: .info, visibleDuration: 10.0, retryButtonTitle: LocalizableString.close.localized, retryAction: { })
 		}
 
 		let callback: DeepLinkHandler.QueryParamsCallBack = { [weak self] params in

--- a/PresentationLayer/Utils/Toast.swift
+++ b/PresentationLayer/Utils/Toast.swift
@@ -26,18 +26,26 @@ class Toast: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    /// Show toast at the bottom of the screen.
-    /// - Parameters:
-    ///   - text: The text to show
-    ///   - type: The toast type for the appropriate style, currentlye `error` or `info`
-    ///   - visibleDuration: The duration that the toast will be on screen
-    ///   - retryAction: Action to be exectuted once the retry button tapped. If not passed the retry button will be hidden
-    func show(text: AttributedString, type: ToastView.ToastType = .error, visibleDuration: CGFloat = 3.0, retryAction: VoidCallback? = nil) {
+	/// Show toast at the bottom of the screen.
+	/// - Parameters:
+	///   - text: The text to show
+	///   - type: The toast type for the appropriate style, currentlye `error` or `info`
+	///   - visibleDuration: The duration that the toast will be on screen
+	///   - retryButtonTitle: The title of the retry buton, by default is LocalizableString.retry.localized
+	///   - retryAction: Action to be exectuted once the retry button tapped. If not passed the retry button will be hidden
+	func show(text: AttributedString,
+			  type: ToastView.ToastType = .error,
+			  visibleDuration: CGFloat = 3.0,
+			  retryButtonTitle: String = LocalizableString.retry.localized,
+			  retryAction: VoidCallback? = nil) {
         guard let keyWindow, superview == nil else {
             return
         }
 
-        let view = ToastView(text: text, type: type, dismissInterval: visibleDuration, dismissCompletion: { [weak self] in
+        let view = ToastView(text: text, type: type,
+							 dismissInterval: visibleDuration,
+							 retryButtonTitle: retryButtonTitle,
+							 dismissCompletion: { [weak self] in
             self?.hostVC?.view.removeFromSuperview()
             self?.removeFromSuperview()
         }, retryAction: retryAction)

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -5251,6 +5251,17 @@
         }
       }
     },
+    "profile_claim_from_web_alert_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Having trouble claiming? Try visiting **%@** from a desktop browser."
+          }
+        }
+      }
+    },
     "profile_claim_from_web_description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -1953,6 +1953,17 @@
         }
       }
     },
+    "close" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
+          }
+        }
+      }
+    },
     "confirm" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/LocalizableConstants.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableConstants.swift
@@ -143,6 +143,7 @@ enum LocalizableString: WXMLocalizable {
     case uvIndex
     case share
     case retry
+	case close
     case clear
     case cancel
     case change
@@ -527,6 +528,8 @@ extension LocalizableString {
                 return "share"
             case .retry:
                 return "retry"
+			case .close:
+				return "close"
             case .clear:
                 return "clear"
             case .cancel:

--- a/wxm-ios/Resources/Localizable/LocalizableString+Profile.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+Profile.swift
@@ -16,6 +16,7 @@ extension LocalizableString {
 		case noRewardsWarningDescription
 		case noRewardsWarningButtonTitle
 		case claimFromWebDescription(String)
+		case claimFromWebAlertMessage(String)
 		case myWallet
 		case noWalletAddressDescription
 		case noWalletAddressErrorTitle
@@ -37,7 +38,7 @@ extension LocalizableString.Profile: WXMLocalizable {
 	var localized: String {
 		var localized = NSLocalizedString(self.key, comment: "")
 		switch self {
-			case .claimFromWebDescription(let text):
+			case .claimFromWebDescription(let text), .claimFromWebAlertMessage(let text):
 				localized = String(format: localized, text)
 			default:
 				break
@@ -62,6 +63,8 @@ extension LocalizableString.Profile: WXMLocalizable {
 				return "profile_no_rewards_warning_button_title"
 			case .claimFromWebDescription:
 				return "profile_claim_from_web_description"
+			case .claimFromWebAlertMessage:
+				return "profile_claim_from_web_alert_message"
 			case .myWallet:
 				return "profile_my_wallet"
 			case .noWalletAddressDescription:


### PR DESCRIPTION
## **Why?**
Show info toast when coming back from the claim app web view
### **How?**
- Added action to be called on the back button of the web view
- Inside this 👆 callback we show the info toast
### **Testing**
Go to the claim app, use the production API to make the claim button visible, tap the back button and  move back. Make sure the toast is rendered as expected
### **Additional context**
fixes fe-905
