### PR TITLE
Chart issue in reward anaytics

### DIFF
--- a/PresentationLayer/UIComponents/Screens/RewardAnalyticsView.swift
+++ b/PresentationLayer/UIComponents/Screens/RewardAnalyticsView.swift
@@ -160,7 +160,8 @@ private struct ContentView: View {
 			.id(viewModel.summaryMode)
 		}
 		.WXMCardStyle()
-		.animation(.easeIn(duration: animationDuration), value: viewModel.suammaryRewardsIsLoading)
+		.animation(.easeIn(duration: animationDuration),
+				   value: viewModel.suammaryRewardsIsLoading)
 	}
 
 	@ViewBuilder
@@ -248,6 +249,9 @@ private struct ContentView: View {
 					}
 					.aspectRatio(3.0/2.0, contentMode: .fit)
 					.frame(maxWidth: .infinity, maxHeight: .infinity)
+					.transaction { transaction in
+						transaction.animation = nil
+					}
 
 					HStack {
 						ChartLegendView(items: legendItems)
@@ -266,7 +270,8 @@ private struct ContentView: View {
 		}
 		.frame(minHeight: SpinningLoaderView.dimensions)
 		.id(stationItem.mode)
-		.animation(.easeIn(duration: animationDuration), value: stationItem.isLoading)
+		.animation(.easeIn(duration: animationDuration),
+				   value: stationItem.isLoading)
 		.spinningLoader(show: Binding(get: { stationItem.isLoading == true },
 									  set: { _ in }),
 						hideContent: true)

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Me/Network/NetworkDeviceRewardDetailsResponse.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Me/Network/NetworkDeviceRewardDetailsResponse.swift
@@ -88,7 +88,7 @@ public extension NetworkDeviceRewardDetailsResponse {
 	}
 }
 
-public enum BoostCode: Codable, RawRepresentable, Hashable {
+public enum BoostCode: Codable, RawRepresentable, Hashable, Comparable {
 	case betaReward
 	case unknown(String)
 

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Me/Network/NetworkDeviceRewardsResponse.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Me/Network/NetworkDeviceRewardsResponse.swift
@@ -14,7 +14,7 @@ public struct NetworkDeviceRewardsResponse: Codable {
 }
 
 public extension NetworkDeviceRewardsResponse {
-	enum RewardType: String, Codable {
+	enum RewardType: String, Codable, CaseIterable {
 		case base
 		case boost
 	}


### PR DESCRIPTION
## **Why?**
The area graph for each device used to seem  broken when there were more than one reward with the same type 
### **How?**
Fixed the generation of the chart data items with summarized the items with the same type in the factory class (`RewardAnalyitcsChartFactory`)
### **Testing**
Play with the mock files (`get_device_rewards_analytics_`...) and ensure there is no broken state.
Add more items of the same type (eg. `base`) in the same `rewards` array
### **Additional context**
fixes fe-1275


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced chart data handling for improved reward analytics.
	- Introduced a new transaction modifier for explicit animation control in chart views.
	- BoostCode enum now supports comparison operations.
	- RewardType enum now allows iteration over all its cases.

- **Bug Fixes**
	- Improved clarity in animation handling for UI components.

- **Documentation**
	- Updated method signatures for better understanding and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->