### PR TITLE
Dedicated app group for dev builds

### DIFF
--- a/Configuration/Debug/ConfigDebug.xcconfig-template
+++ b/Configuration/Debug/ConfigDebug.xcconfig-template
@@ -14,6 +14,8 @@ Account = weatherXM;
 
 TeamId = {The developer team id};
 
+AppGroup = {The app group for user deaults and keychain};
+
  // A trick to avoid parse issues caused form double slashes of the following urls is to add "$()" after "https:/", 
  // eg. https:/$()/api.myapi.com/api/v1" 
 

--- a/Configuration/Mock/ConfigMock.xcconfig-template
+++ b/Configuration/Mock/ConfigMock.xcconfig-template
@@ -14,6 +14,8 @@ Account = weatherXM;
 
 TeamId = {The developer team id};
 
+AppGroup = {The app group for user deaults and keychain};
+
  // A trick to avoid parse issues caused form double slashes of the following urls is to add "$()" after "https:/", 
  // eg. https:/$()/api.myapi.com/api/v1" 
 

--- a/Configuration/Production/Config.xcconfig-template
+++ b/Configuration/Production/Config.xcconfig-template
@@ -14,6 +14,8 @@ Account = weatherXM;
 
 TeamId = {The developer team id};
 
+AppGroup = {The app group for user deaults and keychain};
+
  // A trick to avoid parse issues caused form double slashes of the following urls is to add "$()" after "https:/", 
  // eg. https:/$()/api.myapi.com/api/v1" 
 

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -11,6 +11,7 @@ setupConfiguration(){
 	echo "UserRefreshTokenService = refreshTokenService;" >> $CONFIGURATION_PATH
 	echo "Account = weatherXM;" >> $CONFIGURATION_PATH
 	echo "TeamId = ${TEAM_ID};" >> $CONFIGURATION_PATH
+	echo "AppGroup = ${APP_GROUP};" >> $CONFIGURATION_PATH
 	echo "ApiUrl = ${API_URL};" >> $CONFIGURATION_PATH
 	echo "ClaimTokenUrl = ${CLAIM_TOKEN_URL};" >> $CONFIGURATION_PATH
 	echo "AppStoreUrl = ${APP_STORE_URL};" >> $CONFIGURATION_PATH

--- a/station-intent/Info.plist
+++ b/station-intent/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>ApiUrl</key>
 	<string>$(ApiUrl)</string>
+	<key>AppGroup</key>
+	<string>$(AppGroup)</string>
 	<key>INIntentsSupported</key>
 	<array>
 		<string>StationWidgetConfigurationIntent</string>

--- a/station-widget/Info.plist
+++ b/station-widget/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>ApiUrl</key>
 	<string>$(ApiUrl)</string>
+	<key>AppGroup</key>
+	<string>$(AppGroup)</string>
 	<key>MixpanelToken</key>
 	<string>$(MixpanelToken)</string>
 	<key>NSExtension</key>

--- a/wxm-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/wxm-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f4728abbf49d30b601989f2eaae6cabf86ecad62c6ce274c3421cb03fb3ba9c7",
+  "originHash" : "8cb8285fe837020417b83302c022c80d5214090b47c86e63bbea0ed6628e55ff",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mixpanel/mixpanel-swift",
       "state" : {
-        "revision" : "7f73084879cf6f8c50ab93e34ab0aae2569b04a8",
-        "version" : "4.2.7"
+        "revision" : "48d6668ceaaefc338f94e2b084c3cf77b90182f8",
+        "version" : "4.3.0"
       }
     },
     {
@@ -285,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "d57a5aecf24a25b32ec4a74be2f5d0a995a47c4b",
-        "version" : "1.27.0"
+        "revision" : "e17d61f26df0f0e06f58f6977ba05a097a720106",
+        "version" : "1.27.1"
       }
     },
     {

--- a/wxm-ios/DataLayer/DataLayer/UserDefaultsService/UserDefaultsService.swift
+++ b/wxm-ios/DataLayer/DataLayer/UserDefaultsService/UserDefaultsService.swift
@@ -10,7 +10,16 @@ import Foundation
 import Toolkit
 
 public struct UserDefaultsService: PersistCacheManager {
-	private let userDefaults = UserDefaults(suiteName: "group.com.weatherxm.app")
+	private let userDefaults: UserDefaults?
+
+	init() {
+		guard let appGroup: String = Bundle.main.getConfiguration(for: .appGroup) else {
+			self.userDefaults = nil
+			return
+		}
+
+		self.userDefaults = UserDefaults(suiteName: "\(appGroup)")
+	}
 
 	// MARK: - PersistCacheManager
 	public func save<T>(value: T, key: String) {

--- a/wxm-ios/DataLayer/KeychainHelperService/KeychainHelperService.swift
+++ b/wxm-ios/DataLayer/KeychainHelperService/KeychainHelperService.swift
@@ -13,11 +13,12 @@ public final class KeychainHelperService {
 	private let accessGroup: String
 
 	public init() {
-		guard let teamId: String = Bundle.main.getConfiguration(for: .teamId) else {
+		guard let teamId: String = Bundle.main.getConfiguration(for: .teamId),
+				let appGroup: String = Bundle.main.getConfiguration(for: .appGroup) else {
 			fatalError("Should provide teamId in configuration file")
 		}
 		
-		accessGroup = "\(teamId).group.com.weatherxm.app"
+		accessGroup = "\(teamId).\(appGroup)"
 	}
 
     func save<T>(_ item: T, service: String, account: String) where T: Codable {

--- a/wxm-ios/Info.plist
+++ b/wxm-ios/Info.plist
@@ -6,6 +6,8 @@
 	<string>$(Account)</string>
 	<key>ApiUrl</key>
 	<string>$(ApiUrl)</string>
+	<key>AppGroup</key>
+	<string>$(AppGroup)</string>
 	<key>AppStoreUrl</key>
 	<string>$(AppStoreUrl)</string>
 	<key>BranchName</key>

--- a/wxm-ios/Toolkit/Toolkit/Utils/Bundle+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/Bundle+.swift
@@ -11,6 +11,7 @@ public enum ConfigurationKey: String {
 	case mapBoxAccessToken = "MBXAccessToken"
 	case mapBoxStyle = "MBXStyle"
 	case teamId = "TeamId"
+	case appGroup = "AppGroup"
 	case apiUrl = "ApiUrl"
 	case claimTokenUrl = "ClaimTokenUrl"
 	case appStoreUrl = "AppStoreUrl"

--- a/wxm-ios/wxm-ios.entitlements
+++ b/wxm-ios/wxm-ios.entitlements
@@ -12,10 +12,12 @@
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.weatherxm.app</string>
+		<string>group.com.weatherxm.app.dev</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)group.com.weatherxm.app</string>
+		<string>$(AppIdentifierPrefix)group.com.weatherxm.app.dev</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## **Why?**
We want to log in with different accounts in production and dev builds 
### **How?**
- Declared new app group in [developer site](https://developer.apple.com)
- The group is injected from the configuration file
  - Updated the ci_script
  - Updated the environment variables in [App Store connect](https://appstoreconnect.apple.com/)
  - Updated the config templates
  - `KeychainHelperService` and `UserDefaultsService` are getting the app group name 
### **Testing**
Set the `AppGroup` variable in config file as shown in the template.
The available groups are `group.com.weatherxm.app` for production and `group.com.weatherxm.app.dev`
To make sure that the app reads from different groups do the following
- Set the `AppGroup` to `group.com.weatherxm.app`
- Login with you account
- Change the `AppGroup` to `group.com.weatherxm.app.dev` and re-run the app
- Make sure you are no logged out and log in with a different account
- Change again the `AppGroup` to `group.com.weatherxm.app` and re-run the app, you should be logged in with the initial account
### **Additional context**
fixes fe-1014
