### PR TITLE
UI glitch in station details

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScrollView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScrollView.swift
@@ -70,7 +70,6 @@ struct TrackableScrollView<Content>: View where Content: View {
             ScrollView(showsIndicators: false) {
                 content()
             }
-			.clipped()
             .modify { view in
                 if refreshAction != nil {
                     view.refreshable {


### PR DESCRIPTION
## **Why?**
Fixed cropped UI when the header is collapsed
### **Testing**
Make sure the UI is rendered properly
### **Screenshots (if applicable)**
The bug
![Simulator Screenshot - iPhone 15 - 2024-06-27 at 17 05 38](https://github.com/WeatherXM/wxm-ios/assets/10021503/b4dc776e-e90e-411f-96bf-34f55bba175b)
