### PR TITLE
Lowercased state values

### DIFF
--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
@@ -200,9 +200,9 @@ extension ParameterValue: RawRepresentable {
 			case .frequencyDocumentation:
 				return "Frequency Documentation"
 			case .failure:
-				return "Failure"
+				return "failure"
 			case .success:
-				return "Success"
+				return "success"
 			case .light:
 				return "light"
 			case .dark:


### PR DESCRIPTION
## **Why?**
There was a conflict with the `success` and `failure` analytics parameter value with the android app
### **How?**
Updated the raw value of analytics enum
### **Testing**
Make sure the event param value is submitted properly. 
eg. go to the claim token screen and go back to track the "token claiming result" `failure` event 
In order to send events to mixpanel, uncheck the `-WXMAnalyticsDisabled YES` launch argument and set the `MixpanelToken` in the config file (eg ConfigDebug)
### **Additional context**
fixes fe-1057
