### PR TITLE
Integrated cell center in public device

### DIFF
--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Cells/PublicDevice.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Cells/PublicDevice.swift
@@ -12,6 +12,7 @@ public struct PublicDevice: Codable {
     var isActive: Bool? = nil
     var lastWeatherStationActivity: String? = nil
     var cellIndex: String? = nil
+	var cellCenter: LocationCoordinates?
     var currentWeather: CurrentWeather? = nil
 	var bundle: StationBundle? = nil
 
@@ -22,6 +23,7 @@ public struct PublicDevice: Codable {
         case isActive
         case lastWeatherStationActivity
         case cellIndex
+		case cellCenter
         case currentWeather = "current_weather"
 		case bundle
     }

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/DeviceDetails.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/DeviceDetails.swift
@@ -76,7 +76,7 @@ extension PublicDevice {
                       label: nil,
                       address: nil,
                       cellIndex: cellIndex,
-                      cellCenter: nil,
+                      cellCenter: cellCenter,
                       isActive: isActive ?? false,
                       weather: currentWeather,
 					  timezone: timezone,


### PR DESCRIPTION
## **Why?**
Navigate to cell stations list on the address chip tap, coming from the explorer
### **How?**
Integrated the `cellCenter` property in the `PublicDevice` model
### **Testing**
Make sure the navigation works when the user comes from the explorer or the search
### **Additional context**
fixes fe-802
