### PR TITLE
User properties enhancements with owned stations and wallet

### DIFF
--- a/PresentationLayer/Utils/Weather/WeatherUnitsManager.swift
+++ b/PresentationLayer/Utils/Weather/WeatherUnitsManager.swift
@@ -22,6 +22,7 @@ class WeatherUnitsManager: ObservableObject {
 
 	init(mainUseCase: MainUseCase) {
 		self.mainUseCase = mainUseCase
+		setWeatherUnitsAnalytics()
 	}
 
 	var temperatureUnit: TemperatureUnitsEnum {
@@ -31,7 +32,7 @@ class WeatherUnitsManager: ObservableObject {
 
 		set {
 			mainUseCase.saveOrUpdateWeatherMetric(unitProtocol: newValue)
-			WXMAnalytics.shared.setUserProperty(key: .temperature, value: temperatureUnit.analyticsValue)
+			setWeatherUnitsAnalytics()
 		}
 	}
 
@@ -42,7 +43,7 @@ class WeatherUnitsManager: ObservableObject {
 
 		set {
 			mainUseCase.saveOrUpdateWeatherMetric(unitProtocol: newValue)
-			WXMAnalytics.shared.setUserProperty(key: .precipitation, value: precipitationUnit.analyticsValue)
+			setWeatherUnitsAnalytics()
 		}
 	}
 
@@ -53,7 +54,7 @@ class WeatherUnitsManager: ObservableObject {
 
 		set {
 			mainUseCase.saveOrUpdateWeatherMetric(unitProtocol: newValue)
-			WXMAnalytics.shared.setUserProperty(key: .wind, value: windSpeedUnit.analyticsValue)
+			setWeatherUnitsAnalytics()
 		}
 	}
 
@@ -64,7 +65,7 @@ class WeatherUnitsManager: ObservableObject {
 
 		set {
 			mainUseCase.saveOrUpdateWeatherMetric(unitProtocol: newValue)
-			WXMAnalytics.shared.setUserProperty(key: .windDirection, value: windDirectionUnit.analyticsValue)
+			setWeatherUnitsAnalytics()
 		}
 	}
 
@@ -75,7 +76,7 @@ class WeatherUnitsManager: ObservableObject {
 
 		set {
 			mainUseCase.saveOrUpdateWeatherMetric(unitProtocol: newValue)
-			WXMAnalytics.shared.setUserProperty(key: .pressure, value: pressureUnit.analyticsValue)
+			setWeatherUnitsAnalytics()
 		}
 	}
 
@@ -122,5 +123,15 @@ class WeatherUnitsManager: ObservableObject {
 			return .hectopascal
 		}
 		return pressureUnits
+	}
+}
+
+private extension WeatherUnitsManager {
+	func setWeatherUnitsAnalytics() {
+		WXMAnalytics.shared.setUserProperty(key: .temperature, value: temperatureUnit.analyticsValue)
+		WXMAnalytics.shared.setUserProperty(key: .precipitation, value: precipitationUnit.analyticsValue)
+		WXMAnalytics.shared.setUserProperty(key: .wind, value: windSpeedUnit.analyticsValue)
+		WXMAnalytics.shared.setUserProperty(key: .windDirection, value: windDirectionUnit.analyticsValue)
+		WXMAnalytics.shared.setUserProperty(key: .pressure, value: pressureUnit.analyticsValue)
 	}
 }

--- a/wxm-ios/DataLayer/UserDevicesService.swift
+++ b/wxm-ios/DataLayer/UserDevicesService.swift
@@ -33,7 +33,10 @@ public class UserDevicesService {
                                                object: nil,
 											   queue: nil) { [weak self] _ in
 			self?.invalidateCaches()
+			self?.updateOwnedStationsAnalyticsProperty()
 		}
+
+		updateOwnedStationsAnalyticsProperty()
     }
 
     deinit {
@@ -78,6 +81,7 @@ public class UserDevicesService {
 					WidgetCenter.shared.reloadAllTimelines()
 					
                     NotificationCenter.default.post(name: .userDevicesListUpdated, object: nil)
+					self?.updateOwnedStationsAnalyticsProperty()
                 }
                 return Just(response)
             }
@@ -250,5 +254,14 @@ private extension UserDevicesService {
 	func invalidateCaches() {
 		followStatesCache.invalidate()
 		userDevicesCache.invalidate()
+	}
+
+	func updateOwnedStationsAnalyticsProperty() {
+		guard let ownedDevicesCount = getCachedDevices()?.filter({ $0.relation == .owned }).count else {
+			WXMAnalytics.shared.removeUserProperty(key: .stationsOwn)
+			return
+		}
+
+		WXMAnalytics.shared.setUserProperty(key: .stationsOwn, value: .custom("\(ownedDevicesCount)"))
 	}
 }

--- a/wxm-ios/DataLayer/UserInfoService.swift
+++ b/wxm-ios/DataLayer/UserInfoService.swift
@@ -20,6 +20,7 @@ public class UserInfoService {
 											   object: nil,
 											   queue: nil) { [weak self] _ in
 			self?.userInfoSubject.send(nil)
+			WXMAnalytics.shared.setUserProperty(key: .hasWallet, value: .custom(String(false)))
 		}
 	}
 

--- a/wxm-ios/DataLayer/UserInfoService.swift
+++ b/wxm-ios/DataLayer/UserInfoService.swift
@@ -36,6 +36,10 @@ public class UserInfoService {
 				return
 			}
 			WXMAnalytics.shared.setUserId(value.id)
+			
+			let hasWallet = value.wallet?.address?.isEmpty == false
+			WXMAnalytics.shared.setUserProperty(key: .hasWallet, value: .custom(String(hasWallet)))
+
 			self?.userInfoSubject.send(value)
 		}
 		.store(in: &cancellableSet)

--- a/wxm-ios/DataLayer/UserInfoService.swift
+++ b/wxm-ios/DataLayer/UserInfoService.swift
@@ -20,7 +20,7 @@ public class UserInfoService {
 											   object: nil,
 											   queue: nil) { [weak self] _ in
 			self?.userInfoSubject.send(nil)
-			WXMAnalytics.shared.setUserProperty(key: .hasWallet, value: .custom(String(false)))
+			WXMAnalytics.shared.removeUserProperty(key: .hasWallet)
 		}
 	}
 

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
@@ -24,7 +24,7 @@ extension Parameter: CustomStringConvertible {
 		switch self {
 			case .action, .actionName, .contentName, .contentId, .promptName, .promptType,
 					.step, .state, .date, .theme, .temperature, .wind, .windDirection, .precipitation, .pressure,
-					.sortBy, .filter, .groupBy, .status, .appId:
+					.sortBy, .filter, .groupBy, .status, .appId, .hasWallet, .stationsOwn:
 				return rawValue
 			case .contentType:
 				return AnalyticsParameterContentType

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
@@ -96,6 +96,8 @@ public enum Parameter: String {
 	case groupBy = "GROUP_BY"
 	case status = "STATUS"
 	case appId = "APP_ID"
+	case stationsOwn = "STATIONS_OWN"
+	case hasWallet = "HAS_WALLET"
 }
 
 public enum ParameterValue {

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsTypes.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsTypes.swift
@@ -28,6 +28,7 @@ protocol AnalyticsProviderImplementation {
 	func trackEvent(_ event: Event, parameters: [Parameter: ParameterValue]?)
 	func setUserId(_ userId: String?)
 	func setUserProperty(key: Parameter, value: ParameterValue)
+	func removeUserProperty(key: Parameter)
 	func setDefaultParameter(key: Parameter, value: ParameterValue)
 	func setAnalyticsCollectionEnabled(_ enabled: Bool)
 }

--- a/wxm-ios/Toolkit/Toolkit/Analytics/FirebaseAnalytics.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/FirebaseAnalytics.swift
@@ -35,6 +35,10 @@ struct FirebaseAnalytics: AnalyticsProviderImplementation {
 		Analytics.setUserProperty(value.rawValue, forName: key.description)
 	}
 
+	func removeUserProperty(key: Parameter) {
+		Analytics.setUserProperty(nil, forName: key.description)
+	}
+
 	func setDefaultParameter(key: Parameter, value: ParameterValue) {
 		Analytics.setDefaultEventParameters([key.description: value.rawValue])
 	}

--- a/wxm-ios/Toolkit/Toolkit/Analytics/MixpanelAnalytics.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/MixpanelAnalytics.swift
@@ -34,7 +34,7 @@ struct MixpanelAnalytics: AnalyticsProviderImplementation {
 
 	func setUserId(_ userId: String?) {
 		if let userId {
-			Mixpanel.mainInstance().identify(distinctId: "pantelis-\(userId)")
+			Mixpanel.mainInstance().identify(distinctId: userId)
 		} else {
 			resetMixpanel()
 		}

--- a/wxm-ios/Toolkit/Toolkit/Analytics/MixpanelAnalytics.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/MixpanelAnalytics.swift
@@ -34,7 +34,7 @@ struct MixpanelAnalytics: AnalyticsProviderImplementation {
 
 	func setUserId(_ userId: String?) {
 		if let userId {
-			Mixpanel.mainInstance().identify(distinctId: userId)
+			Mixpanel.mainInstance().identify(distinctId: "pantelis-\(userId)")
 		} else {
 			resetMixpanel()
 		}
@@ -42,6 +42,10 @@ struct MixpanelAnalytics: AnalyticsProviderImplementation {
 
 	func setUserProperty(key: Parameter, value: ParameterValue) {
 		Mixpanel.mainInstance().people.set(property: key.description, to: value.rawValue)
+	}
+
+	func removeUserProperty(key: Parameter) {
+		Mixpanel.mainInstance().people.unset(properties: [key.description])
 	}
 
 	func setDefaultParameter(key: Parameter, value: ParameterValue) {

--- a/wxm-ios/Toolkit/Toolkit/Analytics/MockAnalytics.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/MockAnalytics.swift
@@ -14,6 +14,7 @@ struct MockAnalytics: AnalyticsProviderImplementation {
 	func trackEvent(_ event: Event, parameters: [Parameter: ParameterValue]?) {}
 	func setUserId(_ userId: String?) {}
 	func setUserProperty(key: Parameter, value: ParameterValue) {}
+	func removeUserProperty(key: Parameter) {}
 	func setDefaultParameter(key: Parameter, value: ParameterValue) {}
 	func setAnalyticsCollectionEnabled(_ enabled: Bool) {}
 }

--- a/wxm-ios/Toolkit/Toolkit/Analytics/WXMAnalytics.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/WXMAnalytics.swift
@@ -45,6 +45,10 @@ public extension WXMAnalytics {
 		providers.forEach { $0.setUserProperty(key: key, value: value) }
     }
 
+	func removeUserProperty(key: Parameter) {
+		providers.forEach { $0.removeUserProperty(key: key) }
+	}
+
     func setDefaultParameter(key: Parameter, value: ParameterValue) {
 		providers.forEach { $0.setDefaultParameter(key: key, value: value) }
     }


### PR DESCRIPTION
## **Why?**
- `HAS_WALLET` user property to show if the user has wallets
- `STATIONS_OWN` user property to show if the count of owned stations
- Set all weather units as user properties on app launch 
### **How?**
- `UserInfoService` which holds the user instance across the app, sets the `HAS_WALLET` and removes it on user logout
- `UserDevicesService` which handles the user devices, sets the `STATIONS_OWN ` and removes it on user logout
- `WeatherUnitsManager` sets all the weather units properties
### **Testing**
Ensure these properties are tracked properly
### **Additional context**
fixes fe-1028
