### PR TITLE
Health metrics updates

### DIFF
--- a/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
@@ -298,6 +298,7 @@ extension DeviceDetails {
 		device.label = "AE:66:F7:21:1F:21:75:11:EC"
 		device.address = "This is an address"
 		device.bundle = .mock()
+		device.batteryState = .low
 		device.rewards = .init(totalRewards: 53.0, actualReward: 12.53533)
 		device.isActive = false
 		device.lastActiveAt = Date.now.toTimestamp()
@@ -317,7 +318,7 @@ extension StationBundle {
 	static func mock(name: StationBundle.Code = .m5) -> StationBundle {
 		.init(name: name,
 			  title: "M5",
-			  connectivity: .wifi,
+			  connectivity: .helium,
 			  wsModel: "WS1000",
 			  gwModel: "WG1000",
 			  hwClass: "A")

--- a/PresentationLayer/Extensions/Numeric/Int+.swift
+++ b/PresentationLayer/Extensions/Numeric/Int+.swift
@@ -43,11 +43,11 @@ extension Int {
 
 	var rewardScoreFontIcon: FontIcon {
 		switch self {
-			case 0..<10:
+			case _ where self < 20:
 				return .hexagonXmark
-			case 10..<95:
+			case _ where self < 80:
 				return .hexagonExclamation
-			case 95...100:
+			case _ where self <= 100:
 				return .hexagonCheck
 			default:
 				return .hexagonExclamation
@@ -56,11 +56,11 @@ extension Int {
 
 	var rewardScoreColor: ColorEnum {
 		switch self {
-			case 0..<10:
+			case _ where self < 20:
 				return .error
-			case 10..<95:
+			case _ where self < 80:
 				return .warning
-			case 95...100:
+			case _ where self <= 100:
 				return .success
 			default:
 				return .noColor
@@ -69,12 +69,10 @@ extension Int {
 
 	var rewardScoreType: CardWarningType? {
 		switch self {
-			case 0..<10:
+			case _ where self < 20:
 				return .error
-			case 10..<95:
+			case _ where self < 80:
 				return .warning
-			case 95...100:
-				return nil
 			default:
 				return nil
 		}

--- a/PresentationLayer/UIComponents/BaseComponents/CardWarningView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/CardWarningView.swift
@@ -18,7 +18,7 @@ struct CardWarningView<Content: View>: View {
         VStack(spacing: CGFloat(.smallSpacing)) {
             HStack(spacing: CGFloat(.smallSpacing)) {
 				if configuration.showIcon {
-					Text(configuration.type.fontIcon.rawValue)
+					Text(configuration.icon?.rawValue ?? configuration.type.fontIcon.rawValue)
 						.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.mediumFontSize)))
 						.foregroundColor(Color(colorEnum: configuration.type.iconColor))
                 }
@@ -86,6 +86,7 @@ struct CardWarningConfiguration: Equatable {
 	static func == (lhs: CardWarningConfiguration, rhs: CardWarningConfiguration) -> Bool {
 		lhs.type == rhs.type &&
 		lhs.showIcon == rhs.showIcon &&
+		lhs.icon == rhs.icon &&
 		lhs.title == rhs.title &&
 		lhs.linkText == rhs.linkText &&
 		lhs.message == rhs.message &&
@@ -94,6 +95,7 @@ struct CardWarningConfiguration: Equatable {
 
 	var type: CardWarningType = .warning
 	var showIcon = true
+	var icon: FontIcon?
 	var title: String?
 	let message: String
 	var linkText: String?

--- a/PresentationLayer/UIComponents/Screens/MultipleAlerts/AlertsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/MultipleAlerts/AlertsViewModel.swift
@@ -40,6 +40,7 @@ private extension AlertsViewModel {
             let alert = MultipleAlertsView.Alert(type: .error,
                                                  title: LocalizableString.alertsStationOfflineTitle.localized,
                                                  message: LocalizableString.alertsStationOfflineDescription.localized,
+												 icon: nil,
                                                  buttonTitle: LocalizableString.contactSupport.localized,
                                                  buttonAction: handleContactSupportTap,
                                                  appearAction: nil)
@@ -50,6 +51,7 @@ private extension AlertsViewModel {
             let alert = MultipleAlertsView.Alert(type: .warning,
                                                  title: LocalizableString.stationWarningUpdateTitle.localized,
                                                  message: LocalizableString.stationWarningUpdateDescription.localized,
+												 icon: .arrowsRotate,
                                                  buttonTitle: LocalizableString.stationWarningUpdateButtonTitle.localized,
                                                  buttonAction: handleFirmwareUpdateTap,
                                                  appearAction: { [weak self] in self?.trackPromptEvent(action: .viewAction) })
@@ -60,6 +62,7 @@ private extension AlertsViewModel {
 			let alert = MultipleAlertsView.Alert(type: .warning,
 												 title: LocalizableString.stationWarningLowBatteryTitle.localized,
 												 message: LocalizableString.stationWarningLowBatteryDescription.localized,
+												 icon: .batteryLow,
 												 buttonTitle: LocalizableString.stationWarningLowBatteryButtonTitle.localized,
 												 buttonAction: handleLowBatteryTap,
 												 appearAction: nil)

--- a/PresentationLayer/UIComponents/Screens/MultipleAlerts/MultipleAlertsView.swift
+++ b/PresentationLayer/UIComponents/Screens/MultipleAlerts/MultipleAlertsView.swift
@@ -25,6 +25,7 @@ struct MultipleAlertsView: View {
 						
 						ForEach(viewModel.alerts, id: \.message) { alert in
 							CardWarningView(configuration: .init(type: alert.type,
+																 icon: alert.icon,
 																 title: alert.title,
 																 message: alert.message,
 																 showBorder: true,
@@ -77,6 +78,7 @@ extension MultipleAlertsView {
         let type: CardWarningType
         let title: String
         let message: String
+		let icon: FontIcon?
         let buttonTitle: String
         let buttonAction: VoidCallback
         let appearAction: VoidCallback?
@@ -87,7 +89,10 @@ struct MultipleAlertsView_Previews: PreviewProvider {
     static var previews: some View {
         let mainVM = MainScreenViewModel.shared
         NavigationContainerView {
-            MultipleAlertsView(viewModel: AlertsViewModel(device: .mockDevice, mainVM: mainVM, followState: .init(deviceId: "123", relation: .owned)))
+            MultipleAlertsView(viewModel: AlertsViewModel(device: .mockDevice,
+														  mainVM: mainVM,
+														  followState: .init(deviceId: "123",
+																			 relation: .owned)))
         }
     }
 }

--- a/PresentationLayer/UIComponents/Screens/MultipleAlerts/MultipleAlertsView.swift
+++ b/PresentationLayer/UIComponents/Screens/MultipleAlerts/MultipleAlertsView.swift
@@ -19,8 +19,6 @@ struct MultipleAlertsView: View {
 			
 			ScrollView {
 				VStack(spacing: CGFloat(.largeSpacing)) {
-					titleView
-					
 					VStack(spacing: CGFloat(.mediumSpacing)) {
 						
 						ForEach(viewModel.alerts, id: \.message) { alert in
@@ -45,30 +43,13 @@ struct MultipleAlertsView: View {
 				.padding(.horizontal, CGFloat(.defaultSidePadding))
 			}
 		}
-	}
-}
+		.onAppear {
+			navigationObject.title = LocalizableString.alerts.localized
+			navigationObject.titleFont = .system(size: CGFloat(.largeTitleFontSize),
+												 weight: .bold)
+			navigationObject.subtitle = viewModel.device.displayName
+			navigationObject.subtitleFont = .system(size: CGFloat(.caption))
 
-private extension MultipleAlertsView {
-	@ViewBuilder
-	var titleView: some View {
-		VStack(spacing: CGFloat(.smallSpacing)) {
-			HStack {
-				Text(LocalizableString.alerts.localized)
-					.font(.system(size: CGFloat(.largeTitleFontSize), weight: .bold))
-					.lineLimit(1)
-					.truncationMode(.middle)
-					.foregroundColor(Color(colorEnum: .text))
-
-				Spacer()
-			}
-
-			HStack {
-				Text(viewModel.device.displayName)
-					.font(.system(size: CGFloat(.caption)))
-					.foregroundColor(Color(colorEnum: .darkGrey))
-
-				Spacer()
-			}
 		}
 	}
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
@@ -235,13 +235,6 @@ private extension StationDetailsViewModel {
 
             switch res {
                 case .success(var deviceDetails):
-                    if deviceDetails.address == nil,
-                       let cellCenter,
-                       let resolvedAddress = try? await useCase?.resolveAddress(location: cellCenter) {
-
-                        deviceDetails.address = resolvedAddress
-                    }
-
                     let followState = try? await useCase?.getDeviceFollowState(deviceId: deviceId).get()
                     DispatchQueue.main.async { [weak self, deviceDetails, followState] in
                         self?.device = deviceDetails

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Cells/PublicDevice.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Cells/PublicDevice.swift
@@ -11,6 +11,7 @@ public struct PublicDevice: Codable {
     var timezone: String?
     var isActive: Bool?
     var lastWeatherStationActivity: String?
+	var address: String?
     var cellIndex: String?
 	var cellCenter: LocationCoordinates?
     var currentWeather: CurrentWeather?
@@ -23,6 +24,7 @@ public struct PublicDevice: Codable {
         case timezone
         case isActive
         case lastWeatherStationActivity
+		case address
         case cellIndex
 		case cellCenter
         case currentWeather = "current_weather"

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/DeviceDetails.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/DeviceDetails.swift
@@ -79,7 +79,7 @@ extension PublicDevice {
                       name: name,
                       friendlyName: nil,
                       label: nil,
-                      address: nil,
+                      address: address,
                       cellIndex: cellIndex,
                       cellCenter: cellCenter,
                       isActive: isActive ?? false,

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/ExplorerUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/ExplorerUseCase.swift
@@ -132,12 +132,10 @@ public class ExplorerUseCase {
                     }
 
                     Task { [weak self] in
-                        let address = await self?.resolveAddressLocation(hexCoordinates) ?? ""
                         var explorerDevices = [DeviceDetails]()
                         await devices.asyncForEach { publicDevice in
                             _ = try? await self?.meRepository.getDeviceFollowState(deviceId: publicDevice.id).get()
                             var device = publicDevice.toDeviceDetails
-                            device.address = address
 							if let hexCoordinates {
 								device.cellCenter = LocationCoordinates(lat: hexCoordinates.latitude, long: hexCoordinates.longitude)
 							}

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -136,7 +136,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The station is offline. Check that it has batteries and internet connection. If the problem persists, contact our support team."
+            "value" : "The station is not sending weather data. Check the outdoor unit’s batteries and the internet connection. If the problem persists, contact our support team."
           }
         }
       }
@@ -147,7 +147,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Station Offline"
+            "value" : "Station Inactive"
           }
         }
       }


### PR DESCRIPTION
## **Why?**
- Removed reverse geocoding functionality 
- Alerts screen updates
- Updated the ranges for the reward score (error, warning, etc)
### **Testing**
- Check if the address field is consistent
- The alerts screen is updated as expected 
- The QoD and reward score colors are following the same logic (range)
### **Additional context**
fixes fe-1190, fe-1199, fe-1193
