### PR TITLE
Updated units style in last active string

### DIFF
--- a/PresentationLayer/Extensions/Common/String+Common.swift
+++ b/PresentationLayer/Extensions/Common/String+Common.swift
@@ -29,7 +29,7 @@ extension String {
 
 		let relativeDateFormatter = RelativeDateTimeFormatter()
 		relativeDateFormatter.locale = Locale(identifier: "en_US_POSIX")
-		relativeDateFormatter.unitsStyle = .full
+		relativeDateFormatter.unitsStyle = .short
 
 		if minutes <= 1 {
 			relativeDate = LocalizableString.justNow.localized


### PR DESCRIPTION
## **Why?**
Show the last active string for stations in short format (eg 2 min. instead of 2 minutes)
### **How?**
Changed the unit style of the formatter
### **Testing**
Make sure the status chip is rendered as described above
### **Additional context**
fixes fe-982
