### PR TITLE
Station details forecast tab improvement

### DIFF
--- a/PresentationLayer/Extensions/DomainExtensions/NetworkDeviceForecastResponse+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/NetworkDeviceForecastResponse+.swift
@@ -20,18 +20,26 @@ extension NetworkDeviceForecastResponse {
 
 extension CurrentWeather {
 	func toMiniCardItem(with timeZone: TimeZone, action: VoidCallback? = nil) -> StationForecastMiniCardView.Item {
-		.init(time: timestamp?.timestampToDate(timeZone: timeZone).transactionsTimeFormat(timeZone: timeZone) ?? "",
-			  animationString: icon?.getAnimationString(),
-			  temperature: temperature?.toTemeratureString(for: WeatherUnitsManager.default.temperatureUnit, decimals: 1) ?? "",
-			  action: action)
+		let precipitationLiterals = WeatherField.precipitationProbability.weatherLiterals(from: self, unitsManager: WeatherUnitsManager.default)
+		let precipitationProb = "\(precipitationLiterals?.value ?? "")\(WeatherField.precipitationProbability.shouldHaveSpaceWithUnit ? " " : "")\(precipitationLiterals?.unit ?? "")"
+
+		return .init(time: timestamp?.timestampToDate(timeZone: timeZone).transactionsTimeFormat(timeZone: timeZone) ?? "",
+					 animationString: icon?.getAnimationString(),
+					 temperature: temperature?.toTemeratureString(for: WeatherUnitsManager.default.temperatureUnit, decimals: 1) ?? "",
+					 precipitation: precipitationProb,
+					 action: action)
 	}
 
 	func toDailyMiniCardItem(with timeZone: TimeZone, action: VoidCallback? = nil) -> StationForecastMiniCardView.Item {
-		.init(time: timestamp?.timestampToDate(timeZone: timeZone).getWeekDay(.abbreviated) ?? "",
-			  animationString: icon?.getAnimationString(),
-			  temperature: temperatureMax?.toTemeratureString(for: WeatherUnitsManager.default.temperatureUnit, decimals: 0) ?? "",
-			  secondaryTemperature: temperatureMin?.toTemeratureString(for: WeatherUnitsManager.default.temperatureUnit, decimals: 0) ?? "",
-			  action: action)
+		let precipitationLiterals = WeatherField.precipitationProbability.weatherLiterals(from: self, unitsManager: WeatherUnitsManager.default)
+		let precipitationProb = "\(precipitationLiterals?.value ?? "")\(WeatherField.precipitationProbability.shouldHaveSpaceWithUnit ? " " : "")\(precipitationLiterals?.unit ?? "")"
+
+		return .init(time: timestamp?.timestampToDate(timeZone: timeZone).getWeekDay(.abbreviated) ?? "",
+					 animationString: icon?.getAnimationString(),
+					 temperature: temperatureMax?.toTemeratureString(for: WeatherUnitsManager.default.temperatureUnit, decimals: 0) ?? "",
+					 secondaryTemperature: temperatureMin?.toTemeratureString(for: WeatherUnitsManager.default.temperatureUnit, decimals: 0) ?? "",
+					 precipitation: precipitationProb,
+					 action: action)
 	}
 
 	func toForecastTemperatureItem(with timeZone: TimeZone, scrollGraphType: ForecastChartType? = nil) -> ForecastTemperatureCardView.Item {

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/CustomRangeSlider.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/CustomRangeSlider.swift
@@ -37,7 +37,7 @@ private extension CustomRangeSlider {
     }
 
     var offset: CGFloat {
-		maxWeeklyTemp - maxDailyTemp
+		minDailyTemp - minWeeklyTemp
     }
 
     @ViewBuilder
@@ -57,6 +57,6 @@ private extension CustomRangeSlider {
 
 struct Previews_CustomRangeSlider_Previews: PreviewProvider {
     static var previews: some View {
-		CustomRangeSlider(minWeeklyTemp: 7.0, maxWeeklyTemp: 19.0, minDailyTemp: 9.0, maxDailyTemp: 18)
+		CustomRangeSlider(minWeeklyTemp: 7.0, maxWeeklyTemp: 19.0, minDailyTemp: 9.0, maxDailyTemp: 18.0)
     }
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForeCastCardView+Content.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForeCastCardView+Content.swift
@@ -50,16 +50,16 @@ private extension StationForecastCardView {
     @ViewBuilder
     var temperatureBar: some View {
         HStack(spacing: CGFloat(.smallSpacing)) {
-            Text("\(forecast.daily?.temperatureMax?.toTemeratureString(for: unitsManager.temperatureUnit) ?? "")")
-				.font(.system(size: CGFloat(.titleFontSize), weight: .bold))
+			Text("\(forecast.daily?.temperatureMin?.toTemeratureString(for: unitsManager.temperatureUnit) ?? "")")
+				.font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
 
             CustomRangeSlider(minWeeklyTemp: minWeekTemperature.toTemeratureUnit(unitsManager.temperatureUnit).rounded(toPlaces: 0),
                               maxWeeklyTemp: maxWeekTemperature.toTemeratureUnit(unitsManager.temperatureUnit).rounded(toPlaces: 0),
                               minDailyTemp: forecast.daily?.temperatureMin?.toTemeratureUnit(unitsManager.temperatureUnit).rounded(toPlaces: 0) ?? 0.0,
                               maxDailyTemp: forecast.daily?.temperatureMax?.toTemeratureUnit(unitsManager.temperatureUnit).rounded(toPlaces: 0) ?? 0.0)
             
-			Text("\(forecast.daily?.temperatureMin?.toTemeratureString(for: unitsManager.temperatureUnit) ?? "")")
-				.font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
+			Text("\(forecast.daily?.temperatureMax?.toTemeratureString(for: unitsManager.temperatureUnit) ?? "")")
+				.font(.system(size: CGFloat(.titleFontSize), weight: .bold))
         }
     }
 

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastCardView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastCardView.swift
@@ -28,6 +28,9 @@ struct StationForecastCardView: View {
 
 					Spacer()
 
+					Text(FontIcon.chevronRight.rawValue)
+						.font(.fontAwesome(font: .FAPro, size: CGFloat(.mediumFontSize)))
+						.foregroundColor(Color(colorEnum: .wxmPrimary))
 				}
 
                 dailyView

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastMiniCardView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastMiniCardView.swift
@@ -41,10 +41,21 @@ struct StationForecastMiniCardView: View {
 							.lineLimit(1)
 					}
 				}
+
+				HStack(spacing: 0.0) {
+					Image(asset: WeatherField.precipitationProbability.hourlyIcon())
+						.renderingMode(.template)
+						.foregroundStyle(Color(colorEnum: .darkestBlue))
+					
+					Text(item.precipitation)
+						.foregroundColor(Color(colorEnum: .darkestBlue))
+						.font(.system(size: CGFloat(.normalFontSize)))
+						.lineLimit(1)
+				}
 			}
 			.WXMCardStyle(backgroundColor: isSelected ? Color(colorEnum: .layer1) : Color(colorEnum: .top),
 						  insideHorizontalPadding: CGFloat(.mediumSidePadding),
-						  insideVerticalPadding: CGFloat(.mediumSidePadding))
+						  insideVerticalPadding: CGFloat(.smallSidePadding))
 		}
 		.allowsHitTesting(item.action != nil)
 		.indication(show: .constant(isSelected), borderColor: Color(colorEnum: .wxmPrimary), bgColor: Color(colorEnum: .wxmPrimary)) {
@@ -59,6 +70,7 @@ extension StationForecastMiniCardView {
 		let animationString: String?
 		let temperature: String
 		var secondaryTemperature: String?
+		var precipitation: String
 		var action: VoidCallback?
 	}
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastMiniCardView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastMiniCardView.swift
@@ -18,30 +18,32 @@ struct StationForecastMiniCardView: View {
 		Button {
 			item.action?()
 		} label: {
-			VStack(spacing: CGFloat(.smallSpacing)) {
-				Text(item.time)
-					.foregroundColor(Color(colorEnum: .darkestBlue))
-					.font(.system(size: CGFloat(.caption)))
-					.minimumScaleFactor(0.8)
-					.lineLimit(1)
-
-				weatherImage
-
-				VStack(spacing: 0.0) {
-					Text(item.temperature)
+			VStack(spacing: 0.0) {
+				VStack(spacing: CGFloat(.smallSpacing)) {
+					Text(item.time)
 						.foregroundColor(Color(colorEnum: .darkestBlue))
-						.font(.system(size: CGFloat(.normalFontSize), weight: .bold))
+						.font(.system(size: CGFloat(.caption)))
+						.minimumScaleFactor(0.8)
 						.lineLimit(1)
-						.fixedSize()
 
-					if let secondaryTemperature = item.secondaryTemperature {
-						Text(secondaryTemperature)
+					weatherImage
+
+					VStack(spacing: 0.0) {
+						Text(item.temperature)
 							.foregroundColor(Color(colorEnum: .darkestBlue))
-							.font(.system(size: CGFloat(.caption)))
+							.font(.system(size: CGFloat(.normalFontSize), weight: .bold))
 							.lineLimit(1)
+							.fixedSize()
+
+						if let secondaryTemperature = item.secondaryTemperature {
+							Text(secondaryTemperature)
+								.foregroundColor(Color(colorEnum: .darkestBlue))
+								.font(.system(size: CGFloat(.caption)))
+								.lineLimit(1)
+						}
 					}
 				}
-
+				
 				HStack(spacing: 0.0) {
 					Image(asset: WeatherField.precipitationProbability.hourlyIcon())
 						.renderingMode(.template)

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
@@ -21,28 +21,28 @@ struct StationForecastView: View {
                 TrackableScrollView(showIndicators: false, offsetObject: viewModel.offsetObject) { completion in
                     viewModel.refresh(completion: completion)
                 } content: {
-                    VStack(spacing: CGFloat(.mediumSpacing)) {
+                    VStack(spacing: CGFloat(.largeSpacing)) {
 
 						hourlyView
 
-						HStack {
-							Text(LocalizableString.Forecast.nextSevenDays.localized)
-								.font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
-								.foregroundColor(Color(colorEnum: .darkestBlue))
-
-							Spacer()
-
-							Button {
-
-							} label: {
-								Text(FontIcon.infoCircle.rawValue)
-									.font(.fontAwesome(font: .FAPro, size: CGFloat(.mediumFontSize)))
-									.foregroundColor(Color(colorEnum: .wxmPrimary))
-							}
-						}
-						.padding(.horizontal)
-
 						VStack(spacing: CGFloat(.mediumSpacing)) {
+							HStack {
+								Text(LocalizableString.Forecast.nextSevenDays.localized)
+									.font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
+									.foregroundColor(Color(colorEnum: .darkestBlue))
+
+								Spacer()
+
+								Button {
+
+								} label: {
+									Text(FontIcon.infoCircle.rawValue)
+										.font(.fontAwesome(font: .FAPro, size: CGFloat(.mediumFontSize)))
+										.foregroundColor(Color(colorEnum: .wxmPrimary))
+								}
+							}
+							.padding(.horizontal)
+
 							ForEach(viewModel.forecasts, id: \.date) { forecast in
 								Button {
 									viewModel.handleForecastTap(forecast: forecast)
@@ -57,13 +57,13 @@ struct StationForecastView: View {
 							.padding(.horizontal)
 						}
 						.padding(.bottom)
-                    }
+					}
 					.iPadMaxWidth()
 					.padding(.vertical)
-                }
-            }
-        }
-        .wxmEmptyView(show: Binding(get: { viewModel.viewState == .hidden }, set: { _ in }), configuration: viewModel.hiddenViewConfiguration)
+				}
+			}
+		}
+		.wxmEmptyView(show: Binding(get: { viewModel.viewState == .hidden }, set: { _ in }), configuration: viewModel.hiddenViewConfiguration)
         .fail(show: Binding(get: { viewModel.viewState == .fail }, set: { _ in }), obj: viewModel.failObj)
         .spinningLoader(show: Binding(get: { viewModel.viewState == .loading }, set: { _ in }), hideContent: true)
         .onAppear {

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
@@ -31,6 +31,14 @@ struct StationForecastView: View {
 								.foregroundColor(Color(colorEnum: .darkestBlue))
 
 							Spacer()
+
+							Button {
+
+							} label: {
+								Text(FontIcon.infoCircle.rawValue)
+									.font(.fontAwesome(font: .FAPro, size: CGFloat(.mediumFontSize)))
+									.foregroundColor(Color(colorEnum: .wxmPrimary))
+							}
 						}
 						.padding(.horizontal)
 


### PR DESCRIPTION
## **Why?**
Improvements in station forecast tab
### **How?**
- Precipitation probability in hourly tiles
- Info icon in the daily section title (the bottom sheet presentation will be implemented in a next PR)
- Swapped temperatures (min/max) position
- Arrow in 7 days cards
### **Testing**
Ensure everything looks as expected
### **Additional context**
fixes fe-1121
