### PR TITLE
My profile tab error state

### DIFF
--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
@@ -221,17 +221,29 @@ private extension ProfileViewModel {
 	}
 
 	func updateRewards(additionalClaimed: String? = nil) {
-		let cumulative = userRewardsResponse?.cumulativeAmount?.toEthDouble ?? 0.0
-		totalEarned = cumulative.toWXMTokenPrecisionString + " " + StringConstants.wxmCurrency
+		if let cumulative = userRewardsResponse?.cumulativeAmount?.toEthDouble {
+			totalEarned = cumulative.toWXMTokenPrecisionString + " " + StringConstants.wxmCurrency
+		} else {
+			totalEarned = "N/A"
+		}
 
-		let claimed = (userRewardsResponse?.totalClaimed?.toEthDouble ?? 0.0) + (additionalClaimed?.toEthDouble ?? 0.0)
-		totalClaimed = claimed.toWXMTokenPrecisionString + " " + StringConstants.wxmCurrency
+		if let total = userRewardsResponse?.totalClaimed?.toEthDouble {
+			let claimed = total + (additionalClaimed?.toEthDouble ?? 0.0)
+			totalClaimed = claimed.toWXMTokenPrecisionString + " " + StringConstants.wxmCurrency
+		} else {
+			totalClaimed = "N/A"
+		}
 
-		let allocated = (userRewardsResponse?.available?.toEthDouble ?? 0.0) - (additionalClaimed?.toEthDouble ?? 0.0)
-		isClaimAvailable = allocated > 0.0
-		let noRewardsString = LocalizableString.Profile.noRewardsDescription.localized
-		let valueString = allocated.toWXMTokenPrecisionString + " " + StringConstants.wxmCurrency
-		allocatedRewards = allocated == 0.0 ? noRewardsString : valueString
+		if let available = userRewardsResponse?.available?.toEthDouble {
+			let allocated = available - (additionalClaimed?.toEthDouble ?? 0.0)
+			isClaimAvailable = allocated > 0.0
+			let noRewardsString = LocalizableString.Profile.noRewardsDescription.localized
+			let valueString = allocated.toWXMTokenPrecisionString + " " + StringConstants.wxmCurrency
+			allocatedRewards = allocated == 0.0 ? noRewardsString : valueString
+		} else {
+			allocatedRewards = "N/A"
+			isClaimAvailable = false
+		}
 	}
 
 	func updateUserInfoValues() {

--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
@@ -224,14 +224,14 @@ private extension ProfileViewModel {
 		if let cumulative = userRewardsResponse?.cumulativeAmount?.toEthDouble {
 			totalEarned = cumulative.toWXMTokenPrecisionString + " " + StringConstants.wxmCurrency
 		} else {
-			totalEarned = "N/A"
+			totalEarned = LocalizableString.notAvailable.localized
 		}
 
 		if let total = userRewardsResponse?.totalClaimed?.toEthDouble {
 			let claimed = total + (additionalClaimed?.toEthDouble ?? 0.0)
 			totalClaimed = claimed.toWXMTokenPrecisionString + " " + StringConstants.wxmCurrency
 		} else {
-			totalClaimed = "N/A"
+			totalClaimed = LocalizableString.notAvailable.localized
 		}
 
 		if let available = userRewardsResponse?.available?.toEthDouble {
@@ -241,7 +241,7 @@ private extension ProfileViewModel {
 			let valueString = allocated.toWXMTokenPrecisionString + " " + StringConstants.wxmCurrency
 			allocatedRewards = allocated == 0.0 ? noRewardsString : valueString
 		} else {
-			allocatedRewards = "N/A"
+			allocatedRewards = LocalizableString.notAvailable.localized
 			isClaimAvailable = false
 		}
 	}

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -5383,6 +5383,17 @@
         }
       }
     },
+    "not_available" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "N/A"
+          }
+        }
+      }
+    },
     "offline_station" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/LocalizableConstants.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableConstants.swift
@@ -14,6 +14,7 @@ protocol WXMLocalizable {
 
 enum LocalizableString: WXMLocalizable {
 	case url(String, String)
+	case notAvailable
 	case confirm
 	case email
 	case mandatoryEmail
@@ -205,6 +206,8 @@ extension LocalizableString {
 		switch self {
 			case .url:
 				return "url_format"
+			case .notAvailable:
+				return "not_available"
 			case .confirm:
 				return "confirm"
 			case .email:


### PR DESCRIPTION
## **Why?**
Update the state of profile tab in case of error
### **How?**
Show N/A when there is no value to show
### **Testing**
- Run the dev app which throws an error in the withdraw endpoint and ensure everything looks as expected.
- Run the app again pointing to the production server (the withdraw endpoint will be successful) and ensure nothing is broken
### **Additional context**
fixes fe-1264
