### PR TITLE
Profile screen not updated on wallet address change

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/CustomPicker.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/CustomPicker.swift
@@ -116,7 +116,6 @@ struct CustomPicker<Item: Equatable & Hashable>: View {
                 }
             }
         }
-		.clipped()
         .background(Color(colorEnum: .top))
         .overlay(
             RoundedRectangle(cornerRadius: 5)

--- a/PresentationLayer/UIComponents/BaseComponents/CustomSheet/BottomSheetModifier.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/CustomSheet/BottomSheetModifier.swift
@@ -118,7 +118,6 @@ extension View {
 							ScrollView(showsIndicators: false) {
 								view
 							}
-							.clipped()
 						} else {
 							view
 						}

--- a/PresentationLayer/UIComponents/BaseComponents/FailSuccess /FailView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/FailSuccess /FailView.swift
@@ -59,7 +59,6 @@ struct FailView: View {
 					// Set min height in order to keep the content centered
 					.frame(minHeight: proxy.size.height)
 				}
-				.clipped()
 			}
             .padding(.bottom, bottomButtonsSize.height)
             .environment(\.openURL, OpenURLAction { url in

--- a/PresentationLayer/UIComponents/BaseComponents/ScrollingPicker/ScrollingPagerView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/ScrollingPicker/ScrollingPagerView.swift
@@ -20,7 +20,6 @@ struct ScrollingPickerView: View {
                       containerSize: proxy.size,
                       textCallback: textCallback,
                       countCallback: countCallback)
-				.clipped()
             }
             .frame(height: 40.0)
 

--- a/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScrollView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScrollView.swift
@@ -88,7 +88,6 @@ struct TrackableScrollView<Content>: View where Content: View {
             } content: {
                 content()
             }
-			.clipped()
             .modify { view in
                 if #available(iOS 16.0, *) {
                     view.scrollContentBackground(.hidden)

--- a/PresentationLayer/UIComponents/Modifiers/DisableScrollClipModifier.swift
+++ b/PresentationLayer/UIComponents/Modifiers/DisableScrollClipModifier.swift
@@ -1,0 +1,24 @@
+//
+//  DisableScrollClipModifier.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 4/7/24.
+//
+
+import SwiftUI
+import SwiftUIIntrospect
+
+extension ScrollView {
+	func disableScrollClip() -> some View {
+		self
+			.modify { scrollView in
+				if #available(iOS 17.0, *) {
+					scrollView.scrollClipDisabled()
+				} else {
+					introspect(.scrollView, on: (.iOS(.v15, .v16))) { scrollView in
+						scrollView.clipsToBounds = false
+					}
+				}
+			}
+	}
+}

--- a/PresentationLayer/UIComponents/Screens/ChangeFrequency/SelectFrequencyView.swift
+++ b/PresentationLayer/UIComponents/Screens/ChangeFrequency/SelectFrequencyView.swift
@@ -42,7 +42,6 @@ struct SelectFrequencyView: View {
                     }
                 }
             }
-			.clipped()
 
             Spacer()
 

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceBegin/ClaimDeviceBeginView.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceBegin/ClaimDeviceBeginView.swift
@@ -52,7 +52,6 @@ struct ClaimDeviceBeginView: View {
 					.padding(.horizontal, CGFloat(.mediumSidePadding))
 					.padding(.top, CGFloat(.largeSidePadding))
 				}
-				.clipped()
 
 				Button {
 					viewModel.handleButtonTap()

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ManualSerialNumber/ManualSerialNumberView.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ManualSerialNumber/ManualSerialNumberView.swift
@@ -56,7 +56,6 @@ struct ManualSerialNumberView: View {
 					.padding(.horizontal, CGFloat(.mediumSidePadding))
 					.padding(.top, CGFloat(.largeSidePadding))
 				}
-				.clipped()
 
 				bottomButton
 			}

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ResetDevice/ResetDeviceView.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ResetDevice/ResetDeviceView.swift
@@ -38,7 +38,7 @@ struct ResetDeviceView: View {
 					}
 					.padding(.horizontal, CGFloat(.mediumSidePadding))
 					.padding(.top, CGFloat(.mediumSidePadding))
-				}.clipped()
+				}
 
 				VStack(spacing: CGFloat(.defaultSpacing)) {
 					resetToggle

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/SelectDevice/SelectDeviceView.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/SelectDevice/SelectDeviceView.swift
@@ -184,7 +184,6 @@ private extension SelectDeviceView {
 				}
 			}
 		}
-		.clipped()
 	}
 
 	@ViewBuilder

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/SerialNumber/ClaimDeviceSerialNumberView.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/SerialNumber/ClaimDeviceSerialNumberView.swift
@@ -39,7 +39,6 @@ struct ClaimDeviceSerialNumberView: View {
 					.padding(.horizontal, CGFloat(.mediumSidePadding))
 					.padding(.top, CGFloat(.largeSidePadding))
 				}
-				.clipped()
 
 				bottomButtons
 					.padding(.horizontal, CGFloat(.mediumSidePadding))

--- a/PresentationLayer/UIComponents/Screens/Explorer/Search/SearchView+Content.swift
+++ b/PresentationLayer/UIComponents/Screens/Explorer/Search/SearchView+Content.swift
@@ -155,7 +155,6 @@ extension SearchView {
                     }
                     .padding(.horizontal, 36.0)
                 }
-				.clipped()
             }
         }
     }

--- a/PresentationLayer/UIComponents/Screens/ForecastDetails/Components/ForecastDetailsDailyView.swift
+++ b/PresentationLayer/UIComponents/Screens/ForecastDetails/Components/ForecastDetailsDailyView.swift
@@ -104,6 +104,7 @@ private extension ForecastDetailsDailyView {
 							}
 						}
 					}
+					.disableScrollClip()
 					.onAppear {
 						if let index = item.initialHourlyItemIndex {
 							proxy.scrollTo(index, anchor: .leading)

--- a/PresentationLayer/UIComponents/Screens/ForecastDetails/ForecastDetailsView.swift
+++ b/PresentationLayer/UIComponents/Screens/ForecastDetails/ForecastDetailsView.swift
@@ -88,6 +88,7 @@ private extension ForecastDetailsView {
 						}
 					}
 				}
+				.disableScrollClip()
 				.onChange(of: viewModel.selectedForecastIndex) { index in
 					withAnimation {
 						proxy.scrollTo(index, anchor: .center)

--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
@@ -52,7 +52,13 @@ class ProfileViewModel: ObservableObject {
 		scrollOffsetObject = .init()
 		tabBarVisibilityHandler = TabBarVisibilityHandler(scrollOffsetObject: self.scrollOffsetObject)
 		tabBarVisibilityHandler.$isTabBarShowing.assign(to: &$isTabBarVisible)
-		
+		MainScreenViewModel.shared.$userInfo.sink { [weak self] response in
+			guard let response else {
+				return
+			}
+			self?.userInfoResponse = response
+		}.store(in: &cancellableSet)
+
 		updateRewards()
 
 		MainScreenViewModel.shared.$isWalletMissing.assign(to: &$showMissingWalletError)

--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
@@ -57,6 +57,9 @@ class ProfileViewModel: ObservableObject {
 				return
 			}
 			self?.userInfoResponse = response
+			Task { [weak self] in
+				await self?.fetchUserRewards()
+			}
 		}.store(in: &cancellableSet)
 
 		updateRewards()
@@ -192,6 +195,9 @@ private extension ProfileViewModel {
 		do {
 			let userRewardsResponse = try await meUseCase.getUserRewards(wallet: address).toAsync()
 			if let error = userRewardsResponse.error {
+				if error.backendError?.code == FailAPICodeEnum.walletAddressNotFound.rawValue {
+					self.userRewardsResponse = nil
+				}
 				return error
 			}
 

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
@@ -89,19 +89,11 @@ private extension StationForecastView {
 						}
 					}.padding(.horizontal)
 				}
-
+				.disableScrollClip()
 			}
 		} else {
 			EmptyView()
 		}
-	}
-}
-
-/// Hack to disable clipping in hourly items scroll view
-private extension UIScrollView {
-	open override var clipsToBounds: Bool {
-		get { true }
-		set {}
 	}
 }
 

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
@@ -49,8 +49,7 @@ struct StationForecastView: View {
 							.padding(.horizontal)
 						}
 						.padding(.bottom)
-                    }
-					.clipped()
+                    }					
 					.iPadMaxWidth()
 					.padding(.vertical)
                 }

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		2612AC482AB49E4000285896 /* Filters+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2612AC472AB49E4000285896 /* Filters+.swift */; };
 		261672472BB310D9009C3DB1 /* WXMRemoteImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261672462BB310D9009C3DB1 /* WXMRemoteImageView.swift */; };
 		261729CD2C32CF7700A1CEFA /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261729CC2C32CF7700A1CEFA /* Haptics.swift */; };
+		261729F42C36A14C00A1CEFA /* SwiftUIIntrospect in Frameworks */ = {isa = PBXBuildFile; productRef = 261729F32C36A14C00A1CEFA /* SwiftUIIntrospect */; };
+		261729F62C36A1AB00A1CEFA /* DisableScrollClipModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261729F52C36A1AB00A1CEFA /* DisableScrollClipModifier.swift */; };
 		2618A6E72A1E440F00983B7B /* ExplorerLocationError+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618A6E62A1E440F00983B7B /* ExplorerLocationError+.swift */; };
 		2618A7142A20FFCA00983B7B /* MultipleAlertsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618A7132A20FFCA00983B7B /* MultipleAlertsView.swift */; };
 		2618A7162A21014200983B7B /* AlertsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618A7152A21014200983B7B /* AlertsViewModel.swift */; };
@@ -563,6 +565,7 @@
 		2612AC472AB49E4000285896 /* Filters+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Filters+.swift"; sourceTree = "<group>"; };
 		261672462BB310D9009C3DB1 /* WXMRemoteImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WXMRemoteImageView.swift; sourceTree = "<group>"; };
 		261729CC2C32CF7700A1CEFA /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
+		261729F52C36A1AB00A1CEFA /* DisableScrollClipModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisableScrollClipModifier.swift; sourceTree = "<group>"; };
 		2618A6E62A1E440F00983B7B /* ExplorerLocationError+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ExplorerLocationError+.swift"; sourceTree = "<group>"; };
 		2618A7132A20FFCA00983B7B /* MultipleAlertsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleAlertsView.swift; sourceTree = "<group>"; };
 		2618A7152A21014200983B7B /* AlertsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertsViewModel.swift; sourceTree = "<group>"; };
@@ -1004,6 +1007,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				264DD4CA2B9B169E002691FF /* NukeUI in Frameworks */,
+				261729F42C36A14C00A1CEFA /* SwiftUIIntrospect in Frameworks */,
 				261E9EB829A92BE000E8EBA3 /* Alamofire in Frameworks */,
 				261E9EAA29A927BE00E8EBA3 /* CodeScanner in Frameworks */,
 				B5799E9F28254E3300FEBB85 /* DataLayer.framework in Frameworks */,
@@ -1492,6 +1496,7 @@
 				264CDE0E2B5A8817004C8F39 /* ReceiveNotificationsModifier.swift */,
 				269E85702B0242C100BE774C /* WXMShareModifier.swift */,
 				266B01E42B8767E4007AC689 /* StationIndication.swift */,
+				261729F52C36A1AB00A1CEFA /* DisableScrollClipModifier.swift */,
 			);
 			path = Modifiers;
 			sourceTree = "<group>";
@@ -2524,6 +2529,7 @@
 				26FFAD672B8DF9C200BF0A6B /* LazyLoadingPager */,
 				264DD4C92B9B169E002691FF /* NukeUI */,
 				269C96892BDBD5660035B8F1 /* Mixpanel */,
+				261729F32C36A14C00A1CEFA /* SwiftUIIntrospect */,
 			);
 			productName = "wxm-ios";
 			productReference = B52BCC712824FB8F00EA3DA5 /* WeatherXM.app */;
@@ -2572,6 +2578,7 @@
 				26FFAD662B8DF9C200BF0A6B /* XCRemoteSwiftPackageReference "LazyLoadingPager" */,
 				264DD4C82B9B169D002691FF /* XCRemoteSwiftPackageReference "Nuke" */,
 				269C96882BDBD5660035B8F1 /* XCRemoteSwiftPackageReference "mixpanel-swift" */,
+				261729F22C36A14C00A1CEFA /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 			);
 			productRefGroup = B52BCC722824FB8F00EA3DA5 /* Products */;
 			projectDirPath = "";
@@ -3096,6 +3103,7 @@
 				267547ED29A9181E008BCF40 /* WebView.swift in Sources */,
 				2623FF932AF14B4E00BCDAC6 /* RewardDetailsViewModel.swift in Sources */,
 				267EC4292A98C3D300F2C37E /* WXMAlertModifier.swift in Sources */,
+				261729F62C36A1AB00A1CEFA /* DisableScrollClipModifier.swift in Sources */,
 				267EC42A2A98C3D300F2C37E /* WXMAlertView.swift in Sources */,
 				26AA21C22BF36B0100B91A7C /* SNValidator.swift in Sources */,
 				26A5456A2C0609D90098FE52 /* ResetDeviceView.swift in Sources */,
@@ -3716,6 +3724,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		261729F22C36A14C00A1CEFA /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/siteline/SwiftUI-Introspect.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.2.0;
+			};
+		};
 		261E9E9B29A925D500E8EBA3 /* XCRemoteSwiftPackageReference "PullableScrollView" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pantelisss/PullableScrollView.git";
@@ -3823,6 +3839,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		261729F32C36A14C00A1CEFA /* SwiftUIIntrospect */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 261729F22C36A14C00A1CEFA /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
+			productName = SwiftUIIntrospect;
+		};
 		261E9E9C29A925D500E8EBA3 /* PullableScrollView */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 261E9E9B29A925D500E8EBA3 /* XCRemoteSwiftPackageReference "PullableScrollView" */;

--- a/wxm-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/wxm-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a3420f86d59cf4e7b580d594f9d47c7b6472948b6716a45a4e8ad28b748bc191",
+  "originHash" : "7c534e77b1622df0443bcb7659d1beab8735d467d0364bb35ca24ee6ccef6fac",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/twostraws/CodeScanner",
       "state" : {
-        "revision" : "944a6a1ca030dbd890e647a678e718fc2115d35c",
-        "version" : "2.4.1"
+        "revision" : "34da57fb63b47add20de8a85da58191523ccce57",
+        "version" : "2.5.0"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke.git",
       "state" : {
-        "revision" : "8e431251dea0081b6ab154dab61a6ec74e4b6577",
-        "version" : "12.6.0"
+        "revision" : "311016d972aa751ae8ab0cd5897422ebe7db0501",
+        "version" : "12.7.3"
       }
     },
     {
@@ -281,12 +281,21 @@
       }
     },
     {
+      "identity" : "swiftui-introspect",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
+      "state" : {
+        "revision" : "668a65735751432b640260c56dfa621cec568368",
+        "version" : "1.2.0"
+      }
+    },
+    {
       "identity" : "swinject",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Swinject/Swinject",
       "state" : {
-        "revision" : "c7920e1f2b237ee16150ab82388d7411b578d355",
-        "version" : "2.8.7"
+        "revision" : "be9dbcc7b86811bc131539a20c6f9c2d3e56919f",
+        "version" : "2.9.1"
       }
     },
     {

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/MeRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/MeRepositoryImpl.swift
@@ -46,8 +46,7 @@ public struct MeRepositoryImpl: MeRepository {
     }
 
     public func saveUserWallet(address: String) throws -> AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never> {
-        let urlRequest = try MeApiRequestBuilder.saveUserWallet(address: address).asURLRequest()
-        return ApiClient.shared.requestCodableAuthorized(urlRequest)
+		return try userInfoService.saveUserWallet(address: address)
     }
 
 	public func getCachedDevices() -> [NetworkDevicesResponse]? {

--- a/wxm-ios/DataLayer/UserInfoService.swift
+++ b/wxm-ios/DataLayer/UserInfoService.swift
@@ -43,6 +43,18 @@ public class UserInfoService {
 		return publisher
 	}
 
+	public func saveUserWallet(address: String) throws -> AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never> {
+		let urlRequest = try MeApiRequestBuilder.saveUserWallet(address: address).asURLRequest()
+		let publisher: AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never> = ApiClient.shared.requestCodableAuthorized(urlRequest)
+		return publisher.flatMap { [weak self] response in
+			if response.error == nil {
+				_ = try? self?.getUser()
+			}
+			return Just(response)
+		}
+		.eraseToAnyPublisher()
+	}
+
 	public func getLatestUserInfoPublisher() -> AnyPublisher<NetworkUserInfoResponse?, Never> {
 		userInfoSubject.eraseToAnyPublisher()
 	}


### PR DESCRIPTION
## **Why?**
Profile tab isn't synced once you change the wallet address from "My Wallet" screen
### **How?**
- Moved the save wallet address functionality to `UserInfoService` in order to keep the user info sync once the wallet request is successful
- Observe changes in user's model in `ProfileViewModel`
One more fix is to refactor the way we clip content in scroll views. Everything started for the issue of th screenshot
### **Testing**
- Make sure the content in profile tab are synced once you change the wallet address
- Make sure the issue of the screenshot is fixed
### **Screenshots (if applicable)**
![IMG_D3D83327E460-1](https://github.com/WeatherXM/wxm-ios/assets/10021503/505ab94d-4e71-404b-8d2d-6a25bf5ca7ec)
### **Additional context**
fixes fe-915
