### PR TITLE
App charts fixes

### DIFF
--- a/PresentationLayer/Constants/WeatherFields.swift
+++ b/PresentationLayer/Constants/WeatherFields.swift
@@ -98,6 +98,8 @@ extension WeatherField: CustomStringConvertible {
 		switch self {
 			case .precipitationProbability:
 				return LocalizableString.probability.localized
+			case .precipitation:
+				return LocalizableString.precipRate.localized
 			default:
 				return displayTitle
 		}
@@ -116,7 +118,7 @@ extension WeatherField: CustomStringConvertible {
 			case .windDirection:
 				return LocalizableString.windDirection.localized
             case .precipitation:
-                return LocalizableString.precipitation.localized
+                return LocalizableString.maxRate.localized
             case .precipitationProbability:
                 return LocalizableString.precipProbability.localized
             case .dailyPrecipitation:

--- a/PresentationLayer/Constants/WeatherFields.swift
+++ b/PresentationLayer/Constants/WeatherFields.swift
@@ -98,8 +98,6 @@ extension WeatherField: CustomStringConvertible {
 		switch self {
 			case .precipitationProbability:
 				return LocalizableString.probability.localized
-			case .precipitation:
-				return LocalizableString.precipRate.localized
 			default:
 				return displayTitle
 		}
@@ -118,7 +116,7 @@ extension WeatherField: CustomStringConvertible {
 			case .windDirection:
 				return LocalizableString.windDirection.localized
             case .precipitation:
-                return LocalizableString.maxRate.localized
+                return LocalizableString.precipitation.localized
             case .precipitationProbability:
                 return LocalizableString.precipProbability.localized
             case .dailyPrecipitation:

--- a/PresentationLayer/Constants/WeatherFields.swift
+++ b/PresentationLayer/Constants/WeatherFields.swift
@@ -292,7 +292,8 @@ extension WeatherField {
                                unitsManager: WeatherUnitsManager,
                                includeDirection: Bool = true,
                                isForHourlyForecast: Bool = false,
-                               shouldConvertUnits: Bool = true) -> WeatherValueLiterals? {
+                               shouldConvertUnits: Bool = true,
+							   isAccumulated: Bool = false) -> WeatherValueLiterals? {
         guard let value, !value.isNaN else {
             return nil
         }
@@ -312,6 +313,9 @@ extension WeatherField {
 			case .windDirection:
 				return nil
             case .precipitation:
+				if isAccumulated {
+					return formatter.getPrecipitationAccumulatedLiterals(from: value, unit: unitsManager.precipitationUnit)
+				}
                 return formatter.getPrecipitationLiterals(value: value, unit: unitsManager.precipitationUnit)
             case .precipitationProbability:
                 return formatter.getPrecipitationProbabilityLiterals(value: value)

--- a/PresentationLayer/UIComponents/BaseComponents/ScrollingPicker/ScrollingPagerView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/ScrollingPicker/ScrollingPagerView.swift
@@ -58,6 +58,7 @@ private struct Pager: UIViewRepresentable {
         let flowlayout = PagingCollectionViewLayout()
         flowlayout.scrollDirection = .horizontal
         flowlayout.itemSize = CGSize(width: containerSize.width / 2.0, height: 40.0)
+		flowlayout.minimumLineSpacing = 0.0
 
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowlayout)
         collectionView.register(PagerCell.self, forCellWithReuseIdentifier: cellId)

--- a/PresentationLayer/UIComponents/BaseComponents/ScrollingPicker/ScrollingPagerView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/ScrollingPicker/ScrollingPagerView.swift
@@ -20,6 +20,7 @@ struct ScrollingPickerView: View {
                       containerSize: proxy.size,
                       textCallback: textCallback,
                       countCallback: countCallback)
+				.clipped()
             }
             .frame(height: 40.0)
 

--- a/PresentationLayer/UIComponents/Screens/ForecastDetails/Components/ForecastChartTypes.swift
+++ b/PresentationLayer/UIComponents/Screens/ForecastDetails/Components/ForecastChartTypes.swift
@@ -120,4 +120,14 @@ enum ForecastChartType: String, ChartCardProtocol {
 	func highlightTitle(for weatherField: WeatherField) -> String {
 		weatherField.graphHighlightTitle
 	}
+
+	func getWeatherLiterals(chartEntry: ChartDataEntry?, weatherField: WeatherField) -> WeatherValueLiterals? {
+		let literals = weatherField.createWeatherLiterals(from: chartEntry?.y,
+														  addditonalInfo: chartEntry?.data,
+														  unitsManager: WeatherUnitsManager.default,
+														  shouldConvertUnits: false,
+														  isAccumulated: true)
+
+		return literals
+	}
 }

--- a/PresentationLayer/UIComponents/Screens/ForecastDetails/Components/ForecastChartTypes.swift
+++ b/PresentationLayer/UIComponents/Screens/ForecastDetails/Components/ForecastChartTypes.swift
@@ -112,4 +112,12 @@ enum ForecastChartType: String, ChartCardProtocol {
 				}
 		}
 	}
+
+	func legendTitle(for weatherField: WeatherField) -> String {
+		weatherField.legendTitle
+	}
+
+	func highlightTitle(for weatherField: WeatherField) -> String {
+		weatherField.graphHighlightTitle
+	}
 }

--- a/PresentationLayer/UIComponents/Screens/HistoryScreen/HistoryView/ChartCardTypes.swift
+++ b/PresentationLayer/UIComponents/Screens/HistoryScreen/HistoryView/ChartCardTypes.swift
@@ -128,4 +128,22 @@ enum ChartCardType: String, ChartCardProtocol {
 				leftAxis.axisMinimum = 0.0
 		}
 	}
+
+	func legendTitle(for weatherField: WeatherField) -> String {
+		switch weatherField {
+			case .precipitation:
+				LocalizableString.precipRate.localized
+			default:
+				weatherField.legendTitle
+		}
+	}
+
+	func highlightTitle(for weatherField: WeatherField) -> String {
+		switch weatherField {
+			case .precipitation:
+				LocalizableString.maxRate.localized
+			default:
+				weatherField.graphHighlightTitle
+		}
+	}
 }

--- a/PresentationLayer/UIComponents/Screens/HistoryScreen/HistoryView/ChartCardTypes.swift
+++ b/PresentationLayer/UIComponents/Screens/HistoryScreen/HistoryView/ChartCardTypes.swift
@@ -146,4 +146,13 @@ enum ChartCardType: String, ChartCardProtocol {
 				weatherField.graphHighlightTitle
 		}
 	}
+
+	func getWeatherLiterals(chartEntry: ChartDataEntry?, weatherField: WeatherField) -> WeatherValueLiterals? {
+		let literals = weatherField.createWeatherLiterals(from: chartEntry?.y,
+														  addditonalInfo: chartEntry?.data,
+														  unitsManager: WeatherUnitsManager.default,
+														  shouldConvertUnits: false)
+
+		return literals
+	}
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherCharts/ChartCardView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherCharts/ChartCardView.swift
@@ -91,10 +91,7 @@ private extension ChartCardView {
         let comps: [String] = chartDataModels.map { model in
 			let entry = model.entries[safe: index]
             let value = entry?.y
-            let literals = model.weatherField.createWeatherLiterals(from: value,
-                                                                    addditonalInfo: entry?.data,
-                                                                    unitsManager: unitsManager,
-                                                                    shouldConvertUnits: false)
+			let literals = type.getWeatherLiterals(chartEntry: entry, weatherField: model.weatherField)
             let formattedValue = "\(literals?.value ?? "")\(model.weatherField.shouldHaveSpaceWithUnit ? " " : "")\(literals?.unit ?? "")".trimWhiteSpaces()
 			return "\(type.highlightTitle(for: model.weatherField)): **\(formattedValue)**"
         }

--- a/PresentationLayer/UIComponents/Screens/WeatherCharts/ChartCardView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherCharts/ChartCardView.swift
@@ -70,7 +70,7 @@ private extension ChartCardView {
             ForEach(0 ..< chartDataModels.count, id: \.self) { index in
                 let model = chartDataModels[index]
                 VStack(alignment: .leading, spacing: CGFloat(.minimumSpacing)) {
-                    Text(model.weatherField.legendTitle)
+					Text(type.legendTitle(for: model.weatherField))
                         .foregroundColor(Color(colorEnum: .text))
                         .font(.system(size: CGFloat(.caption)))
                         .lineLimit(1)
@@ -96,7 +96,7 @@ private extension ChartCardView {
                                                                     unitsManager: unitsManager,
                                                                     shouldConvertUnits: false)
             let formattedValue = "\(literals?.value ?? "")\(model.weatherField.shouldHaveSpaceWithUnit ? " " : "")\(literals?.unit ?? "")".trimWhiteSpaces()
-            return "\(model.weatherField.graphHighlightTitle): **\(formattedValue)**"
+			return "\(type.highlightTitle(for: model.weatherField)): **\(formattedValue)**"
         }
         let text = comps.joined(separator: "﹒")
 

--- a/PresentationLayer/UIComponents/Screens/WeatherCharts/WeatherChartTypes.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherCharts/WeatherChartTypes.swift
@@ -16,6 +16,8 @@ protocol ChartCardProtocol: CaseIterable, CustomStringConvertible {
 	var isRightAxisEnabled: Bool { get }
 	func getAxisDependecy(for weatherField: WeatherField) -> YAxis.AxisDependency
 	func configureAxis(leftAxis: YAxis, rightAxis: YAxis, for lineData: LineChartData)
+	func legendTitle(for weatherField: WeatherField) -> String
+	func highlightTitle(for weatherField: WeatherField) -> String
 }
 
 

--- a/PresentationLayer/UIComponents/Screens/WeatherCharts/WeatherChartTypes.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherCharts/WeatherChartTypes.swift
@@ -18,6 +18,7 @@ protocol ChartCardProtocol: CaseIterable, CustomStringConvertible {
 	func configureAxis(leftAxis: YAxis, rightAxis: YAxis, for lineData: LineChartData)
 	func legendTitle(for weatherField: WeatherField) -> String
 	func highlightTitle(for weatherField: WeatherField) -> String
+	func getWeatherLiterals(chartEntry: ChartDataEntry?, weatherField: WeatherField) -> WeatherValueLiterals?
 }
 
 

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -4632,6 +4632,17 @@
         }
       }
     },
+    "max_rate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Max Rate"
+          }
+        }
+      }
+    },
     "moderate" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/LocalizableConstants.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableConstants.swift
@@ -53,6 +53,7 @@ enum LocalizableString: WXMLocalizable {
     case precipitation
     case precipitationRate
     case precipRate
+	case maxRate
     case precipitationProbability
 	case precipProbability
 	case probability
@@ -347,6 +348,8 @@ extension LocalizableString {
                 return "precipitation_rate"
             case .precipRate:
                 return "precip_rate"
+			case .maxRate:
+				return "max_rate"
             case .precipitationProbability:
                 return "precipitation_probability"
 			case .precipProbability:


### PR DESCRIPTION
## **Why?**
- Should update the legend title and highlight title for the precipitation in historical data
- UI issue in historical data screed date picker in the iPad
### **How?**
- Added one extra layer to retrieve the title for each weather field for the charts in the `ChartCardProtocol`
- Added `clipped` modifier in date picker to stop showing content outside the scroller area
### **Testing**
- Make sure the precipitation graph card is the expected in historical data screen and nothing is broken in the forecast screen
- Make sure the date picker is rendered properly in an iPad
### **Additional context**
fixes fe-910, fe-949
