### PR TITLE
Add weatherxm mapbox style as env param

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,9 @@ We have a variable for Mapbox:
 You can view Mapbox guide on Access
 Token [here](https://docs.mapbox.com/help/getting-started/access-tokens/).
 
+- `MBXStyle`
+  For custom mapbox style. It's optional.
+
 ### Different Schemes
 
 We have 3 different app schemes. For each scheme a

--- a/Configuration/Debug/ConfigDebug.xcconfig-template
+++ b/Configuration/Debug/ConfigDebug.xcconfig-template
@@ -2,6 +2,10 @@
 
 MBXAccessToken = {mapbox access token};
 
+ // A trick to avoid parse issues caused form double slashes of the following urls is to add "$()" after "mapbox::/", 
+ // eg. mapbox:/$()/style/..."
+MBXStyle = {mapbox style url};
+
 UserAccessTokenService = accessTokenService;
 
 UserRefreshTokenService = refreshTokenService;

--- a/Configuration/Mock/ConfigMock.xcconfig-template
+++ b/Configuration/Mock/ConfigMock.xcconfig-template
@@ -2,6 +2,10 @@
 
 MBXAccessToken = {mapbox access token};
 
+ // A trick to avoid parse issues caused form double slashes of the following urls is to add "$()" after "mapbox::/", 
+ // eg. mapbox:/$()/style/..." 
+MBXStyle = {mapbox style url};
+
 UserAccessTokenService = accessTokenService;
 
 UserRefreshTokenService = refreshTokenService;

--- a/Configuration/Production/Config.xcconfig-template
+++ b/Configuration/Production/Config.xcconfig-template
@@ -2,6 +2,10 @@
 
 MBXAccessToken = {mapbox access token};
 
+ // A trick to avoid parse issues caused form double slashes of the following urls is to add "$()" after "mapbox::/", 
+ // eg. mapbox:/$()/style/..." 
+MBXStyle = {mapbox style url};
+
 UserAccessTokenService = accessTokenService;
 
 UserRefreshTokenService = refreshTokenService;

--- a/PresentationLayer/UIComponents/MapBox/MapBoxMapView.swift
+++ b/PresentationLayer/UIComponents/MapBox/MapBoxMapView.swift
@@ -109,11 +109,8 @@ class MapViewController: UIViewController {
 
     override public func viewDidLoad() {
         super.viewDidLoad()
-		guard let accessToken: String = Bundle.main.getConfiguration(for: .mapBoxAccessToken) else {
-            return
-        }
 
-        let myMapInitOptions = MapInitOptions(styleURI: StyleURI(rawValue: MapBoxConstants.mapBoxStyle))
+		let myMapInitOptions = MapInitOptions(styleURI: MapBoxConstants.styleURI)
 
 		mapView = MapView(frame: .zero, mapInitOptions: myMapInitOptions)
         mapView.ornaments.options.scaleBar.visibility = .hidden

--- a/PresentationLayer/Utils/MapBox/MapBoxConstants.swift
+++ b/PresentationLayer/Utils/MapBox/MapBoxConstants.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 import UIKit
+import MapboxMaps
 
 enum MapBoxConstants {
-	static let mapBoxStyle = Bundle.main.getConfiguration(for: .mapBoxStyle) ?? ""
 	static let polygonFillColor = UIColor(red: 51.0/255.0, green: 136.0/255.0, blue: 255.0/255.0, alpha: 0.5)
 	static let snapshotSize: CGSize = CGSize(width: 340.0, height: 200.0)
 	static let snapshotZoom: CGFloat = 11.0
@@ -19,4 +19,20 @@ enum MapBoxConstants {
 	static let initialLon = 23.710478235562956
 	static let heatmapLayerId = "wtxm-heatmap-layer"
 	static let heatmapSource = "heatmap"
+
+	static var styleURI: StyleURI {
+		guard let style: String = Bundle.main.getConfiguration(for: .mapBoxStyle) else {
+			return .standard
+		}
+
+		return StyleURI(rawValue: style) ?? .standard
+	}
+
+	static var styleURL: URL? {
+		guard let style: String = Bundle.main.getConfiguration(for: .mapBoxStyle) else {
+			return nil
+		}
+
+		return URL(string: style)
+	}
 }

--- a/PresentationLayer/Utils/MapBox/MapBoxConstants.swift
+++ b/PresentationLayer/Utils/MapBox/MapBoxConstants.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 enum MapBoxConstants {
-	static let mapBoxStyle = "mapbox://styles/exmachina/ckrxjh01a5e7317plznjeicao"
+	static let mapBoxStyle = Bundle.main.getConfiguration(for: .mapBoxStyle) ?? ""
 	static let polygonFillColor = UIColor(red: 51.0/255.0, green: 136.0/255.0, blue: 255.0/255.0, alpha: 0.5)
 	static let snapshotSize: CGSize = CGSize(width: 340.0, height: 200.0)
 	static let snapshotZoom: CGFloat = 11.0

--- a/PresentationLayer/Utils/MapBox/MapBoxSnapshotUrlGenerator.swift
+++ b/PresentationLayer/Utils/MapBox/MapBoxSnapshotUrlGenerator.swift
@@ -15,7 +15,7 @@ struct MapBoxSnapshotUrlGenerator {
 	let options: Options
 
 	func getUrl() -> URL? {
-		guard let styleUrl = URL(string: MapBoxConstants.mapBoxStyle),
+		guard let styleUrl = MapBoxConstants.styleURL,
 			  let accessToken: String = Bundle.main.getConfiguration(for: .mapBoxAccessToken) else {
 			return nil
 		}

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -6,6 +6,7 @@ setupConfiguration(){
 
 	echo "#include \"../Version.xcconfig\"" > $CONFIGURATION_PATH
 	echo "MBXAccessToken = ${MAPBOX_ACCESS_TOKEN};" >> $CONFIGURATION_PATH
+	echo "MBXStyle = ${MAPBOX_STYLE};" >> $CONFIGURATION_PATH
 	echo "UserAccessTokenService = accessTokenService;" >> $CONFIGURATION_PATH
 	echo "UserRefreshTokenService = refreshTokenService;" >> $CONFIGURATION_PATH
 	echo "Account = weatherXM;" >> $CONFIGURATION_PATH

--- a/wxm-ios/Info.plist
+++ b/wxm-ios/Info.plist
@@ -51,6 +51,8 @@
 	</array>
 	<key>MBXAccessToken</key>
 	<string>$(MBXAccessToken)</string>
+	<key>MBXStyle</key>
+	<string>$(MBXStyle)</string>
 	<key>MixpanelToken</key>
 	<string>$(MixpanelToken)</string>
 	<key>NSUserNotificationsUsageDescription</key>

--- a/wxm-ios/Toolkit/Toolkit/Utils/Bundle+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/Bundle+.swift
@@ -9,6 +9,7 @@ import Foundation
 
 public enum ConfigurationKey: String {
 	case mapBoxAccessToken = "MBXAccessToken"
+	case mapBoxStyle = "MBXStyle"
 	case teamId = "TeamId"
 	case apiUrl = "ApiUrl"
 	case claimTokenUrl = "ClaimTokenUrl"


### PR DESCRIPTION
## **Why?**
Inject mapbox style from configuration
### **How?**
- Declared `MBXStyle` var in. configuration files
- Updated the way we retrieve this value in the app
- Fallback to `standard` style when it's not provided
### **Testing**
Set the `MBXStyle` var in the configuration files and make sure everything is rendered as expected 
### **Additional context**
fixes fe-913
