### PR TITLE
Updated remote config keys

### DIFF
--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/RemoteConfigRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/RemoteConfigRepositoryImpl.swift
@@ -91,9 +91,9 @@ private extension RemoteConfigRepositoryImpl {
 		let infoBanner = InfoBanner(id: infoBannerId,
 									title: RemoteConfigManager.shared.infoBannerTitle,
 									message: RemoteConfigManager.shared.infoBannerMessage,
-									buttonShow: RemoteConfigManager.shared.infoButtonShow,
+									buttonShow: RemoteConfigManager.shared.infoBannerActionShow,
 									actionLabel: RemoteConfigManager.shared.infoBannerActionLabel,
-									url: RemoteConfigManager.shared.infoBannerUrl,
+									url: RemoteConfigManager.shared.infoBannerActionUrl,
 									dismissable: RemoteConfigManager.shared.infoBannerDismissable)
 
 		infoBannerCurrentValueSubject.send(infoBanner)

--- a/wxm-ios/Toolkit/Toolkit/FirebaseManager/FirebaseManagerTypes.swift
+++ b/wxm-ios/Toolkit/Toolkit/FirebaseManager/FirebaseManagerTypes.swift
@@ -44,9 +44,9 @@ public enum RemoteConfigKey: String, CaseIterable {
 	case infoBannerId = "info_banner_id"
 	case infoBannerTitle = "info_banner_title"
 	case infoBannerMessage = "info_banner_message"
-	case infoButtonShow = "info_button_show"
+	case infoBannerActionShow = "info_banner_action_show"
 	case infoBannerActionLabel = "info_banner_action_label"
-	case infoBannerUrl = "info_banner_url"
+	case infoBannerActionUrl = "info_banner_action_url"
 	case infoBannerShow = "info_banner_show"
 	case infoBannerDismissable = "info_banner_dismissable"
 
@@ -78,11 +78,11 @@ public enum RemoteConfigKey: String, CaseIterable {
 				return "-" as NSObject
 			case .infoBannerMessage:
 				return "-" as NSObject
-			case .infoButtonShow:
+			case .infoBannerActionShow:
 				return false as NSObject
 			case .infoBannerActionLabel:
 				return "-" as NSObject
-			case .infoBannerUrl:
+			case .infoBannerActionUrl:
 				return "-" as NSObject
 			case .infoBannerShow:
 				return false as NSObject

--- a/wxm-ios/Toolkit/Toolkit/FirebaseManager/RemoteConfigManager.swift
+++ b/wxm-ios/Toolkit/Toolkit/FirebaseManager/RemoteConfigManager.swift
@@ -29,9 +29,9 @@ public class RemoteConfigManager: ObservableObject {
 	@Published public var infoBannerId: String?
 	@Published public var infoBannerTitle: String?
 	@Published public var infoBannerMessage: String?
-	@Published public var infoButtonShow: Bool?
+	@Published public var infoBannerActionShow: Bool?
 	@Published public var infoBannerActionLabel: String?
-	@Published public var infoBannerUrl: String?
+	@Published public var infoBannerActionUrl: String?
 	@Published public var infoBannerShow: Bool?
 	@Published public var infoBannerDismissable: Bool?
 
@@ -72,9 +72,9 @@ private extension RemoteConfigManager {
 			self.infoBannerId = self.getConfigValue(key: .infoBannerId)
 			self.infoBannerTitle = self.getConfigValue(key: .infoBannerTitle)
 			self.infoBannerMessage = self.getConfigValue(key: .infoBannerMessage)
-			self.infoButtonShow = self.getConfigValue(key: .infoButtonShow)
+			self.infoBannerActionShow = self.getConfigValue(key: .infoBannerActionShow)
 			self.infoBannerActionLabel = self.getConfigValue(key: .infoBannerActionLabel)
-			self.infoBannerUrl = self.getConfigValue(key: .infoBannerUrl)
+			self.infoBannerActionUrl = self.getConfigValue(key: .infoBannerActionUrl)
 			self.infoBannerShow = self.getConfigValue(key: .infoBannerShow)
 			self.infoBannerDismissable = self.getConfigValue(key: .infoBannerDismissable)
 		}


### PR DESCRIPTION
## **Why?**
Updated remote config keys for info banner
### **How?**
- `info_banner_url` -> `info_banner_action_url`
- `info_button_show` -> `info_banner_action_show`
### **Testing**
Make sure nothing is broken in info banner functionality 
### **Additional context**
fixes fe-1180


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced clarity in info banner handling with updated property names for better understanding.
- **Bug Fixes**
	- Adjusted logic for info banner visibility to align with new naming conventions.
- **Documentation**
	- Updated enum cases in the Firebase Manager to reflect new naming for info banner properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->