### PR TITLE
Analytics issue with token claiming result

### DIFF
--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
@@ -144,11 +144,12 @@ class ProfileViewModel: ObservableObject {
 		}
 
 		let callback: DeepLinkHandler.QueryParamsCallBack = { [weak self] params in
-			WXMAnalytics.shared.trackEvent(.viewContent, parameters: [.contentName: .tokenClaimingResult,
-																	  .state: .success])
-
 			if let amount = params?[DisplayLinkParams.claimedAmount.rawValue] {
 				self?.updateRewards(additionalClaimed: amount)
+
+				// We consider there is a successful claim
+				WXMAnalytics.shared.trackEvent(.viewContent, parameters: [.contentName: .tokenClaimingResult,
+																		  .state: .success])
 			}
 		}
 

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -3743,7 +3743,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/siteline/SwiftUI-Introspect.git";
 			requirement = {
-				kind = upToNextMajorVersion;
+				kind = upToNextMinorVersion;
 				minimumVersion = 1.2.0;
 			};
 		};

--- a/wxm-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/wxm-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2e1757b868b2ea300e7b04bccd6eae91d5cc6123cb74533ce9e854987c6482ea",
+  "originHash" : "f4728abbf49d30b601989f2eaae6cabf86ecad62c6ce274c3421cb03fb3ba9c7",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -13,7 +13,7 @@
     {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "location" : "https://github.com/Alamofire/Alamofire",
       "state" : {
         "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
         "version" : "5.9.1"
@@ -38,12 +38,30 @@
       }
     },
     {
+      "identity" : "codescanner",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/twostraws/CodeScanner",
+      "state" : {
+        "revision" : "34da57fb63b47add20de8a85da58191523ccce57",
+        "version" : "2.5.0"
+      }
+    },
+    {
       "identity" : "firebase-ios-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "e57841b296d04370ea23580f908881b0ccab17b9",
-        "version" : "10.28.1"
+        "revision" : "eca84fd638116dd6adb633b5a3f31cc7befcbb7d",
+        "version" : "10.29.0"
+      }
+    },
+    {
+      "identity" : "flanimatedimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Flipboard/FLAnimatedImage",
+      "state" : {
+        "revision" : "d4f07b6f164d53c1212c3e54d6460738b1981e9f",
+        "version" : "1.0.17"
       }
     },
     {
@@ -110,12 +128,39 @@
       }
     },
     {
+      "identity" : "iqkeyboardmanager",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hackiftekhar/IQKeyboardManager.git",
+      "state" : {
+        "revision" : "c00b1ae9fa1ad8af4465bb6ca901f6943fc98eba",
+        "version" : "6.5.16"
+      }
+    },
+    {
+      "identity" : "lazyloadingpager",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/WeatherXM/LazyLoadingPager",
+      "state" : {
+        "revision" : "6c3573a3eabb7692b841061b5f3f14c14e50bb27",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "leveldb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/leveldb.git",
       "state" : {
         "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
         "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "lottie-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/airbnb/lottie-ios.git",
+      "state" : {
+        "revision" : "fe4c6fe3a0aa66cdeb51d549623c82ca9704b9a5",
+        "version" : "4.5.0"
       }
     },
     {
@@ -132,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-core-maps-ios.git",
       "state" : {
-        "revision" : "5d5d126c7a0f743b05c8889437e788fdd2356308",
-        "version" : "11.5.0"
+        "revision" : "33c88427d47dc075aa1bff8e088570110a19ed1a",
+        "version" : "11.5.1"
       }
     },
     {
@@ -141,8 +186,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-maps-ios/",
       "state" : {
-        "revision" : "692d783e92077d34af0a766b57cd4c85e341db61",
-        "version" : "11.5.0"
+        "revision" : "3d063d661ea969be5a0f1cf8fde5461597911924",
+        "version" : "11.5.1"
+      }
+    },
+    {
+      "identity" : "mapboxstatic.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mapbox/MapboxStatic.swift",
+      "state" : {
+        "revision" : "886e17c242fe9f573ab6c27871a26c0795400017",
+        "version" : "0.12.0"
       }
     },
     {
@@ -164,12 +218,39 @@
       }
     },
     {
+      "identity" : "nuke",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Nuke.git",
+      "state" : {
+        "revision" : "0ead44350d2737db384908569c012fe67c421e4d",
+        "version" : "12.8.0"
+      }
+    },
+    {
+      "identity" : "polyline",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/raphaelmor/Polyline.git",
+      "state" : {
+        "revision" : "353f80378dcd8f17eefe8550090c6b1ae3c9da23",
+        "version" : "5.1.0"
+      }
+    },
+    {
       "identity" : "promises",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
         "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
         "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "pullablescrollview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pantelisss/PullableScrollView.git",
+      "state" : {
+        "revision" : "da9d37dc041c2554a7ea163f6bdc5b5d3027cc99",
+        "version" : "1.0.1"
       }
     },
     {
@@ -204,8 +285,26 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "9f0c76544701845ad98716f3f6a774a892152bcb",
-        "version" : "1.26.0"
+        "revision" : "d57a5aecf24a25b32ec4a74be2f5d0a995a47c4b",
+        "version" : "1.27.0"
+      }
+    },
+    {
+      "identity" : "swiftui-introspect",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
+      "state" : {
+        "revision" : "668a65735751432b640260c56dfa621cec568368",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swinject",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Swinject/Swinject",
+      "state" : {
+        "revision" : "be9dbcc7b86811bc131539a20c6f9c2d3e56919f",
+        "version" : "2.9.1"
       }
     },
     {
@@ -215,6 +314,15 @@
       "state" : {
         "revision" : "213050191cfcb3d5aa76e1fa90c6ff1e182a42ca",
         "version" : "2.8.0"
+      }
+    },
+    {
+      "identity" : "veil",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/DanielCardonaRojas/Veil",
+      "state" : {
+        "revision" : "967a2f103972ce5043e28f1920330ee934bcbadc",
+        "version" : "0.2.0"
       }
     },
     {


### PR DESCRIPTION
## **Why?**
The success event used to be tracked on every redirect invocation
### **How?**
We track the event only when the redirect url contains the `claimed_amount` parameter 
### **Testing**
Make sure the event is triggered only when the user taps on the `Done` button after a successful claim.
You can run on a real device and add a breakpoint in `ProfileViewModel` ln151 and make sure the debug stops only in the case mentioned above
### **Additional context**
fixes fe-1026
