### PR TITLE
Analytics explorer settings bug

### DIFF
--- a/PresentationLayer/UIComponents/Screens/Explorer/Search/ExplorerSearchViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/Explorer/Search/ExplorerSearchViewModel.swift
@@ -75,7 +75,7 @@ class ExplorerSearchViewModel: ObservableObject {
     }
 
     func handleSettingsButtonTap() {
-        WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.actionName: .explorerSettings])
+        WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .explorerSettings])
         delegate?.settingsButtonTapped()
     }
 


### PR DESCRIPTION
## **Why?**
The `Explorer Settings` value should be sent as `CONTENT_TYPE` instead of `ACTION_NAME`
### **How?**
Fixed the param key
### **Testing**
Make sure the `Explorer Settings` is tracked properly
### **Additional context**
fixes fe-1099
