### PR TITLE
Regular font weight in the temperature label

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/WeatherOverview/WeatherOverviewView+Content.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherOverview/WeatherOverviewView+Content.swift
@@ -180,7 +180,9 @@ extension WeatherOverviewView {
 	}
 
     var attributedTemperatureString: AttributedString {
-		let font = UIFont.systemFont(ofSize: temperatureFontSize, weight: .bold)
+		/// Different configuration according to the `Mode`. `.default` mode is when is presented in the main app, otherwise is widget
+		let weight: UIFont.Weight = mode == .default ? .regular : .bold
+		let font = UIFont.systemFont(ofSize: temperatureFontSize, weight: weight)
         let temperatureLiterals: WeatherValueLiterals = WeatherField.temperature.weatherLiterals(from: weather, unitsManager: unitsManager) ?? ("", "")
 
         var attributedString = AttributedString("\(temperatureLiterals.value)\(temperatureLiterals.unit)")

--- a/PresentationLayer/UIComponents/BaseComponents/WeatherOverview/WeatherOverviewView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherOverview/WeatherOverviewView.swift
@@ -70,9 +70,11 @@ struct WeatherOverviewView: View {
 
 extension WeatherOverviewView {
 	enum Mode {
+		/// Widgets
 		case minimal
 		case medium
 		case large
+		/// Main app
 		case `default`
 	}
 


### PR DESCRIPTION
## **Why?**
After some updates for the widget, by mistake the font weight of the temperature label in the main app changed
### **Testing**
Make sure the temperature label is bold in the widgets and regular in the app
### **Screenshots (if applicable)**
![Simulator Screenshot - iPhone 15 - 2024-06-25 at 09 40 58](https://github.com/WeatherXM/wxm-ios/assets/10021503/c1fad233-1f24-4189-97ec-cccbd668575b)
### **Additional context**
fixes fe-964
