### PR TITLE
Station list card improvements for health metrics

### DIFF
--- a/PresentationLayer/Constants/FontsEnum.swift
+++ b/PresentationLayer/Constants/FontsEnum.swift
@@ -52,6 +52,7 @@ enum FontIcon: String {
 	case circleTwo = "circle-2"
 	case circleThree = "circle-3"
 	case circleFour = "circle-4"
+	case circleSmall = "circle-small"
 	case qrcode
 	case barcode
 	case split
@@ -68,4 +69,6 @@ enum FontIcon: String {
 	case gauge
 	case sun
 	case dropletDegree = "droplet-degree"
+	case arrowsRotate = "arrows-rotate"
+	case batteryLow = "battery_low"
 }

--- a/PresentationLayer/Constants/FontsEnum.swift
+++ b/PresentationLayer/Constants/FontsEnum.swift
@@ -62,6 +62,7 @@ enum FontIcon: String {
 	case chevronDown = "chevron-down"
 	case faceSadCry = "face-sad-cry"
 	case rotateRight = "rotate-right"
+	case temperatureThreeQuarters = "temperature-three-quarters"
 	case umbrella
 	case cloudShowers = "cloud-showers"
 	case locationArrow = "location-arrow"

--- a/PresentationLayer/Constants/FontsEnum.swift
+++ b/PresentationLayer/Constants/FontsEnum.swift
@@ -70,5 +70,5 @@ enum FontIcon: String {
 	case sun
 	case dropletDegree = "droplet-degree"
 	case arrowsRotate = "arrows-rotate"
-	case batteryLow = "battery_low"
+	case batteryLow = "battery-low"
 }

--- a/PresentationLayer/Constants/FontsEnum.swift
+++ b/PresentationLayer/Constants/FontsEnum.swift
@@ -72,4 +72,5 @@ enum FontIcon: String {
 	case dropletDegree = "droplet-degree"
 	case arrowsRotate = "arrows-rotate"
 	case batteryLow = "battery-low"
+	case chartSimple = "chart-simple"
 }

--- a/PresentationLayer/Constants/WeatherFields.swift
+++ b/PresentationLayer/Constants/WeatherFields.swift
@@ -11,7 +11,11 @@ import DomainLayer
 import Toolkit
 
 extension WeatherField: CustomStringConvertible {
-	
+
+	static var stationListFields: [WeatherField] {
+		[.temperature, .wind, .humidity, .precipitation]
+	}
+
 	static var mainFields: [WeatherField] {
 		[.humidity, .wind, .precipitation]
 	}
@@ -141,9 +145,9 @@ extension WeatherField: CustomStringConvertible {
 	var fontIcon: FontIcon? {
 		switch self {
 			case .temperature:
-				nil
+					.temperatureThreeQuarters
 			case .feelsLike:
-				nil
+					.temperatureThreeQuarters
 			case .humidity:
 					.humidity
 			case .wind:

--- a/PresentationLayer/Constants/WeatherFields.swift
+++ b/PresentationLayer/Constants/WeatherFields.swift
@@ -45,7 +45,7 @@ extension WeatherField: CustomStringConvertible {
 			case .windDirection:
 				return LocalizableString.windDirection.localized
 			case .precipitation:
-				return LocalizableString.precipitationRate.localized
+				return LocalizableString.precipRate.localized
 			case .precipitationProbability:
 				return LocalizableString.precipitationProbability.localized
 			case .dailyPrecipitation:

--- a/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
@@ -141,24 +141,21 @@ extension DeviceDetails {
 	}
 
 	func getIssuesChip(followState: UserDeviceFollowState?) -> StationChipsView.IssuesChip? {
-		guard case let issues = issues(mainVM: .shared, followState: followState).sorted(by: { $0.warningType > $1.warningType }),
-			  let warningType = issues.first?.warningType else {
+		let issues = issues(mainVM: .shared, followState: followState).sorted(by: { $0.warningType > $1.warningType })
+		guard let firstIssue = issues.first else {
 			return nil
 		}
 
 		if issues.count > 1 {
-			return .init(type: warningType,
+			return .init(type: firstIssue.warningType,
 						 icon: .hexagonExclamation,
 						 title: LocalizableString.issues(issues.count).localized)
 		}
 
-		if let issue = issues.first {
-			return .init(type: warningType,
-						 icon: issue.type.fontIcon,
-						 title: issue.type.description)
-		}
 
-		return nil
+		return .init(type: firstIssue.warningType,
+					 icon: firstIssue.type.fontIcon,
+					 title: firstIssue.type.description)
 	}
 
 	func isBatteryLow(followState: UserDeviceFollowState?) -> Bool {

--- a/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
@@ -67,9 +67,16 @@ extension DeviceDetails {
 
 	var qodStatusColor: ColorEnum {
 		guard let qod else {
-			return .success
+			return .darkGrey
 		}
 		return qod.rewardScoreColor
+	}
+
+	var polStatusColor: ColorEnum {
+		guard let pol else {
+			return .darkGrey
+		}
+		return pol.color
 	}
 
 	var qodWarningType: CardWarningType? {
@@ -277,8 +284,8 @@ extension DeviceDetails {
 		device.lastActiveAt = Date.now.toTimestamp()
 		device.firmware = Firmware(assigned: "1.0.0", current: "1.0.1")
 		device.cellCenter = .init(lat: 0.0, long: 0.0)
-		device.pol = .verified
-		device.qod = 91
+		device.pol = nil
+		device.qod = nil
 
 		let currentWeather = CurrentWeather.mockInstance
 		device.weather = currentWeather

--- a/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
@@ -72,6 +72,10 @@ extension DeviceDetails {
 		return qod.rewardScoreColor
 	}
 
+	var qodWarningType: CardWarningType? {
+		qod?.rewardScoreType
+	}
+
 	var qodStatusText: String {
 		guard let qod else {
 			return LocalizableString.Error.noDataTitle.localized
@@ -164,9 +168,9 @@ extension DeviceDetails {
 		return batteryState == .low
 	}
 	
-	func overallWarningType(mainVM: MainScreenViewModel, followState: UserDeviceFollowState?) -> CardWarningType {
-		let issues = issues(mainVM: mainVM, followState: followState).sorted(by: { $0.type < $1.type })
-		return issues.first?.warningType ?? .info
+	func overallWarningType(mainVM: MainScreenViewModel, followState: UserDeviceFollowState?) -> CardWarningType? {
+		let issuesChipType = getIssuesChip(followState: followState)?.type
+		return [qodWarningType, pol?.warningType, issuesChipType].compactMap { $0 }.sorted(by: { $0 > $1}).first
 	}
 	
 	func needsUpdate(persistedVersion: FirmwareVersion?) -> Bool {
@@ -248,6 +252,17 @@ extension PolStatus {
 					.error
 		}
 	}
+
+	var warningType: CardWarningType? {
+		switch self {
+			case .verified:
+				nil
+			case .notVerified:
+					.warning
+			case .noLocation:
+					.error
+		}
+	}
 }
 
 // MARK: - Mock
@@ -265,8 +280,8 @@ extension DeviceDetails {
 		device.lastActiveAt = Date.now.toTimestamp()
 		device.firmware = Firmware(assigned: "1.0.0", current: "1.0.1")
 		device.cellCenter = .init(lat: 0.0, long: 0.0)
-		device.pol = .notVerified
-		device.qod = 65
+		device.pol = .verified
+		device.qod = 91
 
 		let currentWeather = CurrentWeather.mockInstance
 		device.weather = currentWeather

--- a/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
@@ -85,6 +85,17 @@ extension DeviceDetails {
 					return LocalizableString.lowBatteryWarningTitle.localized
 			}
 		}
+
+		var fontIcon: FontIcon {
+			switch self {
+				case .offline:
+						.hexagonXmark
+				case .needsUpdate:
+						.arrowsRotate
+				case .lowBattery:
+						.batteryLow
+			}
+		}
 	}
 	
 	struct Issue {
@@ -101,7 +112,28 @@ extension DeviceDetails {
 			}
 		}
 	}
-	
+
+	func getIssuesChip(followState: UserDeviceFollowState?) -> StationChipsView.IssuesChip? {
+		guard case let issues = issues(mainVM: .shared, followState: followState).sorted(by: { $0.warningType > $1.warningType }),
+			  let warningType = issues.first?.warningType else {
+			return nil
+		}
+
+		if issues.count > 1 {
+			return .init(type: warningType,
+						 icon: warningType.fontIcon,
+						 title: LocalizableString.issues(issues.count).localized)
+		}
+
+		if let issue = issues.first, issue.type != .offline {
+			return .init(type: warningType,
+						 icon: issue.type.fontIcon,
+						 title: issue.type.description)
+		}
+
+		return nil
+	}
+
 	func isBatteryLow(followState: UserDeviceFollowState?) -> Bool {
 		guard followState?.relation == .owned else {
 			return false
@@ -193,7 +225,7 @@ extension DeviceDetails {
 		device.address = "This is an address"
 		device.bundle = .mock()
 		device.rewards = .init(totalRewards: 53.0, actualReward: 12.53533)
-		device.isActive = true
+		device.isActive = false
 		device.lastActiveAt = Date.now.toTimestamp()
 		device.firmware = Firmware(assigned: "1.0.0", current: "1.0.1")
 		device.cellCenter = .init(lat: 0.0, long: 0.0)

--- a/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
@@ -20,8 +20,7 @@ extension DeviceDetails {
 	
 	var stationLastActiveConf: StationLastActiveView.Configuration {
 		StationLastActiveView.Configuration(lastActiveAt: lastActiveAt,
-											stateColor: activeStateColor(isActive: isActive),
-											tintColor: activeStateTintColor(isActive: isActive))
+											stateColor: activeStateColor(isActive: isActive))
 	}
 	
 	/// Label without occurences of ":"

--- a/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
@@ -64,6 +64,29 @@ extension DeviceDetails {
 	var isHelium: Bool {
 		bundle?.connectivity == .helium
 	}
+
+	var qodStatusColor: ColorEnum {
+		guard let qod else {
+			return .success
+		}
+		return qod.rewardScoreColor
+	}
+
+	var qodStatusText: String {
+		guard let qod else {
+			return LocalizableString.Error.noDataTitle.localized
+		}
+
+		return LocalizableString.Home.dataQuality(qod).localized
+	}
+
+	var locationText: String {
+		guard let address else {
+			return LocalizableString.Error.noLocationDataTitle.localized
+		}
+
+		return address
+	}
 }
 
 // MARK: - Issues
@@ -214,6 +237,19 @@ extension Firmware {
 	}
 }
 
+extension PolStatus {
+	var color: ColorEnum {
+		switch self {
+			case .verified:
+					.success
+			case .notVerified:
+					.warning
+			case .noLocation:
+					.error
+		}
+	}
+}
+
 // MARK: - Mock
 
 extension DeviceDetails {
@@ -229,7 +265,9 @@ extension DeviceDetails {
 		device.lastActiveAt = Date.now.toTimestamp()
 		device.firmware = Firmware(assigned: "1.0.0", current: "1.0.1")
 		device.cellCenter = .init(lat: 0.0, long: 0.0)
-		
+		device.pol = .notVerified
+		device.qod = 65
+
 		let currentWeather = CurrentWeather.mockInstance
 		device.weather = currentWeather
 		

--- a/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
@@ -78,7 +78,7 @@ extension DeviceDetails {
 		var description: String {
 			switch self {
 				case .offline:
-					return LocalizableString.alertsStationOfflineTitle.localized
+					return LocalizableString.stationInactive.localized
 				case .needsUpdate:
 					return LocalizableString.updateRequiredTitle.localized
 				case .lowBattery:
@@ -121,11 +121,11 @@ extension DeviceDetails {
 
 		if issues.count > 1 {
 			return .init(type: warningType,
-						 icon: warningType.fontIcon,
+						 icon: .hexagonExclamation,
 						 title: LocalizableString.issues(issues.count).localized)
 		}
 
-		if let issue = issues.first, issue.type != .offline {
+		if let issue = issues.first {
 			return .init(type: warningType,
 						 icon: issue.type.fontIcon,
 						 title: issue.type.description)

--- a/PresentationLayer/Extensions/Numeric/Int+.swift
+++ b/PresentationLayer/Extensions/Numeric/Int+.swift
@@ -66,4 +66,17 @@ extension Int {
 				return .noColor
 		}
 	}
+
+	var rewardScoreType: CardWarningType? {
+		switch self {
+			case 0..<10:
+				return .error
+			case 10..<95:
+				return .warning
+			case 95...100:
+				return nil
+			default:
+				return nil
+		}
+	}
 }

--- a/PresentationLayer/UIComponents/BaseComponents/PercentageGridLayoutView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/PercentageGridLayoutView.swift
@@ -10,25 +10,31 @@ import SwiftUI
 struct PercentageGridLayoutView<Content: View>: View {
     var alignments: [Alignment] = [.leading, .leading]
     var firstColumnPercentage: CGFloat = 0.6
+	var linesSpacing: CGFloat?
 
     let content: () -> Content
     @State private var size: CGSize = .zero
 
-    var body: some View {
-		#if MAIN_APP
-        LazyVGrid(columns: [GridItem(.fixed(size.width * firstColumnPercentage), spacing: 0.0, alignment: alignments[0]),
-                            GridItem(.flexible(), spacing: 0.0, alignment: alignments[1])]) {
-            content()
-        }.sizeObserver(size: $size)
-		#else
+	var body: some View {
+#if MAIN_APP
+		LazyVGrid(columns: [GridItem(.fixed(size.width * firstColumnPercentage),
+									 spacing: 0.0,
+									 alignment: alignments[0]),
+							GridItem(.flexible(),
+									 spacing: 0.0,
+									 alignment: alignments[1])],
+				  spacing: linesSpacing) {
+			content()
+		}.sizeObserver(size: $size)
+#else
 		VStack {
 			LazyVGrid(columns: [GridItem(.flexible(), spacing: 0.0, alignment: alignments[0]),
 								GridItem(.flexible(), spacing: 0.0, alignment: alignments[1])]) {
 				content()
 			}
 		}
-		#endif
-    }
+#endif
+	}
 }
 
 struct PercentageGridLayoutView_Previews: PreviewProvider {

--- a/PresentationLayer/UIComponents/BaseComponents/StationLastActiveView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/StationLastActiveView.swift
@@ -18,11 +18,11 @@ struct StationLastActiveView: View {
                 .foregroundColor(Color(colorEnum: configuration.stateColor))
 				.frame(width: 10.0)
 
-            Text(configuration.lastActiveAt?.lastActiveTime() ?? "-")
+			Text(configuration.lastActiveAt?.lastActiveTime() ?? LocalizableString.notAvailable.localized)
                 .font(.system(size: CGFloat(.caption)))
 				.foregroundColor(Color(colorEnum: .text))
         }
-        .WXMCardStyle(backgroundColor: Color(colorEnum: configuration.tintColor),
+		.WXMCardStyle(backgroundColor: Color(colorEnum: .blueTint),
                       insideHorizontalPadding: CGFloat(.smallSidePadding),
                       insideVerticalPadding: CGFloat(.smallSidePadding),
                       cornerRadius: CGFloat(.buttonCornerRadius))
@@ -33,13 +33,11 @@ extension StationLastActiveView {
     struct Configuration {
         let lastActiveAt: String?
         let stateColor: ColorEnum
-        let tintColor: ColorEnum
     }
 
     init(device: DeviceDetails) {
         let conf = Configuration(lastActiveAt: device.lastActiveAt,
-                                 stateColor: device.isActiveStateColor,
-                                 tintColor: device.isActiveStateTintColor)
+                                 stateColor: device.isActiveStateColor)
         self.configuration = conf
     }
 }

--- a/PresentationLayer/UIComponents/BaseComponents/StationLastActiveView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/StationLastActiveView.swift
@@ -16,7 +16,7 @@ struct StationLastActiveView: View {
 		HStack(spacing: CGFloat(.smallSpacing)) {
 			Circle()
                 .foregroundColor(Color(colorEnum: configuration.stateColor))
-				.frame(width: 10.0)
+				.frame(width: 10.0, height: 10.0)
 
 			Text(configuration.lastActiveAt?.lastActiveTime() ?? LocalizableString.notAvailable.localized)
                 .font(.system(size: CGFloat(.caption)))

--- a/PresentationLayer/UIComponents/BaseComponents/WeatherOverview/WeatherOverviewView+Content.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherOverview/WeatherOverviewView+Content.swift
@@ -74,6 +74,20 @@ extension WeatherOverviewView {
 							}
 						}
 					}
+				case .grid:
+					PercentageGridLayoutView(alignments: [.leading, .leading], firstColumnPercentage: 0.25) {
+						Group {
+							weatherImage
+
+							LazyVGrid(columns: [.init(), .init()],
+									  spacing: CGFloat(.mediumSpacing)) {
+								ForEach(WeatherField.stationListFields, id: \.description) { field in
+									weatherFieldView(for: field)
+								}
+							}
+						}
+					}
+
 			}
 		}
 	}
@@ -86,7 +100,7 @@ extension WeatherOverviewView {
 					Image(asset: .noDataIcon)
 						.renderingMode(.template)
 						.foregroundColor(Color(colorEnum: .text))
-				case .default, .medium, .large:
+				case .default, .medium, .large, .grid:
 					Image(asset: .noDataIcon)
 						.renderingMode(.template)
 						.foregroundColor(Color(colorEnum: .text))
@@ -109,7 +123,8 @@ extension WeatherOverviewView {
     @ViewBuilder
     var secondaryFieldsView: some View {
         VStack(spacing: CGFloat(.defaultSpacing)) {
-            PercentageGridLayoutView(firstColumnPercentage: 0.5) {
+			PercentageGridLayoutView(firstColumnPercentage: 0.5,
+									 linesSpacing: CGFloat(.smallSpacing)) {
                 ForEach(WeatherField.secondaryFields, id: \.description) { field in
                     weatherFieldView(for: field)
                 }
@@ -139,11 +154,10 @@ extension WeatherOverviewView {
 
     @ViewBuilder
     func weatherFieldView(for field: WeatherField) -> some View {
-        HStack(spacing: 0.0) {
-            Image(asset: field.icon)
-                .renderingMode(.template)
-                .foregroundColor(Color(colorEnum: .darkestBlue))
-				.aspectRatio(contentMode: .fill)
+		HStack(alignment: .center, spacing: CGFloat(.smallSpacing)) {
+			Text(field.fontIcon?.rawValue ?? "")
+				.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.smallTitleFontSize)))
+				.foregroundColor(Color(colorEnum: .darkestBlue))
 				.rotationEffect(Angle(degrees: field.iconRotation(from: weather)))
 
             VStack(alignment: .leading, spacing: 0.0) {
@@ -157,6 +171,8 @@ extension WeatherOverviewView {
 											unitsManager: unitsManager,
 											fontSize: weatherFieldsValueFontSize))
             }
+
+			Spacer(minLength: 0.0)
         }
     }
 
@@ -231,6 +247,8 @@ private extension WeatherOverviewView {
 				return CGFloat(.minimumSpacing)
 			case .default:
 				return CGFloat(.smallSpacing)
+			case .grid:
+				return CGFloat(.mediumSpacing)
 		}
 	}
 
@@ -242,7 +260,7 @@ private extension WeatherOverviewView {
 				return CGFloat(.littleCaption)
 			case .large:
 				return CGFloat(.caption)
-			case .default:
+			case .default, .grid:
 				return CGFloat(.caption)
 		}
 	}
@@ -255,7 +273,7 @@ private extension WeatherOverviewView {
 				CGFloat(.caption)
 			case .large:
 				CGFloat(.normalFontSize)
-			case .default:
+			case .default, .grid:
 				CGFloat(.mediumFontSize)
 		}
 	}
@@ -270,6 +288,9 @@ private extension WeatherOverviewView {
 				CGFloat(.largeTitleFontSize)
 			case .default:
 				CGFloat(.XXXLTitleFontSize)
+			case .grid:
+				// There is no special position for the temperature in this layout
+					.nan
 		}
 	}
 
@@ -283,6 +304,9 @@ private extension WeatherOverviewView {
 				CGFloat(.largeTitleFontSize)
 			case .default:
 				CGFloat(.XLTitleFontSize)
+			case .grid:
+				// There is no special position for the temperature in this layout
+					.nan
 		}
 	}
 
@@ -296,6 +320,9 @@ private extension WeatherOverviewView {
 				CGFloat(.normalFontSize)
 			case .default:
 				CGFloat(.mediumFontSize)
+			case .grid:
+				// There is no special position for the temperature in this layout
+					.nan
 		}
 	}
 
@@ -309,6 +336,9 @@ private extension WeatherOverviewView {
 				CGFloat(.smallFontSize)
 			case .default:
 				CGFloat(.caption)
+			case .grid:
+				// There is no special position for the temperature in this layout
+					.nan
 		}
 	}
 
@@ -320,7 +350,7 @@ private extension WeatherOverviewView {
 				return CGFloat(.mediumFontSize)
 			case .large:
 				return CGFloat(.mediumFontSize)
-			case .default:
+			case .default, .grid:
 				return CGFloat(.smallTitleFontSize)
 		}
 	}

--- a/PresentationLayer/UIComponents/BaseComponents/WeatherOverview/WeatherOverviewView+Content.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherOverview/WeatherOverviewView+Content.swift
@@ -290,7 +290,7 @@ private extension WeatherOverviewView {
 				CGFloat(.XXXLTitleFontSize)
 			case .grid:
 				// There is no special position for the temperature in this layout
-					.nan
+				0.0
 		}
 	}
 
@@ -306,7 +306,7 @@ private extension WeatherOverviewView {
 				CGFloat(.XLTitleFontSize)
 			case .grid:
 				// There is no special position for the temperature in this layout
-					.nan
+				0.0
 		}
 	}
 
@@ -322,7 +322,7 @@ private extension WeatherOverviewView {
 				CGFloat(.mediumFontSize)
 			case .grid:
 				// There is no special position for the temperature in this layout
-					.nan
+				0.0
 		}
 	}
 
@@ -338,7 +338,7 @@ private extension WeatherOverviewView {
 				CGFloat(.caption)
 			case .grid:
 				// There is no special position for the temperature in this layout
-					.nan
+				0.0
 		}
 	}
 

--- a/PresentationLayer/UIComponents/BaseComponents/WeatherOverview/WeatherOverviewView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherOverview/WeatherOverviewView.swift
@@ -27,7 +27,7 @@ struct WeatherOverviewView: View {
 				CGFloat(.weatherIconMediumDimension)
 			case .large:
 				CGFloat(.weatherIconLargeDimension)
-			case .default:
+			case .default, .grid:
 				CGFloat(.weatherIconDefaultDimension)
 		}
 	}
@@ -76,6 +76,7 @@ extension WeatherOverviewView {
 		case large
 		/// Main app
 		case `default`
+		case grid
 	}
 
 	private var mainViewVerticalPadding: CGFloat {
@@ -86,7 +87,7 @@ extension WeatherOverviewView {
 				CGFloat(.minimumPadding)
 			case .large:
 				CGFloat(.smallSidePadding)
-			case .default:
+			case .default, .grid:
 				CGFloat(.defaultSidePadding)
 		}
 	}
@@ -99,6 +100,13 @@ struct WeatherOverviewView_Previews: PreviewProvider {
             WeatherOverviewView(weather: CurrentWeather.mockInstance, showSecondaryFields: true, buttonTitle: "Button text", isButtonEnabled: false) {}
         }
     }
+}
+
+#Preview("Grid Layout") {
+	return ZStack {
+		Color(.red)
+		WeatherOverviewView(mode: .grid, weather: CurrentWeather.mockInstance, showSecondaryFields: false) {}
+	}
 }
 
 #Preview {

--- a/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCard+Content.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCard+Content.swift
@@ -16,10 +16,8 @@ extension WeatherStationCard {
         StationAddressTitleView(device: device,
                                 followState: followState,
 								issues: nil,
-                                showSubtitle: false,
                                 showStateIcon: true,
-                                tapStateIconAction: followAction,
-                                tapAddressAction: nil)
+                                tapStateIconAction: followAction)
     }
 
     @ViewBuilder

--- a/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCard.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCard.swift
@@ -61,7 +61,7 @@ private extension WeatherStationCard {
 			HStack(spacing: CGFloat(.smallSpacing)) {
 				Text(FontIcon.hexagon.rawValue)
 					.font(.fontAwesome(font: .FAPro, size: CGFloat(.mediumFontSize)))
-					.foregroundStyle(Color(colorEnum: device.pol?.color ?? .noColor))
+					.foregroundStyle(Color(colorEnum: device.polStatusColor))
 					.fixedSize()
 
 				Text(device.locationText)

--- a/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCard.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCard.swift
@@ -19,19 +19,49 @@ struct WeatherStationCard: View {
 
 	var body: some View {
 		VStack(spacing: 0.0) {
-			WeatherStationCardView(device: device, followState: followState, followAction: followAction)
-				.background {
-					Color(colorEnum: .top)
-						.cornerRadius(CGFloat(.cardCornerRadius))
-				}
+			WeatherStationCardView(device: device,
+								   followState: followState,
+								   followAction: followAction)
+
+			healthMetricsView
 		}
 		.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
 		.WXMCardStyle(backgroundColor: Color(colorEnum: .top),
 					  insideHorizontalPadding: .zero,
 					  insideVerticalPadding: .zero,
 					  cornerRadius: CGFloat(.cardCornerRadius))
-		.stationIndication(device: device, followState: followState)
 		.wxmShadow()
+	}
+}
+
+private extension WeatherStationCard {
+	@ViewBuilder
+	var healthMetricsView: some View {
+		HStack(spacing: CGFloat(.mediumSpacing)) {
+			HStack(spacing: CGFloat(.smallSpacing)) {
+				Text(FontIcon.chartSimple.rawValue)
+					.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.mediumFontSize)))
+					.foregroundStyle(Color(colorEnum: device.qodStatusColor))
+
+				Text(device.qodStatusText)
+					.font(.system(size: CGFloat(.caption)))
+					.foregroundStyle(Color(colorEnum: .text))
+			}
+
+			HStack(spacing: CGFloat(.smallSpacing)) {
+				Text(FontIcon.hexagon.rawValue)
+					.font(.fontAwesome(font: .FAPro, size: CGFloat(.mediumFontSize)))
+					.foregroundStyle(Color(colorEnum: device.pol?.color ?? .noColor))
+				Text(device.locationText)
+					.font(.system(size: CGFloat(.caption)))
+					.foregroundStyle(Color(colorEnum: .text))
+			}
+
+			Spacer()
+		}
+		.padding(.horizontal, CGFloat(.defaultSpacing))
+		.padding(.vertical, CGFloat(.smallToMediumSpacing))
+		.background(Color(colorEnum: .blueTint))
 	}
 }
 

--- a/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCard.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCard.swift
@@ -23,9 +23,16 @@ struct WeatherStationCard: View {
 								   followState: followState,
 								   followAction: followAction)
 
+			if UIDevice.current.isIPad {
+				Spacer()
+			}
+			
 			healthMetricsView
 		}
-		.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+		.if(UIDevice.current.isIPad) { view in
+			// Modify the view to get equal heights in iPad grid layout
+			view.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+		}
 		.WXMCardStyle(backgroundColor: Color(colorEnum: .top),
 					  insideHorizontalPadding: .zero,
 					  insideVerticalPadding: .zero,

--- a/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCard.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCard.swift
@@ -30,6 +30,7 @@ struct WeatherStationCard: View {
 					  insideHorizontalPadding: .zero,
 					  insideVerticalPadding: .zero,
 					  cornerRadius: CGFloat(.cardCornerRadius))
+		.stationIndication(device: device, followState: followState)
 		.wxmShadow()
 	}
 }

--- a/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCard.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCard.swift
@@ -26,7 +26,7 @@ struct WeatherStationCard: View {
 			if UIDevice.current.isIPad {
 				Spacer()
 			}
-			
+
 			healthMetricsView
 		}
 		.if(UIDevice.current.isIPad) { view in
@@ -50,19 +50,25 @@ private extension WeatherStationCard {
 				Text(FontIcon.chartSimple.rawValue)
 					.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.mediumFontSize)))
 					.foregroundStyle(Color(colorEnum: device.qodStatusColor))
+					.fixedSize()
 
 				Text(device.qodStatusText)
 					.font(.system(size: CGFloat(.caption)))
 					.foregroundStyle(Color(colorEnum: .text))
+					.fixedSize()
 			}
 
 			HStack(spacing: CGFloat(.smallSpacing)) {
 				Text(FontIcon.hexagon.rawValue)
 					.font(.fontAwesome(font: .FAPro, size: CGFloat(.mediumFontSize)))
 					.foregroundStyle(Color(colorEnum: device.pol?.color ?? .noColor))
+					.fixedSize()
+
 				Text(device.locationText)
 					.font(.system(size: CGFloat(.caption)))
 					.foregroundStyle(Color(colorEnum: .text))
+					.lineLimit(2)
+					.fixedSize(horizontal: false, vertical: true)
 			}
 
 			Spacer()

--- a/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCardView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCardView.swift
@@ -30,7 +30,7 @@ private extension WeatherStationCardView {
 	var titleView: some View {
 		StationAddressTitleView(device: device,
 								followState: followState,
-								issues: nil,
+								issues: device.getIssuesChip(followState: followState),
 								areChipsScrollable: false,
 								showStateIcon: true,
 								tapStateIconAction: followAction)

--- a/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCardView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCardView.swift
@@ -38,7 +38,7 @@ private extension WeatherStationCardView {
 
 	@ViewBuilder
 	var weatherView: some View {
-		WeatherOverviewView(weather: device.weather)
+		WeatherOverviewView(mode: .grid, weather: device.weather)
 	}
 }
 

--- a/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCardView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCardView.swift
@@ -32,10 +32,8 @@ private extension WeatherStationCardView {
 								followState: followState,
 								issues: nil,
 								areChipsScrollable: false,
-								showSubtitle: false,
 								showStateIcon: true,
-								tapStateIconAction: followAction,
-								tapAddressAction: nil)
+								tapStateIconAction: followAction)
 	}
 
 	@ViewBuilder

--- a/PresentationLayer/UIComponents/Modifiers/StationIndication.swift
+++ b/PresentationLayer/UIComponents/Modifiers/StationIndication.swift
@@ -17,8 +17,7 @@ private struct StationIndicationModifier: ViewModifier {
 	func body(content: Content) -> some View {
 		let warningType = device.overallWarningType(mainVM: mainScreenViewModel, followState: followState)
 		content
-			.indication(show: .init(get: { warningType != nil },
-									set: { _ in }),
+			.indication(show: .constant(warningType != nil),
 						borderColor: Color(colorEnum: warningType?.iconColor ?? .noColor),
 						bgColor: Color(colorEnum: warningType?.tintColor ?? .noColor)) {
 				EmptyView()

--- a/PresentationLayer/UIComponents/Modifiers/StationIndication.swift
+++ b/PresentationLayer/UIComponents/Modifiers/StationIndication.swift
@@ -15,169 +15,22 @@ private struct StationIndicationModifier: ViewModifier {
 	let mainScreenViewModel = MainScreenViewModel.shared
 
 	func body(content: Content) -> some View {
-		content
-			.indication(show: .init(get: { device.hasIssues(mainVM: mainScreenViewModel, followState: followState) },
-									set: { _ in }),
-						borderColor: Color(colorEnum: device.overallWarningType(mainVM: mainScreenViewModel, followState: followState).iconColor),
-						bgColor: Color(colorEnum: device.overallWarningType(mainVM: mainScreenViewModel, followState: followState).tintColor)) {
-				statusView
-			}
-	}
-}
-
-private extension StationIndicationModifier {
-	@ViewBuilder
-	var statusView: some View {
-		let alertsCount = device.issuesCount(mainVM: mainScreenViewModel, followState: followState)
 		let warningType = device.overallWarningType(mainVM: mainScreenViewModel, followState: followState)
-		if alertsCount > 1 {
-			multipleAlertsView(alertsCount: alertsCount)
-		} else if !device.isActive {
-			HStack(spacing: CGFloat(.smallSpacing)) {
-				Image(asset: warningType.icon)
-					.renderingMode(.template)
-					.foregroundColor(Color(colorEnum: warningType.iconColor))
-
-				Text(LocalizableString.offlineStation.localized)
-					.foregroundColor(Color(colorEnum: .text))
-					.font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
-
-				Spacer()
-			}
-			.padding(CGFloat(.smallSidePadding))
-		} else {
-			warningView
-		}
-	}
-
-	@ViewBuilder
-	func multipleAlertsView(alertsCount: Int) -> some View {
-		let warningType = device.overallWarningType(mainVM: mainScreenViewModel, followState: followState)
-		HStack(spacing: CGFloat(.smallSpacing)) {
-			Image(asset: warningType.icon)
-				.renderingMode(.template)
-				.foregroundColor(Color(colorEnum: warningType.iconColor))
-
-			Text(LocalizableString.issues(alertsCount).localized)
-				.foregroundColor(Color(colorEnum: .text))
-				.font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
-
-			Spacer()
-
-			Button {
-				Router.shared.navigateTo(.viewMoreAlerts(ViewModelsFactory.getAlertsViewModel(device: device,
-																							  mainVM: mainScreenViewModel,
-																							  followState: followState)))
-
-				WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .viewAll,
-																	  .itemId: .multipleIssue])
-			} label: {
-				Text(LocalizableString.viewAll.localized)
-					.padding(.horizontal, CGFloat(.mediumToLargeSidePadding))
-					.padding(.vertical, CGFloat(.smallToMediumSidePadding))
-			}
-			.buttonStyle(WXMButtonStyle.transparentFixedSize)
-			.clipShape(Capsule())
-
-		}
-		.padding(CGFloat(.defaultSidePadding))
-	}
-
-	@ViewBuilder
-	var warningView: some View {
-		if device.needsUpdate(mainVM: mainScreenViewModel, followState: followState) {
-			CardWarningView(configuration: .init(title: LocalizableString.stationWarningUpdateTitle.localized,
-												 message: LocalizableString.stationWarningUpdateDescription.localized,
-												 closeAction: nil),
-							showContentFullWidth: true) {
-				Button {
-					mainScreenViewModel.showFirmwareUpdate(device: device)
-
-					WXMAnalytics.shared.trackEvent(.prompt, parameters: [.promptName: .OTAAvailable,
-																   .promptType: .warnPromptType,
-																   .action: .action])
-				} label: {
-					Text(LocalizableString.stationWarningUpdateButtonTitle.localized)
-				}
-				.buttonStyle(WXMButtonStyle.transparent)
-				.buttonStyle(.plain)
-				.padding(.top, CGFloat(.minimumPadding))
-			}
-			.onAppear {
-				WXMAnalytics.shared.trackEvent(.prompt, parameters: [.promptName: .OTAAvailable,
-															   .promptType: .warnPromptType,
-															   .action: .viewAction])
-			}
-		} else if device.isBatteryLow(followState: followState) {
-			CardWarningView(configuration: .init(title: LocalizableString.stationWarningLowBatteryTitle.localized,
-												 message: LocalizableString.stationWarningLowBatteryDescription.localized,
-												 closeAction: nil),
-							showContentFullWidth: true) {
-				Button {
-					guard let name = device.bundle?.name else {
-						return
-					}
-
-					var urlString: String?
-					switch name {
-						case .m5:
-							urlString = DisplayedLinks.m5Batteries.linkURL
-						case .h1, .h2:
-							urlString = DisplayedLinks.heliumBatteries.linkURL
-						case .d1:
-							urlString = DisplayedLinks.d1Batteries.linkURL
-						case .pulse:
-							#warning("Set pulse link")
-					}
-
-					if let urlString, let url = URL(string: urlString) {
-						UIApplication.shared.open(url)
-					}
-					
-					WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .webDocumentation,
-																		  .itemId: .custom(urlString ?? "")])
-				} label: {
-					Text(LocalizableString.stationWarningLowBatteryButtonTitle.localized)
-				}
-				.buttonStyle(WXMButtonStyle.transparent)
-				.buttonStyle(.plain)
-				.padding(.top, CGFloat(.minimumPadding))
-			}
-		} else {
-			EmptyView()
-		}
-	}
-
-}
-
-private struct OfflineStationIndicationModifier: ViewModifier {
-	let device: DeviceDetails
-
-	func body(content: Content) -> some View {
 		content
-			.indication(show: .init(get: { !device.isActive },
+			.indication(show: .init(get: { warningType != nil },
 									set: { _ in }),
-						borderColor: Color(colorEnum: CardWarningType.error.iconColor),
-						bgColor: Color(colorEnum: CardWarningType.error.tintColor)) {
-				CardWarningView(configuration: .init(type: .error,
-													 title: LocalizableString.offlineStation.localized,
-													 message: LocalizableString.offlineStationDescription.localized,
-													 closeAction: nil)) {
-					EmptyView()
-				}
+						borderColor: Color(colorEnum: warningType?.iconColor ?? .noColor),
+						bgColor: Color(colorEnum: warningType?.tintColor ?? .noColor)) {
+				EmptyView()
 			}
 	}
 }
+
 
 extension View {
 	@ViewBuilder
 	func stationIndication(device: DeviceDetails, followState: UserDeviceFollowState?) -> some View {
 		modifier(StationIndicationModifier(device: device, followState: followState))
-	}
-
-	@ViewBuilder
-	func offlineStationIndication(device: DeviceDetails) -> some View {
-		modifier(OfflineStationIndicationModifier(device: device))
 	}
 }
 

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeView.swift
@@ -248,3 +248,10 @@ private struct ContentView: View {
         .padding(.bottom)
     }
 }
+
+#Preview {
+	WeatherStationsHomeView(swinjectHelper: SwinjectHelper.shared,
+							isTabBarShowing: .constant(false),
+							tabBarItemsSize: .constant(.zero),
+							isWalletEmpty: .constant(false))
+}

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Observations/ObservationsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Observations/ObservationsView.swift
@@ -55,8 +55,7 @@ private extension ObservationsView {
                                 buttonTitle: LocalizableString.StationDetails.viewHistoricalData.localized,
                                 isButtonEnabled: viewModel.followState != nil) {
                 viewModel.handleHistoricalDataButtonTap()
-			}
-			.offlineStationIndication(device: device)
+			}.stationIndication(device: device, followState: viewModel.followState)
         } else {
             EmptyView()
         }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationChipsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationChipsView.swift
@@ -20,11 +20,8 @@ struct StationChipsView: View {
 	var body: some View {
 		HStack(spacing: CGFloat(.smallSpacing)) {
 			issuesChip
-				.fixedSize()
 			statusChip
-				.fixedSize()
 			bundleChip
-				.fixedSize()
 
 			Spacer()
 		}

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationChipsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationChipsView.swift
@@ -10,24 +10,21 @@ import DomainLayer
 import Toolkit
 
 struct StationChipsView: View {
-	typealias IssuesChip = (type: CardWarningType, title: String)
 
 	let device: DeviceDetails
 	let issues: IssuesChip?
 	var isScrollable: Bool = true
-	var addressAction: VoidCallback?
 	var warningAction: VoidCallback?
 	var statusAction: VoidCallback?
 
 	var body: some View {
 		HStack(spacing: CGFloat(.smallSpacing)) {
-			warningsChip
+			issuesChip
 				.fixedSize()
 			statusChip
 				.fixedSize()
 			bundleChip
 				.fixedSize()
-			addressChip
 
 			Spacer()
 		}
@@ -39,36 +36,15 @@ struct StationChipsView: View {
 	}
 }
 
-private extension StationChipsView {
-	@ViewBuilder
-	var addressChip: some View {
-		if let address = device.address {
-			Button {
-				addressAction?()
-			} label: {
-
-				HStack(spacing: CGFloat(.smallSpacing)) {
-					Text(FontIcon.hexagon.rawValue)
-						.font(.fontAwesome(font: .FAPro, size: CGFloat(.mediumFontSize)))
-						.foregroundColor(Color(colorEnum: .text))
-						.lineLimit(1)
-
-					Text(address)
-						.font(.system(size: CGFloat(.caption)))
-						.foregroundColor(Color(colorEnum: .text))
-						.lineLimit(1)
-				}
-				.WXMCardStyle(backgroundColor: Color(colorEnum: .blueTint),
-							  insideHorizontalPadding: CGFloat(.smallSidePadding),
-							  insideVerticalPadding: CGFloat(.smallSidePadding),
-							  cornerRadius: CGFloat(.buttonCornerRadius))
-			}
-			.allowsHitTesting(addressAction != nil)
-		} else {
-			EmptyView()
-		}
+extension StationChipsView {
+	struct IssuesChip {
+		let type: CardWarningType
+		let icon: FontIcon
+		let title: String
 	}
+}
 
+private extension StationChipsView {
 	@ViewBuilder
 	var statusChip: some View {
 		Button {
@@ -81,15 +57,15 @@ private extension StationChipsView {
 	}
 
 	@ViewBuilder
-	var warningsChip: some View {
+	var issuesChip: some View {
 		if let issues {
 			Button {
 				warningAction?()
 			} label: {
 
 				HStack(spacing: CGFloat(.smallSpacing)) {
-					Text(issues.type.fontIcon.rawValue)
-						.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.mediumFontSize)))
+					Text(issues.icon.rawValue)
+						.font(.fontAwesome(font: .FAPro, size: CGFloat(.mediumFontSize)))
 						.foregroundColor(Color(colorEnum: issues.type.iconColor))
 
 					Text(issues.title)
@@ -129,6 +105,8 @@ private extension StationChipsView {
 }
 
 #Preview {
-	StationChipsView(device: .mockDevice, issues: (.error, "2 issues"))
+	StationChipsView(device: .mockDevice, issues: .init(type: .error,
+														icon: .arrowsRotate,
+														title: "2 issues"))
 		.padding()
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationChipsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationChipsView.swift
@@ -65,7 +65,7 @@ private extension StationChipsView {
 
 				HStack(spacing: CGFloat(.smallSpacing)) {
 					Text(issues.icon.rawValue)
-						.font(.fontAwesome(font: .FAPro, size: CGFloat(.mediumFontSize)))
+						.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.mediumFontSize)))
 						.foregroundColor(Color(colorEnum: issues.type.iconColor))
 
 					Text(issues.title)

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsContainerView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsContainerView.swift
@@ -179,7 +179,6 @@ private struct StationDetailsView: View {
 										issues: viewModel.issues,
                                         showStateIcon: true,
                                         tapStateIconAction: { viewModel.followButtonTapped()},
-                                        tapAddressAction: { viewModel.addressTapped() },
 										tapWarningAction: { viewModel.warningTapped() },
 										tapStatusAction: { viewModel.statusTapped() })
                 .sizeObserver(size: $titleViewAddressSize)

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsTypes.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsTypes.swift
@@ -22,19 +22,17 @@ struct StationAddressTitleView: View {
 	
 	let device: DeviceDetails
 	let followState: UserDeviceFollowState?
-    let subtitle: String?
 	let issues: StationChipsView.IssuesChip?
 	let areChipsScrollable: Bool
     let showStateIcon: Bool
     let stateFAIcon: StateFontAwesome
     let isStateIconEnabled: Bool
     let tapStateIconAction: VoidCallback?
-    let tapAddressAction: VoidCallback?
 	let tapWarningAction: VoidCallback?
 	let tapStatusAction: VoidCallback?
 
     var body: some View {
-        VStack(spacing: CGFloat(.mediumSpacing)) {
+        VStack(spacing: CGFloat(.minimumSpacing)) {
             HStack {
                 VStack(spacing: CGFloat(.minimumSpacing)) {
                     HStack {
@@ -42,16 +40,6 @@ struct StationAddressTitleView: View {
                             .font(.system(size: CGFloat(.smallTitleFontSize), weight: .bold))
                             .foregroundColor(Color(colorEnum: .text))
                         Spacer()
-                    }
-
-                    if let subtitle {
-                        HStack {
-                            Text(subtitle)
-                                .font(.system(size: CGFloat(.caption)))
-                                .foregroundColor(Color(colorEnum: .darkGrey))
-                            Spacer()
-                        }
-
                     }
                 }
 
@@ -72,7 +60,6 @@ struct StationAddressTitleView: View {
 			StationChipsView(device: device,
 							 issues: issues,
 							 isScrollable: areChipsScrollable,
-							 addressAction: tapAddressAction,
 							 warningAction: tapWarningAction,
 							 statusAction: tapStatusAction)
         }
@@ -85,23 +72,18 @@ extension StationAddressTitleView {
 		 followState: UserDeviceFollowState?,
 		 issues: StationChipsView.IssuesChip?,
 		 areChipsScrollable: Bool = true,
-		 showSubtitle: Bool = true,
 		 showStateIcon: Bool = true,
 		 tapStateIconAction: VoidCallback? = nil,
-		 tapAddressAction: VoidCallback? = nil,
 		 tapWarningAction: VoidCallback? = nil,
 		 tapStatusAction: VoidCallback? = nil) {
 		self.device = device
 		self.followState = followState
-        let subtitle = device.friendlyName != nil ? device.name : nil
-        self.subtitle = showSubtitle ? subtitle : nil
 		self.issues = issues
 		self.areChipsScrollable = areChipsScrollable
         self.showStateIcon = showStateIcon
         self.stateFAIcon = followState?.state.FAIcon ?? UserDeviceFollowState.defaultFAIcon
         self.isStateIconEnabled = followState?.state.isActionable ?? true
         self.tapStateIconAction = tapStateIconAction
-        self.tapAddressAction = tapAddressAction
 		self.tapWarningAction = tapWarningAction
 		self.tapStatusAction = tapStatusAction
     }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
@@ -291,11 +291,15 @@ private extension StationDetailsViewModel {
 		}
 
 		if issues.count > 1 {
-			return (warningType, LocalizableString.issues(issues.count).localized)
+			return .init(type: warningType,
+						 icon: warningType.fontIcon,
+						 title: LocalizableString.issues(issues.count).localized)
 		}
 
 		if let issue = issues.first, issue.type != .offline {
-			return (warningType, issue.type.description)
+			return .init(type: warningType,
+						 icon: warningType.fontIcon,
+						 title: issue.type.description)
 		}
 
 		return nil

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
@@ -46,7 +46,7 @@ class StationDetailsViewModel: ObservableObject {
 	private(set) var shareDialogText: String?
     private(set) var isHeaderHidden: Bool = false
 	var issues: StationChipsView.IssuesChip? {
-		getIssuesChip()
+		device?.getIssuesChip(followState: followState)
 	}
 
     private var cancellables: Set<AnyCancellable> = []
@@ -283,27 +283,6 @@ private extension StationDetailsViewModel {
         loginAlertConfiguration = conf
         showLoginAlert = true
     }
-
-	func getIssuesChip() -> StationChipsView.IssuesChip? {
-		guard let issues = device?.issues(mainVM: .shared, followState: followState).sorted(by: { $0.warningType > $1.warningType }),
-			  let warningType = issues.first?.warningType else {
-			return nil
-		}
-
-		if issues.count > 1 {
-			return .init(type: warningType,
-						 icon: warningType.fontIcon,
-						 title: LocalizableString.issues(issues.count).localized)
-		}
-
-		if let issue = issues.first, issue.type != .offline {
-			return .init(type: warningType,
-						 icon: warningType.fontIcon,
-						 title: issue.type.description)
-		}
-
-		return nil
-	}
 
 	func navigateToAlerts() {
 		guard let device else {

--- a/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/get_user_devices.json
+++ b/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/get_user_devices.json
@@ -110,6 +110,11 @@
     "rewards": {
       "actual_reward": 10.165180164109882,
       "total_rewards": 323.64723442479493
-    }
+    },
+	"metrics" : {
+	  "pol_reason" : "NO_LOCATION_DATA",
+	  "ts" : "2024-10-14T00:00:00+00:00",
+	  "qod_score" : 99
+	}
   }
 ]

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Cells/PublicDevice.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Cells/PublicDevice.swift
@@ -15,6 +15,8 @@ public struct PublicDevice: Codable {
 	var cellCenter: LocationCoordinates?
     var currentWeather: CurrentWeather?
 	var bundle: StationBundle?
+	var qod: Int?
+	var pol: PolStatus?
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -26,5 +28,7 @@ public struct PublicDevice: Codable {
 		case cellCenter
         case currentWeather = "current_weather"
 		case bundle
+		case qod
+		case pol
     }
 }

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Cells/PublicDevice.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Cells/PublicDevice.swift
@@ -15,8 +15,7 @@ public struct PublicDevice: Codable {
 	var cellCenter: LocationCoordinates?
     var currentWeather: CurrentWeather?
 	var bundle: StationBundle?
-	var qod: Int?
-	var pol: PolStatus?
+	var metrics: Metrics?
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -28,7 +27,6 @@ public struct PublicDevice: Codable {
 		case cellCenter
         case currentWeather = "current_weather"
 		case bundle
-		case qod
-		case pol
+		case metrics
     }
 }

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Devices/NetworkDevicesResponse.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Devices/NetworkDevicesResponse.swift
@@ -21,11 +21,13 @@ public struct NetworkDevicesResponse: Codable, Identifiable {
     public var rewards: Rewards? = .init()
     public var relation: DeviceRelation?
 	public var bundle: StationBundle?
+	public var qod: Int?
+	public var pol: PolStatus?
 
     public init() {}
 
     enum CodingKeys: String, CodingKey {
-        case id, name, timezone, address, attributes, location, rewards, label, relation, bundle
+		case id, name, timezone, address, attributes, location, rewards, label, relation, bundle, qod, pol
 		case batteryState = "bat_state"
         case currentWeather = "current_weather"
     }
@@ -44,6 +46,8 @@ public struct NetworkDevicesResponse: Codable, Identifiable {
         rewards = try values.decodeIfPresent(Rewards.self, forKey: .rewards) ?? Rewards()
         relation = try? values.decodeIfPresent(DeviceRelation.self, forKey: .relation)
 		bundle = try? values.decodeIfPresent(StationBundle.self, forKey: .bundle)
+		qod = try? values.decodeIfPresent(Int.self, forKey: .qod)
+		pol = try? values.decodeIfPresent(PolStatus.self, forKey: .pol)
     }
 }
 

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Devices/NetworkDevicesResponse.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Devices/NetworkDevicesResponse.swift
@@ -21,13 +21,12 @@ public struct NetworkDevicesResponse: Codable, Identifiable {
     public var rewards: Rewards? = .init()
     public var relation: DeviceRelation?
 	public var bundle: StationBundle?
-	public var qod: Int?
-	public var pol: PolStatus?
+	public var metrics: Metrics?
 
     public init() {}
 
     enum CodingKeys: String, CodingKey {
-		case id, name, timezone, address, attributes, location, rewards, label, relation, bundle, qod, pol
+		case id, name, timezone, address, attributes, location, rewards, label, relation, bundle, metrics
 		case batteryState = "bat_state"
         case currentWeather = "current_weather"
     }
@@ -46,8 +45,7 @@ public struct NetworkDevicesResponse: Codable, Identifiable {
         rewards = try values.decodeIfPresent(Rewards.self, forKey: .rewards) ?? Rewards()
         relation = try? values.decodeIfPresent(DeviceRelation.self, forKey: .relation)
 		bundle = try? values.decodeIfPresent(StationBundle.self, forKey: .bundle)
-		qod = try? values.decodeIfPresent(Int.self, forKey: .qod)
-		pol = try? values.decodeIfPresent(PolStatus.self, forKey: .pol)
+		metrics = try? values.decodeIfPresent(Metrics.self, forKey: .metrics)
     }
 }
 

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Devices/NetworkDevicesTypes.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Devices/NetworkDevicesTypes.swift
@@ -83,3 +83,9 @@ public enum Connectivity: String, Codable {
 	case helium
 	case cellular
 }
+
+public enum PolStatus: String, Codable {
+	case verified
+	case notVerified
+	case noLocation
+}

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Devices/NetworkDevicesTypes.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Devices/NetworkDevicesTypes.swift
@@ -86,6 +86,25 @@ public enum Connectivity: String, Codable {
 
 public enum PolStatus: String, Codable {
 	case verified
-	case notVerified
-	case noLocation
+	case notVerified = "LOCATION_NOT_VERIFIED"
+	case noLocation = "NO_LOCATION_DATA"
+}
+
+public struct Metrics: Codable {
+	public let ts: Date?
+	public let qodScore: Int?
+	public let polReason: PolStatus?
+
+	enum CodingKeys: String, CodingKey {
+		case ts
+		case qodScore = "qod_score"
+		case polReason = "pol_reason"
+	}
+
+	public init(from decoder: any Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		self.ts = try container.decodeIfPresent(Date.self, forKey: .ts)
+		self.qodScore = try container.decodeIfPresent(Int.self, forKey: .qodScore)
+		self.polReason = try? container.decodeIfPresent(PolStatus.self, forKey: .polReason) ?? .verified
+	}
 }

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/DeviceDetails.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/DeviceDetails.swift
@@ -26,6 +26,8 @@ public struct DeviceDetails {
     public var rewards: Rewards?
     public var firmware: Firmware?
 	public var bundle: StationBundle?
+	public var qod: Int?
+	public var pol: PolStatus?
 }
 
 public extension DeviceDetails {
@@ -63,7 +65,9 @@ extension NetworkDevicesResponse {
                       claimedAt: attributes.claimedAt,
                       rewards: rewards,
                       firmware: attributes.firmware,
-					  bundle: bundle)
+					  bundle: bundle,
+					  qod: qod,
+					  pol: pol)
     }
 }
 
@@ -82,6 +86,8 @@ extension PublicDevice {
                       lastActiveAt: lastWeatherStationActivity,
                       rewards: nil,
                       firmware: nil,
-					  bundle: bundle)
+					  bundle: bundle,
+					  qod: qod,
+					  pol: pol)
     }
 }

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/DeviceDetails.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/DeviceDetails.swift
@@ -28,6 +28,7 @@ public struct DeviceDetails {
 	public var bundle: StationBundle?
 	public var qod: Int?
 	public var pol: PolStatus?
+	public var latestQodTs: Date?
 }
 
 public extension DeviceDetails {
@@ -67,7 +68,8 @@ extension NetworkDevicesResponse {
                       firmware: attributes.firmware,
 					  bundle: bundle,
 					  qod: metrics?.qodScore,
-					  pol: metrics?.polReason)
+					  pol: metrics?.polReason,
+					  latestQodTs: metrics?.ts)
     }
 }
 
@@ -87,7 +89,8 @@ extension PublicDevice {
                       rewards: nil,
                       firmware: nil,
 					  bundle: bundle,
-					  qod: qod,
-					  pol: pol)
+					  qod: metrics?.qodScore,
+					  pol: metrics?.polReason,
+					  latestQodTs: metrics?.ts)
     }
 }

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/DeviceDetails.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/DeviceDetails.swift
@@ -66,8 +66,8 @@ extension NetworkDevicesResponse {
                       rewards: rewards,
                       firmware: attributes.firmware,
 					  bundle: bundle,
-					  qod: qod,
-					  pol: pol)
+					  qod: metrics?.qodScore,
+					  pol: metrics?.polReason)
     }
 }
 

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -5383,6 +5383,17 @@
         }
       }
     },
+    "not_available" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "N/A"
+          }
+        }
+      }
+    },
     "offline_station" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -8023,6 +8023,17 @@
         }
       }
     },
+    "station_inactive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station inactive"
+          }
+        }
+      }
+    },
     "station_no_data_text" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -4684,6 +4684,17 @@
         }
       }
     },
+    "home_data_quality" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data Quality %d%%"
+          }
+        }
+      }
+    },
     "home_following_weather_stations_empty_button_title" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/LocalizableConstants.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableConstants.swift
@@ -171,6 +171,7 @@ enum LocalizableString: WXMLocalizable {
 	case activeStations(Int?)
 	case activeStation(Int?)
 	case presentStations(Int?)
+	case stationInactive
 
 	var localized: String {
 		var localized = NSLocalizedString(self.key, comment: "")
@@ -532,6 +533,8 @@ extension LocalizableString {
 				return "active_station_format"
 			case .presentStations:
 				return "present_stations_format"
+			case .stationInactive:
+				return "station_inactive"
 		}
 	}
 }

--- a/wxm-ios/Resources/Localizable/LocalizableConstants.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableConstants.swift
@@ -14,6 +14,7 @@ protocol WXMLocalizable {
 
 enum LocalizableString: WXMLocalizable {
 	case url(String, String)
+	case notAvailable
 	case confirm
 	case email
 	case mandatoryEmail
@@ -205,6 +206,8 @@ extension LocalizableString {
 		switch self {
 			case .url:
 				return "url_format"
+			case .notAvailable:
+				return "not_available"
 			case .confirm:
 				return "confirm"
 			case .email:

--- a/wxm-ios/Resources/Localizable/LocalizableString+Home.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+Home.swift
@@ -18,12 +18,22 @@ extension LocalizableString {
         case followingWeatherStationsEmptyDescription
         case followingWeatherStationsEmptyButtonTitle
 		case noRewardsYet
+		case dataQuality(Int)
     }
 }
 
 extension LocalizableString.Home: WXMLocalizable {
     var localized: String {
-        NSLocalizedString(key, comment: "")
+		var localized = NSLocalizedString(self.key, comment: "")
+		switch self {
+			case .dataQuality(let num):
+				localized = String(format: localized, num)
+			default:
+				break
+		}
+
+		return localized
+
     }
 
     var key: String {
@@ -46,6 +56,8 @@ extension LocalizableString.Home: WXMLocalizable {
                 return "home_following_weather_stations_empty_button_title"
 			case .noRewardsYet:
 				return "home_no_rewards_yet"
+			case .dataQuality:
+				return "home_data_quality"
         }
     }
 }


### PR DESCRIPTION
## **Why?**
Health metrics in Home Screen 
### **How?**
- Integrated `Metrics` model in all device models
- Updated weather area layout in the devices list
- Removed station indication "overflow layout" from card items
### **Testing**
Make sure the card items are rendered as expected.
You can "play" with the mock scheme and `get_user_devices` json
### **Additional context**
fixes fe-1187


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded font icon options with new icons for enhanced visual representation.
	- Introduced a new display mode, `.grid`, in the Weather Overview View for improved layout flexibility.
	- Added new properties to enhance device metrics and status tracking.
	- New computed properties for device quality status and weather fields.
	- Enhanced layout capabilities with new spacing options in UI components.
	- Added new localization cases for improved user experience regarding data availability and station status.
	- Improved representation of issues in the Station Chips View with a structured format.

- **Bug Fixes**
	- Updated localization strings for better user experience in weather-related displays.

- **Documentation**
	- Enhanced localization support with new string entries for better accessibility.

- **Chores**
	- Streamlined initialization processes for various UI components to improve code maintainability.
	- Simplified logic for displaying device indications, enhancing clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->