### PR TITLE
Set location issue

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/SelectLocationMap/SelectLocationMapView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/SelectLocationMap/SelectLocationMapView.swift
@@ -19,7 +19,8 @@ struct SelectLocationMapView: View {
 				MapBoxClaimDeviceView(location: $viewModel.selectedCoordinate,
 									  annotationTitle: Binding(get: { viewModel.selectedDeviceLocation?.name },
 															   set: { _ in }),
-									  geometryProxyForFrameOfMapView: proxy.frame(in: .local))
+									  geometryProxyForFrameOfMapView: proxy.frame(in: .local),
+									  mapControls: viewModel.mapControls)
 
 				searchArea
 			}

--- a/PresentationLayer/UIComponents/BaseComponents/SelectLocationMap/SelectLocationMapViewModel.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/SelectLocationMap/SelectLocationMapViewModel.swift
@@ -23,6 +23,7 @@ class SelectLocationMapViewModel: ObservableObject {
 	}
 	@Published var searchTerm: String = ""
 	@Published private(set) var searchResults: [DeviceLocationSearchResult] = []
+	var mapControls: MapControls = .init()
 	private var cancellableSet: Set<AnyCancellable> = .init()
 	private var latestTask: Cancellable?
 	let useCase: DeviceLocationUseCase
@@ -54,17 +55,21 @@ class SelectLocationMapViewModel: ObservableObject {
 	func handleSearchResultTap(result: DeviceLocationSearchResult) {
 		latestTask?.cancel()
 		latestTask = useCase.locationFromSearchResult(result).sink { [weak self] location in
-			self?.selectedCoordinate = location.coordinates.toCLLocationCoordinate2D()
+			self?.mapControls.setMapCenter?(location.coordinates.toCLLocationCoordinate2D())
 		}
 	}
 
 	func moveToUserLocation() {
-		Task {
-			let result = await useCase.getUserLocation()
+		Task { [weak self] in
+			guard let self else {
+				return
+			}
+
+			let result = await self.useCase.getUserLocation()
 			DispatchQueue.main.async {
 				switch result {
 					case .success(let coordinates):
-						self.selectedCoordinate = coordinates
+						self.mapControls.setMapCenter?(coordinates)
 					case .failure(let error):
 						switch error {
 							case .locationNotFound:
@@ -85,7 +90,9 @@ class SelectLocationMapViewModel: ObservableObject {
 private extension SelectLocationMapViewModel {
 	func getLocationFromCoordinate() {
 		latestTask?.cancel()
+		print("selectedCoordinate: \(selectedCoordinate)" )
 		latestTask = useCase.locationFromCoordinates(LocationCoordinates.fromCLLocationCoordinate2D(selectedCoordinate)).sink { [weak self] location in
+			print("selectedDeviceLocation: \(location?.coordinates)" )
 			self?.selectedDeviceLocation = location
 		}
 	}

--- a/PresentationLayer/UIComponents/BaseComponents/SelectLocationMap/SelectLocationMapViewModel.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/SelectLocationMap/SelectLocationMapViewModel.swift
@@ -11,14 +11,25 @@ import Combine
 import DomainLayer
 
 protocol SelectLocationMapViewModelDelegate: AnyObject {
-	func updatedSelectedLocation(location: DeviceLocation?)
+	func updatedResolvedLocation(location: DeviceLocation?)
+	func updatedSelectedCoordinate(coordinate: CLLocationCoordinate2D?)
+}
+
+// Make protocol functions optional
+extension SelectLocationMapViewModelDelegate {
+	func updatedResolvedLocation(location: DeviceLocation?) {}
+	func updatedSelectedCoordinate(coordinate: CLLocationCoordinate2D?) {}
 }
 
 class SelectLocationMapViewModel: ObservableObject {
-	@Published var selectedCoordinate: CLLocationCoordinate2D
+	@Published var selectedCoordinate: CLLocationCoordinate2D {
+		didSet {
+			delegate?.updatedSelectedCoordinate(coordinate: selectedCoordinate)
+		}
+	}
 	@Published private(set) var selectedDeviceLocation: DeviceLocation? {
 		didSet {
-			delegate?.updatedSelectedLocation(location: selectedDeviceLocation)
+			delegate?.updatedResolvedLocation(location: selectedDeviceLocation)
 		}
 	}
 	@Published var searchTerm: String = ""

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/Location/ClaimDeviceLocationViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/Location/ClaimDeviceLocationViewModel.swift
@@ -33,7 +33,7 @@ class ClaimDeviceLocationViewModel: ObservableObject {
 }
 
 extension ClaimDeviceLocationViewModel: SelectLocationMapViewModelDelegate {
-	func updatedSelectedLocation(location: DeviceLocation?) {
+	func updatedResolvedLocation(location: DeviceLocation?) {
 		self.selectedLocation = location
 	}
 }

--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoRowView.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoRowView.swift
@@ -83,6 +83,7 @@ extension DeviceInfoRowView {
         static func == (lhs: DeviceInfoRowView.Row, rhs: DeviceInfoRowView.Row) -> Bool {
             lhs.title == rhs.title &&
             lhs.description == rhs.description &&
+			lhs.imageUrl == rhs.imageUrl &&
             lhs.buttonInfo == rhs.buttonInfo &&
             lhs.warning == rhs.warning
         }

--- a/PresentationLayer/UIComponents/Screens/SelectStationLocation/SelectStationLocationViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/SelectStationLocation/SelectStationLocationViewModel.swift
@@ -20,7 +20,7 @@ class SelectStationLocationViewModel: ObservableObject {
 	let deviceLocationUseCase: DeviceLocationUseCase
 	let meUseCase: MeUseCase
 	@Published var termsAccepted: Bool = false
-	@Published private(set) var selectedDeviceLocation: DeviceLocation?
+	@Published private(set) var selectedCoordinate: CLLocationCoordinate2D?
 	@Published var isSuccessful: Bool = false
 	private(set) var successObj: FailSuccessStateObject = .emptyObj
 	let locationViewModel: SelectLocationMapViewModel
@@ -42,7 +42,7 @@ class SelectStationLocationViewModel: ObservableObject {
 	}
 
 	func handleConfirmTap() {
-		guard let selectedCoordinate = selectedDeviceLocation?.coordinates.toCLLocationCoordinate2D(),
+		guard let selectedCoordinate,
 			  deviceLocationUseCase.areLocationCoordinatesValid(LocationCoordinates.fromCLLocationCoordinate2D(selectedCoordinate)) else {
 			Toast.shared.show(text: LocalizableString.invalidLocationErrorText.localized.attributedMarkdown ?? "")
 			return
@@ -53,14 +53,14 @@ class SelectStationLocationViewModel: ObservableObject {
 }
 
 extension SelectStationLocationViewModel: SelectLocationMapViewModelDelegate {
-	func updatedSelectedLocation(location: DeviceLocation?) {
-		self.selectedDeviceLocation = location
+	func updatedSelectedCoordinate(coordinate: CLLocationCoordinate2D?) {
+		self.selectedCoordinate = coordinate
 	}
 }
 
 private extension SelectStationLocationViewModel {
 	func setLocation() {
-		guard let deviceId = device.id, let selectedCoordinate = selectedDeviceLocation?.coordinates.toCLLocationCoordinate2D() else {
+		guard let deviceId = device.id, let selectedCoordinate else {
 			return
 		}
 

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -34,7 +34,7 @@ echo "password ${MAPBOX_TOKEN}" >> ~/.netrc
 if ([ "$CI_WORKFLOW" = "QA Production" ]) || ([ "$CI_WORKFLOW" = "QA Dev" ]) || ([ "$CI_WORKFLOW" = "Dev Build" ]);
 then
 echo "Install Firebase CLI"
-curl -Lo ./firebase-tools-macos https://firebase.tools/bin/macos/latest
+curl -Lo ./firebase-tools-macos https://github.com/firebase/firebase-tools/releases/download/v13.16.0/firebase-tools-macos
 chmod +x ./firebase-tools-macos
 
 DEBUG_CONFIGURATION_PATH=${CI_PRIMARY_REPOSITORY_PATH}/Configuration/Debug/ConfigDebug.xcconfig

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/LocationRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/LocationRepositoryImpl.swift
@@ -109,12 +109,12 @@ public class DeviceLocationRepositoryImpl: DeviceLocationRepository {
 		mapBoxSearchEngine.reverseGeocoding(options: options) { result in
 			switch result {
 				case let .success(addresses):
-					guard let actualAddress = addresses.first, actualAddress.isAccurate else {
+					guard let actualAddress = addresses.first else {
 						self.reverseGeocodedAddressSubject.send(nil)
 						return
 					}
 
-					self.reverseGeocodedAddressSubject.send(actualAddress.toLocation())
+					self.reverseGeocodedAddressSubject.send(actualAddress.toLocation(with: coordinates.toCLLocationCoordinate2D()))
 				case let .failure(error):
 					if let locationError = error.toDeviceLocationError() {
 						self.errorSubject.send(locationError)
@@ -190,15 +190,15 @@ extension SearchSuggestion {
 }
 
 extension SearchResult {
-	func toLocation() -> DeviceLocation {
-		let parsedAddress = address?.formattedAddress(style: .medium) ?? "-"
+	func toLocation(with locationCoordinate: CLLocationCoordinate2D? = nil) -> DeviceLocation {
+		let parsedAddress = isAccurate ? address?.formattedAddress(style: .medium) : nil
 
 		return DeviceLocation(
 			id: id,
 			name: parsedAddress,
 			country: address?.country,
 			countryCode: metadata?["iso_3166_1"],
-			coordinates: LocationCoordinates.fromCLLocationCoordinate2D(coordinate)
+			coordinates: LocationCoordinates.fromCLLocationCoordinate2D(locationCoordinate ?? coordinate)
 		)
 	}
 

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/LocationRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/LocationRepositoryImpl.swift
@@ -109,7 +109,7 @@ public class DeviceLocationRepositoryImpl: DeviceLocationRepository {
 		mapBoxSearchEngine.reverseGeocoding(options: options) { result in
 			switch result {
 				case let .success(addresses):
-					guard let actualAddress = addresses.first else {
+					guard let actualAddress = addresses.first, actualAddress.isAccurate else {
 						self.reverseGeocodedAddressSubject.send(nil)
 						return
 					}
@@ -191,11 +191,7 @@ extension SearchSuggestion {
 
 extension SearchResult {
 	func toLocation() -> DeviceLocation {
-		var parsedAddress = name
-
-		if let houseNumber = address?.houseNumber {
-			parsedAddress += " \(houseNumber)"
-		}
+		let parsedAddress = address?.formattedAddress(style: .medium) ?? "-"
 
 		return DeviceLocation(
 			id: id,
@@ -204,6 +200,15 @@ extension SearchResult {
 			countryCode: metadata?["iso_3166_1"],
 			coordinates: LocationCoordinates.fromCLLocationCoordinate2D(coordinate)
 		)
+	}
+
+	var isAccurate: Bool {
+		switch accuracy {
+			case .point, .rooftop, .street:
+				true
+			default:
+				false
+		}
 	}
 }
 

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/DeviceLocation.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/DeviceLocation.swift
@@ -30,12 +30,12 @@ public struct DeviceLocationSearchResult: Identifiable, Equatable, Hashable {
 
 public struct DeviceLocation: Identifiable, Equatable {
     public let id: String
-    public let name: String
+    public let name: String?
     public let country: String?
     public let countryCode: String?
     public let coordinates: LocationCoordinates
 
-    public init(id: String, name: String, country: String?, countryCode: String?, coordinates: LocationCoordinates) {
+    public init(id: String, name: String?, country: String?, countryCode: String?, coordinates: LocationCoordinates) {
         self.id = id
         self.name = name
         self.country = country


### PR DESCRIPTION
## **Why?**
In some cases, the submitted location in the claim device and edit location screens is different from the location shown on the map.
The issue has to do with the Mapbox reverse geocoding. Sometimes the resolved location has different coordinate than the passed point.
### **How?**
- We assign the point to be resolved in the retrieved location object from reverse geocoding
- The select location screen uses the actual position on map instead of the resolved object
- We show only the accurate addresses coming from the reverse geocoding. Similar logic with the Android app
### **Testing**
Make sure the device location is set correctly in the select location screen and claim device flow.
A good edge case is the one presented in the task's video
### **Additional context**
Add any other context about the PR here.
