### PR TITLE
Error title for reward boosts screen

### DIFF
--- a/PresentationLayer/Extensions/DomainExtensions/Common/NetworkErrorResponse+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/Common/NetworkErrorResponse+.swift
@@ -15,7 +15,7 @@ extension NetworkErrorResponse {
         let description: String?
 
 		#if MAIN_APP
-        func defaultFailObject(type: SuccessFailEnum, retryAction: VoidCallback?) -> FailSuccessStateObject {
+		func defaultFailObject(type: SuccessFailEnum, retryAction: VoidCallback?) -> FailSuccessStateObject {
             let obj = FailSuccessStateObject(type: type,
                                              title: title,
                                              subtitle: description?.attributedMarkdown,
@@ -51,6 +51,11 @@ extension NetworkErrorResponse {
 
         return UIInfo(title: title, description: description)
     }
+
+	func uiInfo(title: String) -> UIInfo {
+		let info = uiInfo
+		return UIInfo(title: title, description: info.description)
+	}
 }
 
 private extension FailAPICodeEnum {

--- a/PresentationLayer/UIComponents/Screens/RewardBoosts/RewardBoostsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/RewardBoosts/RewardBoostsViewModel.swift
@@ -44,7 +44,7 @@ class RewardBoostsViewModel: ObservableObject {
 					completion()
 				case .failure(let error):
 					self.state = .fail
-					self.failObj = error.uiInfo.defaultFailObject(type: .rewardDetails) {
+					self.failObj = error.uiInfo(title: LocalizableString.RewardDetails.rewardsBoostFailedTitle.localized).defaultFailObject(type: .rewardDetails) {
 						self.state = .loading
 						self.refresh {}
 					}

--- a/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
+++ b/wxm-ios/Resources/Localizable/Localizable+RewardDetails.swift
@@ -64,6 +64,7 @@ extension LocalizableString {
 		case timelineInfoDescription(String?, String)
 		case contactSupportButtonTitle
 		case unhandledBoostMessage
+		case rewardsBoostFailedTitle
 	}
 }
 
@@ -216,6 +217,8 @@ extension LocalizableString.RewardDetails: WXMLocalizable {
 				return "reward_details_contact_support_button_title"
 			case .unhandledBoostMessage:
 				return "reward_details_unhandled_boost_message"
+			case .rewardsBoostFailedTitle:
+				return "reward_details_rewards_boost_failed_title"
 		}
 	}
 }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -6040,6 +6040,17 @@
         }
       }
     },
+    "reward_details_rewards_boost_failed_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reward Boost could not be fetched"
+          }
+        }
+      }
+    },
     "reward_details_timeline_info_description_format" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## **Why?**
Dedicated title for error state in reward boosts screen
### **How?**
Added parameter for title in `UIInfo` extension of  `NetwrokErrorResponse`
### **Testing**
You can check the `SwiftUI` preview in `RewardBoostsView` file
### **Additional context**
fixes fe-887
