### PR TITLE
QR code scanner needs to be the shape of code 128 barcode

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/Scanner/ScannerOverlayView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/Scanner/ScannerOverlayView.swift
@@ -7,8 +7,8 @@
 
 import SwiftUI
 
-struct QrScannerView: View {
-    let qrSquareDimensions: CGFloat = 300
+struct ScannerOverlayView: View {
+	var layout: Layout = .square
     let backgroundOpacity: CGFloat = 0.5
     let lineOpacity: CGFloat = 0.4
     let lineHeight: CGFloat = 1
@@ -37,13 +37,14 @@ struct QrScannerView: View {
     var qrBox: some View {
 		GeometryReader { proxy in
 			ZStack {
+				let frameSize = frameSize(containerSize: proxy.size)
 				Rectangle()
-					.frame(width: proxy.size.width / 2.0,
-						   height: proxy.size.width / 2.0)
+					.frame(width: frameSize.width,
+						   height: frameSize.height)
 					.blendMode(.destinationOut)
 				Rectangle()
 					.fill(Color.red.opacity(lineOpacity))
-					.frame(width: proxy.size.width / 2.0, height: lineHeight)
+					.frame(width: frameSize.width, height: lineHeight)
 			}
 			.position(x: proxy.size.width / 2.0, y: proxy.size.height / 2.0)
 		}
@@ -58,8 +59,24 @@ struct QrScannerView: View {
 			.padding(CGFloat(.defaultSidePadding))
 			.fixedSize(horizontal: false, vertical: true)
     }
+
+	func frameSize(containerSize: CGSize) -> CGSize {
+		switch layout {
+			case .rectangle:
+				CGSize(width: 3.0 * containerSize.width / 4.0, height: containerSize.width / 4.0)
+			case .square:
+				CGSize(width: containerSize.width / 2.0, height: containerSize.width / 2.0)
+		}
+	}
+}
+
+extension ScannerOverlayView {
+	enum Layout {
+		case rectangle
+		case square
+	}
 }
 
 #Preview {
-	QrScannerView()
+	ScannerOverlayView(layout: .rectangle)
 }

--- a/PresentationLayer/UIComponents/BaseComponents/Scanner/ScannerView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/Scanner/ScannerView.swift
@@ -19,7 +19,7 @@ struct ScannerView: View {
 		if #available(iOS 16.0, *) {
 			Scanner(mode: mode, completion: completion)
 		} else {
-			CodeScannerView(codeTypes: [mode.toMetadataObjectType]) { result in
+			CodeScannerView(codeTypes: mode.toMetadataObjectTypes) { result in
 				switch result {
 					case .success(let input):
 						completion(input.string)
@@ -47,12 +47,14 @@ extension ScannerView {
 			}
 		}
 
-		var toMetadataObjectType: AVMetadataObject.ObjectType {
+		var toMetadataObjectTypes: [AVMetadataObject.ObjectType] {
 			switch self {
 				case .qr:
-						.qr
+					[.qr]
 				case .barcode:
-						.code128
+					[.code128, .ean8, .ean13]
+			}
+		}
 
 		var overlayLayout: ScannerOverlayView.Layout {
 			switch self {
@@ -133,8 +135,8 @@ private class DataScannerWrapperViewController: UIViewController {
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		let controller = DataScannerViewController(recognizedDataTypes: [mode.toBarcodeSymbology],
-												   qualityLevel: .fast,
-												   isHighFrameRateTrackingEnabled: false,
+												   qualityLevel: .accurate,
+												   isHighFrameRateTrackingEnabled: true,
 												   isPinchToZoomEnabled: false,
 												   isGuidanceEnabled: false)
 		scannerController = controller

--- a/PresentationLayer/UIComponents/BaseComponents/Scanner/ScannerView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/Scanner/ScannerView.swift
@@ -27,7 +27,7 @@ struct ScannerView: View {
 						completion(nil)
 				}
 			}
-			.overlay(QrScannerView())
+			.overlay(ScannerOverlayView(layout: mode.overlayLayout))
 		}
     }
 }
@@ -53,6 +53,13 @@ extension ScannerView {
 						.qr
 				case .barcode:
 						.code128
+
+		var overlayLayout: ScannerOverlayView.Layout {
+			switch self {
+				case .qr:
+						.square
+				case .barcode:
+						.rectangle
 			}
 		}
 	}
@@ -145,7 +152,7 @@ private class DataScannerWrapperViewController: UIViewController {
 
 		controller.didMove(toParent: self)
 
-		let overlayVC = UIHostingController(rootView: QrScannerView())
+		let overlayVC = UIHostingController(rootView: ScannerOverlayView(layout: mode.overlayLayout))
 		controller.addChild(overlayVC)
 		overlayVC.view.translatesAutoresizingMaskIntoConstraints = false
 		overlayVC.view.backgroundColor = .clear
@@ -167,18 +174,34 @@ private class DataScannerWrapperViewController: UIViewController {
 		
 		// Position of the region of interest is a rectangle at the center of the view
 		let viewBounds = scannerController?.view.bounds ?? .zero
-		let region = CGRect(x: viewBounds.width / 4.0,
-							y: 3.0 * viewBounds.height / 8.0,
-							width: viewBounds.width / 2.0,
-							height: viewBounds.width / 2.0)
+		let region = regionRect(viewBounds: viewBounds)
 		scannerController?.regionOfInterest = region
 		
 		if scannerController?.isScanning == false {
 			try? scannerController?.startScanning()
 		}
 	}
+
+	func regionRect(viewBounds: CGRect) -> CGRect {
+		switch mode {
+			case .qr:
+				let region = CGRect(x: viewBounds.width / 4.0,
+									y: 3.0 * viewBounds.height / 8.0,
+									width: viewBounds.width / 2.0,
+									height: viewBounds.width / 2.0)
+
+				return region
+			case .barcode:
+				let region = CGRect(x: viewBounds.width / 8.0,
+									y: viewBounds.height / 2.0 - viewBounds.width / 8.0,
+									width: 3.0 * viewBounds.width / 4.0,
+									height: viewBounds.width / 4.0)
+
+				return region
+		}
+	}
 }
 
 #Preview {
-	ScannerView(mode: .qr) { _ in }
+	ScannerView(mode: .barcode) { _ in }
 }

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ManualSerialNumber/ManualSerialNumberTypes.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ManualSerialNumber/ManualSerialNumberTypes.swift
@@ -72,6 +72,20 @@ enum SerialNumberInputType: RawRepresentable, CustomStringConvertible {
 					.asciiCapable
 		}
 	}
+
+	var autocapitalizationType: UITextAutocapitalizationType {
+		switch self {
+			case .claimingKey:
+					.none
+			case .serialNumber(let deviceType):
+				switch deviceType {
+					case .m5, .d1:
+							.none
+					case .pulse:
+							.allCharacters
+				}
+		}
+	}
 }
 
 struct SerialNumberInputField: Identifiable {

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ManualSerialNumber/ManualSerialNumberView.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ManualSerialNumber/ManualSerialNumberView.swift
@@ -127,7 +127,7 @@ private extension ManualSerialNumberView {
 					tf.textColor = UIColor(colorEnum: .text)
 					tf.prefix = inputField.type.prefix
 					tf.autocorrectionType = .no
-					tf.autocapitalizationType = .none
+					tf.autocapitalizationType = inputField.type.autocapitalizationType
 					tf.backgroundColor = .clear
 				}
 			)

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ManualSerialNumber/ManualSerialNumberViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ManualSerialNumber/ManualSerialNumberViewModel.swift
@@ -76,9 +76,11 @@ class ManualSerialNumberViewModel: ObservableObject {
 						return false
 					case .pulse:
 						if let range = Range(range, in: textfield.text ?? ""),
-						   let newString = textfield.text?.replacingCharacters(in: range, with: text) {
-							return validator?.validateSerialNumberInput(input: newString) ?? true
+						   let newString = textfield.text?.replacingCharacters(in: range, with: text),
+						   validator?.validateSerialNumberInput(input: newString) ?? true {
+							textfield.text = newString.uppercased()
 						}
+						
 						return false
 				}
 		}

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/UITextField+StationSerialNumber.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/UITextField+StationSerialNumber.swift
@@ -11,7 +11,6 @@ extension UITextField {
     private static let PLACEHOLDER_CHARACTER = " "
     private static let SEPARATOR_CHARACTER = ":"
     private static let DISALLOWED_CHARACTERS_REGEX = "[^0-9|A-F|a-f|:]"
-    private static let MONOSPACE_FONT_NAME = "Menlo-Regular"
 
     private static var textFieldAddTrailingCharacters = NSHashTable<UITextField>.weakObjects()
     var addTrailingCharacters: Bool {
@@ -112,13 +111,6 @@ extension UITextField {
                 )
             }
         }
-    }
-
-    func configureForSerialNumber() {
-        // Monospaced font used here for an improved editing experience.
-        font = UIFont(name: Self.MONOSPACE_FONT_NAME, size: FontSizeEnum.mediumFontSize.sizeValue)
-        autocorrectionType = .no
-        autocapitalizationType = .none
     }
 
     static func formatAsSerialNumber(

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -205,7 +205,7 @@
 		267547ED29A9181E008BCF40 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2675473029A9181E008BCF40 /* WebView.swift */; };
 		267547F629A9181E008BCF40 /* TrackableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2675473C29A9181E008BCF40 /* TrackableScrollView.swift */; };
 		267547F729A9181E008BCF40 /* FailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2675473D29A9181E008BCF40 /* FailView.swift */; };
-		267547F829A9181E008BCF40 /* QrScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2675473E29A9181E008BCF40 /* QrScannerView.swift */; };
+		267547F829A9181E008BCF40 /* ScannerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2675473E29A9181E008BCF40 /* ScannerOverlayView.swift */; };
 		267547FB29A9181E008BCF40 /* WeatherStationCard+Content.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2675474229A9181E008BCF40 /* WeatherStationCard+Content.swift */; };
 		267547FC29A9181E008BCF40 /* WeatherStationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2675474329A9181E008BCF40 /* WeatherStationCard.swift */; };
 		267547FD29A9181E008BCF40 /* CardWarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2675474429A9181E008BCF40 /* CardWarningView.swift */; };
@@ -730,7 +730,7 @@
 		2675473029A9181E008BCF40 /* WebView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 		2675473C29A9181E008BCF40 /* TrackableScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackableScrollView.swift; sourceTree = "<group>"; };
 		2675473D29A9181E008BCF40 /* FailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FailView.swift; sourceTree = "<group>"; };
-		2675473E29A9181E008BCF40 /* QrScannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QrScannerView.swift; sourceTree = "<group>"; };
+		2675473E29A9181E008BCF40 /* ScannerOverlayView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScannerOverlayView.swift; sourceTree = "<group>"; };
 		2675474229A9181E008BCF40 /* WeatherStationCard+Content.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WeatherStationCard+Content.swift"; sourceTree = "<group>"; };
 		2675474329A9181E008BCF40 /* WeatherStationCard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeatherStationCard.swift; sourceTree = "<group>"; };
 		2675474429A9181E008BCF40 /* CardWarningView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardWarningView.swift; sourceTree = "<group>"; };
@@ -1904,7 +1904,7 @@
 			isa = PBXGroup;
 			children = (
 				26A308F82C2EE481007A029A /* ScannerView.swift */,
-				2675473E29A9181E008BCF40 /* QrScannerView.swift */,
+				2675473E29A9181E008BCF40 /* ScannerOverlayView.swift */,
 			);
 			path = Scanner;
 			sourceTree = "<group>";
@@ -2990,7 +2990,7 @@
 				2675480529A9181E008BCF40 /* ProgressBarStyle.swift in Sources */,
 				26BE25B62C244ED200799CB3 /* ClaimPulseContainerViewModel.swift in Sources */,
 				26F149E92BDFEAFA0029F981 /* ClaimDeviceContainerView.swift in Sources */,
-				267547F829A9181E008BCF40 /* QrScannerView.swift in Sources */,
+				267547F829A9181E008BCF40 /* ScannerOverlayView.swift in Sources */,
 				26A4118529BA1E1E00A2C10B /* RebootStationView.swift in Sources */,
 				26A4118729BA1E7000A2C10B /* RebootStationViewModel.swift in Sources */,
 				2675481C29A9181E008BCF40 /* RegisterView.swift in Sources */,


### PR DESCRIPTION
## **Why?**
Fixes and improvements in QR scanning and serial number entry
### **How?**
- Rectangle region of interest area for barcode
- Force capitalize serial number while typing
### **Testing**
- Make sure the frame in the camera is rectangle when scanning for barcode and square when scanning for QR
- Make sure the Pulse manual serial number entry is force capitalized
### **Additional context**
fixes fe-998, fe-999
