### PR TITLE
Check if installation id is empty before add it in logout params

### DIFF
--- a/wxm-ios/DataLayer/DataLayer/Networking/ApiRequestBuilders/AuthApiRequestBuilder.swift
+++ b/wxm-ios/DataLayer/DataLayer/Networking/ApiRequestBuilders/AuthApiRequestBuilder.swift
@@ -93,7 +93,7 @@ enum AuthApiRequestBuilder: URLRequestConvertible {
 				return [ParameterConstants.Auth.email: email]
 			case let .logout(accessToken, installationId):
 				var params = [ParameterConstants.Auth.accessToken: accessToken]
-				if let installationId {
+				if let installationId, !installationId.isEmpty {
 					params += [ParameterConstants.Auth.installationId: installationId]
 				}
 				return params


### PR DESCRIPTION
## **Why?**
When, for some reason, there is no installation id, the logout process fails
### **How?**
Omit the installation id param, if is empty, from the logout process
### **Testing**
Build and run the app, make sure the `-WXMAnalyticsDisabled YES` is active and logout
### **Additional context**
fixes fe-1117
