### PR TITLE
Extra query param in claim dapp url when navigating from

### DIFF
--- a/PresentationLayer/Constants/Strings/DisplayedLinks.swift
+++ b/PresentationLayer/Constants/Strings/DisplayedLinks.swift
@@ -111,4 +111,5 @@ enum DisplayLinkParams: String {
 	case network
 	case redirectUrl = "redirect_url"
 	case claimedAmount = "claimed_amount"
+	case embed
 }

--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
@@ -107,7 +107,7 @@ class ProfileViewModel: ObservableObject {
 
 	func handleClaimButtonTap() {
 		let url = DisplayedLinks.claimToken.linkURL
-		var params: [DisplayLinkParams: String] = [:]
+		var params: [DisplayLinkParams: String] = [.embed: String(true)]
 		if let activeTheme = MainScreenViewModel.shared.deviceActiveTheme {
 			params += [.theme: activeTheme.rawValue]
 		}


### PR DESCRIPTION
## **Why?**
`embed` param in claim app URL
### **How?**
Inserted "`embed`: `true`" in URL params of claim app
### **Testing**
Check the logs in in XCode console and make sure the query parameter is included 
### **Screenshots (if applicable)**
![Screenshot 2024-06-10 at 17 49 55](https://github.com/WeatherXM/wxm-ios/assets/10021503/7c36318e-7d23-4fdb-9f10-a03acc2e010b)
### **Additional context**
fixes fe-907
