### PR TITLE
Fixed screens in ipad

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScrollView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScrollView.swift
@@ -54,6 +54,7 @@ struct TrackableScrollView<Content>: View where Content: View {
 						}
                 }
             }
+			.frame(width: outsideProxy.size.width)
 			.modify { view in
 				if let offsetObject {
 					view

--- a/PresentationLayer/UIComponents/Screens/RewardAnalyticsView.swift
+++ b/PresentationLayer/UIComponents/Screens/RewardAnalyticsView.swift
@@ -41,8 +41,10 @@ private struct ContentView: View {
 				switch viewModel.state {
 					case .empty(let configuration):
 						emptyView(configuration: configuration)
+							.iPadMaxWidth()
 					case .noRewards:
 						noRewards
+							.iPadMaxWidth()
 					case .content:
 						rewardsView
 				}
@@ -84,6 +86,7 @@ private struct ContentView: View {
 					stationsList(scrollProxy: proxy)
 				}
 				.padding(CGFloat(.defaultSidePadding))
+				.iPadMaxWidth()
 			}
 			.animation(.easeIn(duration: animationDuration),
 					   value: viewModel.stationItems.values.reduce(into: 0) { $0 = $0 + ($1.isExpanded ? 1 : 0) })

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/TemperatureExplanationView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/TemperatureExplanationView.swift
@@ -56,6 +56,7 @@ struct TemperatureExplanationView: View {
 					.resizable()
 					.aspectRatio(contentMode: .fit)
 					.wxmShadow()
+					.iPadMaxWidth()
 			}
 			.padding(CGFloat(.defaultSidePadding))
 		}


### PR DESCRIPTION
## **Why?**
Some screens were not aligned properly on the iPad
### **How?**
- Fixed main container (`TrackableScrollview`) to keep things centered
- Fixed the layout on iPad for Reward analytics screen, Reward details and Temperature bars explanation bottom sheet
### **Testing**
Make sure the mentioned screens are rendered properly on an iPad
### **Additional context**
fixes fe-1242


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user interface for iPad displays with layout adjustments in various views.
	- Added animations for improved visual feedback during state changes in reward analytics.
	- Improved presentation of temperature bars on iPad devices.

- **Bug Fixes**
	- Improved handling of expanded views and error states in the reward analytics section.

- **Chores**
	- Refined layout and functionality of the `TrackableScrollView` for better sizing and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->