### PR TITLE
Broken UI in resized Mac app

### DIFF
--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationChipsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationChipsView.swift
@@ -51,6 +51,7 @@ private extension StationChipsView {
 					Text(FontIcon.hexagon.rawValue)
 						.font(.fontAwesome(font: .FAPro, size: CGFloat(.mediumFontSize)))
 						.foregroundColor(Color(colorEnum: .text))
+						.lineLimit(1)
 
 					Text(address)
 						.font(.system(size: CGFloat(.caption)))


### PR DESCRIPTION
## **Why?**
Resizing the Mac app to the smallest allowed size breaks the UI
### **How?**
Fixed the layout of font awesome icon
### **Testing**
Run the mac app resize it to the smallest allowed size and make sure everything is rendered properly
### **Screenshots (if applicable)**
![image](https://github.com/user-attachments/assets/934b11ae-f3a8-47ea-a034-2a403be59715)

### **Additional context**
fixes fe-1101
