### PR TITLE
Find a way to zoom inout in mac app

### DIFF
--- a/PresentationLayer/UIComponents/MapBox/MapBoxMapView.swift
+++ b/PresentationLayer/UIComponents/MapBox/MapBoxMapView.swift
@@ -223,6 +223,16 @@ class MapViewController: UIViewController {
         }
     }
 
+	func zoomIn() {
+		let zoomLevel = mapView.mapboxMap.cameraState.zoom
+		mapView.camera.fly(to: CameraOptions(zoom: zoomLevel + 1))
+	}
+
+	func zoomOut() {
+		let zoomLevel = mapView.mapboxMap.cameraState.zoom
+		mapView.camera.fly(to: CameraOptions(zoom: zoomLevel - 1))
+	}
+
     func showUserLocation() {
         mapView?.location.options.puckType = .puck2D()
     }

--- a/PresentationLayer/UIComponents/MapBox/MapBoxMapView.swift
+++ b/PresentationLayer/UIComponents/MapBox/MapBoxMapView.swift
@@ -23,40 +23,9 @@ struct MapBoxMapView: View {
 			MapBoxMap()
 				.ignoresSafeArea()
 
-			VStack {
-				Spacer()
-				HStack {
-					VStack(spacing: 0.0) {
-						Button {
-							explorerViewModel.handleZoomIn()
-						} label: {
-							Text(verbatim: "+")
-								.padding(CGFloat(.mediumSidePadding))
-						}
-						
-						Color(colorEnum: .primary)
-							.frame(height: 2.0)
-
-						Button {
-							explorerViewModel.handleZoomOut()
-						} label: {
-							Text(verbatim: "-")
-								.padding(CGFloat(.mediumSidePadding))
-						}
-					}
-					.foregroundStyle(Color(colorEnum: .primary))
-					.font(.system(size: CGFloat(.largeTitleFontSize), weight: .bold))
-					.background(Color(colorEnum: .top).cornerRadius(CGFloat(.cardCornerRadius)))
-					.strokeBorder(color: Color(colorEnum: .primary),
-								  lineWidth: 2.0,
-								  radius: CGFloat(.cardCornerRadius))
-					.fixedSize()
-
-					Spacer()
-				}
-			}
-			.padding(CGFloat(.defaultSidePadding))
-			.padding(.bottom, controlsBottomOffset)
+			if isRunningOnMac {
+				zoomControls
+			}			
 		}
 		.onChange(of: controlsBottomOffset, perform: { value in
 			print(value)
@@ -70,6 +39,44 @@ extension MapBoxMapView {
 
 		let coordinates: CLLocationCoordinate2D
 		var zoomLevel: CGFloat? = DEFAULT_SNAP_ZOOM_LEVEL
+	}
+
+	@ViewBuilder
+	var zoomControls: some View {
+		VStack {
+			Spacer()
+			HStack {
+				VStack(spacing: 0.0) {
+					Button {
+						explorerViewModel.handleZoomIn()
+					} label: {
+						Text(verbatim: "+")
+							.padding(CGFloat(.mediumSidePadding))
+					}
+
+					Color(colorEnum: .primary)
+						.frame(height: 2.0)
+
+					Button {
+						explorerViewModel.handleZoomOut()
+					} label: {
+						Text(verbatim: "-")
+							.padding(CGFloat(.mediumSidePadding))
+					}
+				}
+				.foregroundStyle(Color(colorEnum: .primary))
+				.font(.system(size: CGFloat(.largeTitleFontSize), weight: .bold))
+				.background(Color(colorEnum: .top).cornerRadius(CGFloat(.cardCornerRadius)))
+				.strokeBorder(color: Color(colorEnum: .primary),
+							  lineWidth: 2.0,
+							  radius: CGFloat(.cardCornerRadius))
+				.fixedSize()
+
+				Spacer()
+			}
+		}
+		.padding(CGFloat(.defaultSidePadding))
+		.padding(.bottom, controlsBottomOffset)
 	}
 }
 

--- a/PresentationLayer/UIComponents/MapBox/MapBoxMapView.swift
+++ b/PresentationLayer/UIComponents/MapBox/MapBoxMapView.swift
@@ -14,7 +14,24 @@ import SwiftUI
 import UIKit
 import Toolkit
 
-struct MapBoxMapView: UIViewControllerRepresentable {
+struct MapBoxMapView: View {
+	var body: some View {
+		ZStack {
+			MapBoxMap()
+		}
+	}
+}
+
+extension MapBoxMapView {
+	struct SnapLocation {
+		static let DEFAULT_SNAP_ZOOM_LEVEL: CGFloat = 11
+
+		let coordinates: CLLocationCoordinate2D
+		var zoomLevel: CGFloat? = DEFAULT_SNAP_ZOOM_LEVEL
+	}
+}
+
+private struct MapBoxMap: UIViewControllerRepresentable {
     @EnvironmentObject var explorerViewModel: ExplorerViewModel
 	private var canellables: CancellableWrapper = .init()
 
@@ -43,18 +60,9 @@ struct MapBoxMapView: UIViewControllerRepresentable {
     }
 }
 
-extension MapBoxMapView {
-	struct SnapLocation {
-		static let DEFAULT_SNAP_ZOOM_LEVEL: CGFloat = 11
-
-		let coordinates: CLLocationCoordinate2D
-		var zoomLevel: CGFloat? = DEFAULT_SNAP_ZOOM_LEVEL
-	}
-}
-
-extension MapBoxMapView {
+extension MapBoxMap {
     func makeCoordinator() -> Coordinator {
-        Coordinator(self, viewModel: explorerViewModel)
+        Coordinator(viewModel: explorerViewModel)
     }
 
     class Coordinator: NSObject, MapViewControllerDelegate {
@@ -87,7 +95,7 @@ extension MapBoxMapView {
 
         let viewModel: ExplorerViewModel
 
-        init(_ mapBoxMapView: MapBoxMapView, viewModel: ExplorerViewModel) {
+        init(viewModel: ExplorerViewModel) {
             self.viewModel = viewModel
         }
     }

--- a/PresentationLayer/UIComponents/MapBox/MapBoxMapView.swift
+++ b/PresentationLayer/UIComponents/MapBox/MapBoxMapView.swift
@@ -24,8 +24,10 @@ struct MapBoxMapView: View {
 				.ignoresSafeArea()
 
 			if isRunningOnMac {
-				zoomControls
-			}			
+				ZoomControls(controlsBottomOffset: $controlsBottomOffset,
+							 zoomOutAction: { explorerViewModel.handleZoomOut() },
+							 zoomInAction: { explorerViewModel.handleZoomIn() })
+			}
 		}
 		.onChange(of: controlsBottomOffset, perform: { value in
 			print(value)
@@ -39,44 +41,6 @@ extension MapBoxMapView {
 
 		let coordinates: CLLocationCoordinate2D
 		var zoomLevel: CGFloat? = DEFAULT_SNAP_ZOOM_LEVEL
-	}
-
-	@ViewBuilder
-	var zoomControls: some View {
-		VStack {
-			Spacer()
-			HStack {
-				VStack(spacing: 0.0) {
-					Button {
-						explorerViewModel.handleZoomIn()
-					} label: {
-						Text(verbatim: "+")
-							.padding(CGFloat(.mediumSidePadding))
-					}
-
-					Color(colorEnum: .primary)
-						.frame(height: 2.0)
-
-					Button {
-						explorerViewModel.handleZoomOut()
-					} label: {
-						Text(verbatim: "-")
-							.padding(CGFloat(.mediumSidePadding))
-					}
-				}
-				.foregroundStyle(Color(colorEnum: .primary))
-				.font(.system(size: CGFloat(.largeTitleFontSize), weight: .bold))
-				.background(Color(colorEnum: .top).cornerRadius(CGFloat(.cardCornerRadius)))
-				.strokeBorder(color: Color(colorEnum: .primary),
-							  lineWidth: 2.0,
-							  radius: CGFloat(.cardCornerRadius))
-				.fixedSize()
-
-				Spacer()
-			}
-		}
-		.padding(CGFloat(.defaultSidePadding))
-		.padding(.bottom, controlsBottomOffset)
 	}
 }
 

--- a/PresentationLayer/UIComponents/MapBox/MapBoxMapView.swift
+++ b/PresentationLayer/UIComponents/MapBox/MapBoxMapView.swift
@@ -15,9 +15,47 @@ import UIKit
 import Toolkit
 
 struct MapBoxMapView: View {
+	@Binding var controlsBottomOffset: CGFloat
+	@EnvironmentObject var explorerViewModel: ExplorerViewModel
+
 	var body: some View {
 		ZStack {
 			MapBoxMap()
+
+			VStack {
+				Spacer()
+				HStack {
+					VStack(spacing: 0.0) {
+						Button {
+							explorerViewModel.handleZoomIn()
+						} label: {
+							Text(verbatim: "+")
+								.padding(CGFloat(.defaultSidePadding))
+						}
+						
+						Color(colorEnum: .primary)
+							.frame(height: 2.0)
+
+						Button {
+							explorerViewModel.handleZoomOut()
+						} label: {
+							Text(verbatim: "-")
+								.padding(CGFloat(.defaultSidePadding))
+						}
+					}
+					.foregroundStyle(Color(colorEnum: .primary))
+					.font(.system(size: CGFloat(.largeTitleFontSize), weight: .bold))
+					.background(Color(colorEnum: .top).cornerRadius(CGFloat(.cardCornerRadius)))
+					.strokeBorder(color: Color(colorEnum: .primary),
+								  lineWidth: 2.0,
+								  radius: CGFloat(.cardCornerRadius))
+					.fixedSize()
+					.padding(.bottom, controlsBottomOffset)
+
+					Spacer()
+				}
+			}
+			.padding(CGFloat(.XLSidePadding))
 		}
 	}
 }
@@ -29,6 +67,11 @@ extension MapBoxMapView {
 		let coordinates: CLLocationCoordinate2D
 		var zoomLevel: CGFloat? = DEFAULT_SNAP_ZOOM_LEVEL
 	}
+}
+
+#Preview {
+	MapBoxMapView(controlsBottomOffset: .constant(0.0))
+		.environmentObject(ViewModelsFactory.getExplorerViewModel())
 }
 
 private struct MapBoxMap: UIViewControllerRepresentable {

--- a/PresentationLayer/UIComponents/MapBox/MapBoxMapView.swift
+++ b/PresentationLayer/UIComponents/MapBox/MapBoxMapView.swift
@@ -21,6 +21,7 @@ struct MapBoxMapView: View {
 	var body: some View {
 		ZStack {
 			MapBoxMap()
+				.ignoresSafeArea()
 
 			VStack {
 				Spacer()
@@ -30,7 +31,7 @@ struct MapBoxMapView: View {
 							explorerViewModel.handleZoomIn()
 						} label: {
 							Text(verbatim: "+")
-								.padding(CGFloat(.defaultSidePadding))
+								.padding(CGFloat(.mediumSidePadding))
 						}
 						
 						Color(colorEnum: .primary)
@@ -40,7 +41,7 @@ struct MapBoxMapView: View {
 							explorerViewModel.handleZoomOut()
 						} label: {
 							Text(verbatim: "-")
-								.padding(CGFloat(.defaultSidePadding))
+								.padding(CGFloat(.mediumSidePadding))
 						}
 					}
 					.foregroundStyle(Color(colorEnum: .primary))
@@ -50,13 +51,16 @@ struct MapBoxMapView: View {
 								  lineWidth: 2.0,
 								  radius: CGFloat(.cardCornerRadius))
 					.fixedSize()
-					.padding(.bottom, controlsBottomOffset)
 
 					Spacer()
 				}
 			}
-			.padding(CGFloat(.XLSidePadding))
+			.padding(CGFloat(.defaultSidePadding))
+			.padding(.bottom, controlsBottomOffset)
 		}
+		.onChange(of: controlsBottomOffset, perform: { value in
+			print(value)
+		})
 	}
 }
 

--- a/PresentationLayer/UIComponents/MapBox/ZoomControls.swift
+++ b/PresentationLayer/UIComponents/MapBox/ZoomControls.swift
@@ -1,0 +1,56 @@
+//
+//  ZoomControls.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 28/6/24.
+//
+
+import SwiftUI
+import Toolkit
+
+struct ZoomControls: View {
+	@Binding var controlsBottomOffset: CGFloat
+	let zoomOutAction: VoidCallback
+	let zoomInAction: VoidCallback
+
+    var body: some View {
+		VStack {
+			Spacer()
+			HStack {
+				VStack(spacing: 0.0) {
+					Button {
+						zoomInAction()
+					} label: {
+						Text(verbatim: "+")
+							.padding(CGFloat(.mediumSidePadding))
+					}
+
+					Color(colorEnum: .primary)
+						.frame(height: 2.0)
+
+					Button {
+						zoomOutAction()
+					} label: {
+						Text(verbatim: "-")
+							.padding(CGFloat(.mediumSidePadding))
+					}
+				}
+				.foregroundStyle(Color(colorEnum: .primary))
+				.font(.system(size: CGFloat(.largeTitleFontSize), weight: .bold))
+				.background(Color(colorEnum: .top).cornerRadius(CGFloat(.cardCornerRadius)))
+				.strokeBorder(color: Color(colorEnum: .primary),
+							  lineWidth: 2.0,
+							  radius: CGFloat(.cardCornerRadius))
+				.fixedSize()
+
+				Spacer()
+			}
+		}
+		.padding(CGFloat(.defaultSidePadding))
+		.padding(.bottom, controlsBottomOffset)
+    }
+}
+
+#Preview {
+    ZoomControls(controlsBottomOffset: .constant(0.0), zoomOutAction: {}, zoomInAction: {})
+}

--- a/PresentationLayer/UIComponents/Screens/Explorer/ExplorerView.swift
+++ b/PresentationLayer/UIComponents/Screens/Explorer/ExplorerView.swift
@@ -15,7 +15,7 @@ struct ExplorerView: View {
 
     var body: some View {
         ZStack {
-            MapBoxMapView()
+			MapBoxMapView(controlsBottomOffset: .constant(0.0))
                 .environmentObject(viewModel)
                 .edgesIgnoringSafeArea(.all)
             explorerContent

--- a/PresentationLayer/UIComponents/Screens/Explorer/ExplorerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/Explorer/ExplorerViewModel.swift
@@ -91,6 +91,14 @@ public final class ExplorerViewModel: ObservableObject {
 				}
 		}
 	}
+
+	func handleZoomIn() {
+		mapController?.zoomIn()
+	}
+
+	func handleZoomOut() {
+		mapController?.zoomOut()
+	}
 }
 
 private extension ExplorerViewModel {

--- a/PresentationLayer/UIComponents/Screens/LoggedInViews/LoggedInTabViewContainer.swift
+++ b/PresentationLayer/UIComponents/Screens/LoggedInViews/LoggedInTabViewContainer.swift
@@ -86,6 +86,7 @@ struct LoggedInTabViewContainer: View {
             VStack(spacing: CGFloat(.defaultSpacing)) {
                 if mainViewModel.selectedTab == .mapTab {
                     fabButtons
+						.padding(.trailing, CGFloat(.defaultSidePadding))
                 }
 
                 if mainViewModel.selectedTab == .homeTab {
@@ -94,8 +95,8 @@ struct LoggedInTabViewContainer: View {
 
 				TabBarView($mainViewModel.selectedTab, mainViewModel.isWalletMissing)
                     .opacity(isTabBarShowing ? 1 : 0)
+					.sizeObserver(size: $tabBarItemsSize)
             }
-            .sizeObserver(size: $tabBarItemsSize)
         }
     }
 }
@@ -106,7 +107,6 @@ private extension LoggedInTabViewContainer {
         ZStack {
 			MapBoxMapView(controlsBottomOffset: $tabBarItemsSize.height)
                 .environmentObject(explorerViewModel)
-                .edgesIgnoringSafeArea(.all)
                 .navigationBarHidden(true)
                 .zIndex(0)
                 .shimmerLoader(show: $explorerViewModel.isLoading)
@@ -141,7 +141,6 @@ private extension LoggedInTabViewContainer {
                 .animation(.easeIn)
             }
         }
-        .padding(CGFloat(.defaultSidePadding))
     }
 
     @ViewBuilder

--- a/PresentationLayer/UIComponents/Screens/LoggedInViews/LoggedInTabViewContainer.swift
+++ b/PresentationLayer/UIComponents/Screens/LoggedInViews/LoggedInTabViewContainer.swift
@@ -104,7 +104,7 @@ private extension LoggedInTabViewContainer {
     @ViewBuilder
     var explorer: some View {
         ZStack {
-            MapBoxMapView()
+			MapBoxMapView(controlsBottomOffset: $tabBarItemsSize.height)
                 .environmentObject(explorerViewModel)
                 .edgesIgnoringSafeArea(.all)
                 .navigationBarHidden(true)
@@ -116,28 +116,6 @@ private extension LoggedInTabViewContainer {
                     .transition(.move(edge: .top).animation(.easeIn(duration: 0.5)))
                     .zIndex(1)
             }
-
-			VStack {
-				Spacer()
-				HStack {
-					VStack {
-						Button {
-							explorerViewModel.handleZoomIn()
-						} label: {
-							Text(verbatim: "+")
-						}
-
-						Button {
-							explorerViewModel.handleZoomOut()
-						} label: {
-							Text(verbatim: "-")
-						}
-
-					}
-					Spacer()
-				}
-			}
-			.padding(CGFloat(.XLSidePadding))
         }
         .animation(.easeIn(duration: 0.4), value: explorerViewModel.showTopOfMapItems)
     }

--- a/PresentationLayer/UIComponents/Screens/LoggedInViews/LoggedInTabViewContainer.swift
+++ b/PresentationLayer/UIComponents/Screens/LoggedInViews/LoggedInTabViewContainer.swift
@@ -116,6 +116,28 @@ private extension LoggedInTabViewContainer {
                     .transition(.move(edge: .top).animation(.easeIn(duration: 0.5)))
                     .zIndex(1)
             }
+
+			VStack {
+				Spacer()
+				HStack {
+					VStack {
+						Button {
+							explorerViewModel.handleZoomIn()
+						} label: {
+							Text(verbatim: "+")
+						}
+
+						Button {
+							explorerViewModel.handleZoomOut()
+						} label: {
+							Text(verbatim: "-")
+						}
+
+					}
+					Spacer()
+				}
+			}
+			.padding(CGFloat(.XLSidePadding))
         }
         .animation(.easeIn(duration: 0.4), value: explorerViewModel.showTopOfMapItems)
     }

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		269C809C2AB9E76F005F9BD6 /* Badge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269C809B2AB9E76F005F9BD6 /* Badge.swift */; };
 		269C968A2BDBD5660035B8F1 /* Mixpanel in Frameworks */ = {isa = PBXBuildFile; productRef = 269C96892BDBD5660035B8F1 /* Mixpanel */; };
 		269E85712B0242C100BE774C /* WXMShareModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269E85702B0242C100BE774C /* WXMShareModifier.swift */; };
+		26A308EA2C2E97B5007A029A /* ZoomControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A308E92C2E97B5007A029A /* ZoomControls.swift */; };
 		26A3B3C52B178F630002F35F /* LocalizableString+Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A3B3C42B178F630002F35F /* LocalizableString+Profile.swift */; };
 		26A3B3C72B1792890002F35F /* ProfileTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A3B3C62B1792890002F35F /* ProfileTypes.swift */; };
 		26A3B3DC2B18D2480002F35F /* TabBarVisibilityHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A3B3DB2B18D2480002F35F /* TabBarVisibilityHandler.swift */; };
@@ -816,6 +817,7 @@
 		2699F5642A5C083D007DBA6F /* NetworkStatsViewModel+Factory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkStatsViewModel+Factory.swift"; sourceTree = "<group>"; };
 		269C809B2AB9E76F005F9BD6 /* Badge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Badge.swift; sourceTree = "<group>"; };
 		269E85702B0242C100BE774C /* WXMShareModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WXMShareModifier.swift; sourceTree = "<group>"; };
+		26A308E92C2E97B5007A029A /* ZoomControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomControls.swift; sourceTree = "<group>"; };
 		26A3B3C42B178F630002F35F /* LocalizableString+Profile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalizableString+Profile.swift"; sourceTree = "<group>"; };
 		26A3B3C62B1792890002F35F /* ProfileTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTypes.swift; sourceTree = "<group>"; };
 		26A3B3DB2B18D2480002F35F /* TabBarVisibilityHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarVisibilityHandler.swift; sourceTree = "<group>"; };
@@ -1649,6 +1651,7 @@
 			children = (
 				2675476C29A9181E008BCF40 /* MapBoxClaimDevice.swift */,
 				2675476D29A9181E008BCF40 /* MapBoxMapView.swift */,
+				26A308E92C2E97B5007A029A /* ZoomControls.swift */,
 			);
 			path = MapBox;
 			sourceTree = "<group>";
@@ -2925,6 +2928,7 @@
 				2674016B2A37246300E54E35 /* NetStatsChartViewModel.swift in Sources */,
 				265D2CE429D2DEB80044D032 /* NetworkDevicesInfoResponse+.swift in Sources */,
 				268028AA2AF298290031379C /* Indication.swift in Sources */,
+				26A308EA2C2E97B5007A029A /* ZoomControls.swift in Sources */,
 				266DC0132A54260900EC9E1F /* NetworkErrorResponse+.swift in Sources */,
 				26E685AF2C0619D700B972B1 /* SelectDeviceView.swift in Sources */,
 				2692D8922A4DC0BA0060CB3C /* NetworkSearchResponse+.swift in Sources */,

--- a/wxm-ios/Toolkit/Toolkit/Utils/UIDevice+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/UIDevice+.swift
@@ -83,3 +83,7 @@ public var disableAnalytics: Bool {
 	let isDisabled = UserDefaults.standard.bool(forKey: WXMAnalyticsDisabled)
 	return isPreview || isDisabled
 }
+
+public var isRunningOnMac: Bool {
+	ProcessInfo.processInfo.isMacCatalystApp
+}


### PR DESCRIPTION
## **Why?**
Added zoom controls on maps for the Mac App
### **How?**
Added zoom controls on maps presented in the app, but only for the Mac app version
### **Testing**
- Run the app on Mac and make sure everything works as expected 
- Run the app on iPhone/iPad and make sure the controls are not visible
### **Additional context**
fixes fe-641
