### PR TITLE
Fixed layout issues in GifImageView

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/GifImageView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/GifImageView.swift
@@ -24,6 +24,11 @@ struct GifImageView: UIViewRepresentable {
 		imageView.animatedImage = image
 		imageView.contentMode = .scaleAspectFit
 
+		imageView.setContentHuggingPriority(.defaultLow, for: .vertical)
+		imageView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+		imageView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+		imageView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
 		return imageView
 	}
 
@@ -36,6 +41,7 @@ struct GifImageView: UIViewRepresentable {
 			.ignoresSafeArea()
 		GifImageView(fileName: "image_pulse_claiming_key")
 			.aspectRatio(1.0, contentMode: .fit)
+			.padding(.horizontal)
 
 	}
 }

--- a/wxm-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/wxm-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8cb8285fe837020417b83302c022c80d5214090b47c86e63bbea0ed6628e55ff",
+  "originHash" : "af7ad626f4862fa0c2fe8614da60079b048f208cf420272d1cb6bacb70efbadd",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",


### PR DESCRIPTION
## **Why?**
Gif image view in claim station screens doesn't resize properly
### **How?**
Made all the necessary changes inside `GifImageView`
### **Testing**
Make sure the gif are rendered properly in the following screens
- M5:
  - "Prepare gateway for claiming"
  - "Enter gateway serial number"
- D1:
  - "Prepare gateway for claiming"
- Pulse:
  - "Enter your gateway's claiming key"  
### **Additional context**
fixes 1106
