### PR TITLE
Updated friendly name max chars

### DIFF
--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel.swift
@@ -112,7 +112,7 @@ class DeviceInfoViewModel: ObservableObject {
 
     private let deviceInfoUseCase: DeviceInfoUseCase?
     private var cancellable: Set<AnyCancellable> = []
-	private let friendlyNameRegex = "^\\S.{0,24}$"
+	private let friendlyNameRegex = "^\\S.{0,64}$"
 
     init(device: DeviceDetails, followState: UserDeviceFollowState?) {
         self.device = device


### PR DESCRIPTION
## **Why?**
Update the max length of a valid friendly name
### **How?**
Updated the friendly name regex
### **Testing**
Ensure you can type max 64 chars in the friendly name text field
### **Additional context**
The functionality is slightly different from the designs because we use the system's alerts UI. 
If we want to change it, we should make updates globally in the app


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Increased the maximum length of valid friendly names from 24 to 64 characters, allowing for more flexibility in user input.
- **Bug Fixes**
	- Improved validation for friendly names to accommodate longer entries without functional disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->