### PR TITLE
Use proper localized decimals separator in weather related

### DIFF
--- a/PresentationLayer/Extensions/Numeric/Double+.swift
+++ b/PresentationLayer/Extensions/Numeric/Double+.swift
@@ -22,19 +22,7 @@ extension Double {
     }
 
 	func toTemeratureString(for unit: TemperatureUnitsEnum, decimals: Int = 0) -> String {
-        let value = toTemeratureUnit(unit).rounded(toPlaces: decimals)
-
-		let formatter = NumberFormatter()
-		formatter.minimumFractionDigits = decimals
-		formatter.maximumFractionDigits = decimals
-		formatter.roundingMode = .halfUp
-		formatter.numberStyle = .decimal
-		let valueStr = formatter.string(for: value) ?? ""
-        switch unit {
-            case .celsius:
-                return "\(valueStr)\(LocalizableString.celsiusSymbol.localized)"
-            case .fahrenheit:
-                return "\(valueStr)\(LocalizableString.fahrenheitSymbol.localized)"
-        }
+		let literals = WeatherFormatter().getTemperatureLiterals(temperature: self, unit: unit, decimals: decimals)
+		return "\(literals.value)\(literals.unit)"
     }
 }

--- a/PresentationLayer/Utils/Weather/WeatherFormatter.swift
+++ b/PresentationLayer/Utils/Weather/WeatherFormatter.swift
@@ -133,7 +133,7 @@ struct WeatherFormatter {
     /// - Parameter value: The value to generate the formatted value
     /// - Returns: A tuple with the text components eg. ("12.2", "W/m2")
     func getSolarRadiationLiterals(value: Double?) -> WeatherValueLiterals {
-        ("\(value?.rounded(toPlaces: 1) ?? 0.0)", UnitConstants.WATTS_PER_SQR)
+		("\((value ?? 0.0).toPrecisionString(minDecimals: 1, precision: 1))", UnitConstants.WATTS_PER_SQR)
     }
 
     /// The text components of the precipitation value. (value, unit)
@@ -143,10 +143,10 @@ struct WeatherFormatter {
     func getPrecipitationLiterals(value: Double?, unit: PrecipitationUnitsEnum) -> WeatherValueLiterals {
         switch unit {
             case .millimeters:
-                return ("\(value?.rounded(toPlaces: 1) ?? Double.nan)", UnitConstants.MILLIMETERS_PER_HOUR)
+				return ("\((value ?? .nan).toPrecisionString(minDecimals: 1, precision: 1))", UnitConstants.MILLIMETERS_PER_HOUR)
             case .inches:
-				let convertedValue = (shouldConvert ? unitsConverter.millimetersToInches(mm: value ?? Double.nan) : value ?? Double.nan).rounded(toPlaces: 2)
-                return ("\(convertedValue)", UnitConstants.INCHES_PER_HOUR)
+				let convertedValue = (shouldConvert ? unitsConverter.millimetersToInches(mm: value ?? Double.nan) : value ?? Double.nan)
+				return (convertedValue.toPrecisionString(minDecimals: 2, precision: 2), UnitConstants.INCHES_PER_HOUR)
         }
     }
 
@@ -157,10 +157,10 @@ struct WeatherFormatter {
     func getPrecipitationAccumulatedLiterals(from value: Double?, unit: PrecipitationUnitsEnum) -> WeatherValueLiterals? {
         switch unit {
             case .millimeters:
-                return ("\((value ?? 0.0).rounded(toPlaces: 1))", UnitConstants.MILLIMETERS)
+                return ((value ?? 0.0).toPrecisionString(minDecimals: 1, precision: 1), UnitConstants.MILLIMETERS)
             case .inches:
-				let convertedValue = (shouldConvert ? unitsConverter.millimetersToInches(mm: value ?? 0.0) : value ?? 0.0).rounded(toPlaces: 2)
-                return ("\(convertedValue)", UnitConstants.INCHES)
+				let convertedValue = (shouldConvert ? unitsConverter.millimetersToInches(mm: value ?? 0.0) : value ?? 0.0)
+                return (convertedValue.toPrecisionString(minDecimals: 2, precision: 2), UnitConstants.INCHES)
         }
     }
 

--- a/PresentationLayer/Utils/Weather/WeatherFormatter.swift
+++ b/PresentationLayer/Utils/Weather/WeatherFormatter.swift
@@ -28,12 +28,11 @@ struct WeatherFormatter {
         switch unit {
             case .hectopascal:
                 let pressureMetric = UnitConstants.HECTOPASCAL
-                pressureValue = pressureValue.rounded(toPlaces: 1)
-                return ("\(pressureValue)", pressureMetric)
+				return ("\(pressureValue.toPrecisionString(precision: 1))", pressureMetric)
             case .inchOfMercury:
                 let pressureMetric = UnitConstants.INCH_OF_MERCURY
-				let pressureValue = (shouldConvert ? unitsConverter.hpaToInHg(hpa: pressureValue) : pressureValue).rounded(toPlaces: 2)
-                return ("\(pressureValue)", pressureMetric)
+				let pressureValue = (shouldConvert ? unitsConverter.hpaToInHg(hpa: pressureValue) : pressureValue)
+                return ("\(pressureValue.toPrecisionString(precision: 2))", pressureMetric)
         }
     }
 
@@ -99,7 +98,7 @@ struct WeatherFormatter {
         }
 
 		let convertedValue = windSpeed.rounded(toPlaces: 1)
-		let convertedValueStr = showDecimals ? "\(convertedValue)" : "\(Int(convertedValue))"
+		let convertedValueStr = showDecimals ? "\(convertedValue.toPrecisionString(minDecimals: 1, precision: 1))" : "\(Int(convertedValue))"
         return ("\(convertedValueStr)", "\(windUnit) \(includeDirection ? windDirectionString : "")".trimWhiteSpaces())
     }
 

--- a/PresentationLayer/Utils/Weather/WeatherFormatter.swift
+++ b/PresentationLayer/Utils/Weather/WeatherFormatter.swift
@@ -31,7 +31,7 @@ struct WeatherFormatter {
 				return ("\(pressureValue.toPrecisionString(precision: 1))", pressureMetric)
             case .inchOfMercury:
                 let pressureMetric = UnitConstants.INCH_OF_MERCURY
-				let pressureValue = (shouldConvert ? unitsConverter.hpaToInHg(hpa: pressureValue) : pressureValue)
+				pressureValue = (shouldConvert ? unitsConverter.hpaToInHg(hpa: pressureValue) : pressureValue)
                 return ("\(pressureValue.toPrecisionString(precision: 2))", pressureMetric)
         }
     }
@@ -52,7 +52,7 @@ struct WeatherFormatter {
             case .celsius:
 				return (temperature.toPrecisionString(minDecimals: decimals, precision: decimals), LocalizableString.celsiusSymbol.localized)
             case .fahrenheit:
-				let value = shouldConvert ? unitsConverter.celsiusToFahrenheit(celsius: temperature.rounded(toPlaces: 1)) : temperature				
+				let value = shouldConvert ? unitsConverter.celsiusToFahrenheit(celsius: temperature) : temperature
 				return (value.toPrecisionString(minDecimals: decimals, precision: decimals), LocalizableString.fahrenheitSymbol.localized)
         }
     }

--- a/PresentationLayer/Utils/Weather/WeatherFormatter.swift
+++ b/PresentationLayer/Utils/Weather/WeatherFormatter.swift
@@ -48,14 +48,13 @@ struct WeatherFormatter {
     /// - Parameter unit: The requested unit
     /// - Parameter temperature: The value to generate the formatted value
     /// - Returns: A tuple with the text components eg. ("12", "°C")
-    func getTemperatureLiterals(temperature: Double, unit: TemperatureUnitsEnum) -> WeatherValueLiterals {
-        let format = "%.1f"
+	func getTemperatureLiterals(temperature: Double, unit: TemperatureUnitsEnum, decimals: Int = 1) -> WeatherValueLiterals {
         switch unit {
             case .celsius:
-                return (String(format: format, temperature), LocalizableString.celsiusSymbol.localized)
+				return (temperature.toPrecisionString(minDecimals: decimals, precision: decimals), LocalizableString.celsiusSymbol.localized)
             case .fahrenheit:
-				let value = shouldConvert ? unitsConverter.celsiusToFahrenheit(celsius: temperature.rounded(toPlaces: 1)) : temperature
-                return (String(format: format, value), LocalizableString.fahrenheitSymbol.localized)
+				let value = shouldConvert ? unitsConverter.celsiusToFahrenheit(celsius: temperature.rounded(toPlaces: 1)) : temperature				
+				return (value.toPrecisionString(minDecimals: decimals, precision: decimals), LocalizableString.fahrenheitSymbol.localized)
         }
     }
 


### PR DESCRIPTION
## **Why?**
Commas or dots for decimals according to phone's locale
### **How?**
Updated the way we generate weather field strings
### **Testing**
Check every screen we show weather-related stuff and make sure the decimals are separated as expected
### **Additional context**
fixes fe-1166


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced temperature formatting with improved precision and customizable decimal places.
	- Simplified temperature string conversion through a dedicated weather formatter.

- **Bug Fixes**
	- Resolved issues with temperature rounding and formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->