### PR TITLE
Integrate library to monitor http requests

### DIFF
--- a/PresentationLayer/UIComponents/Screens/MainScreen/MainScreen.swift
+++ b/PresentationLayer/UIComponents/Screens/MainScreen/MainScreen.swift
@@ -8,6 +8,9 @@
 import Network
 import SwiftUI
 import DomainLayer
+#if DEBUG
+import PulseUI
+#endif
 
 public struct MainScreen: View {
     @StateObject var viewModel: MainScreenViewModel
@@ -40,6 +43,13 @@ public struct MainScreen: View {
 		.onNotificationReceive { notificationResponse in
 			_ = viewModel.deepLinkHandler.handleNotificationReceive(notificationResponse)
 		}
+		#if DEBUG
+		.bottomSheet(show: $viewModel.showHttpMonitor, initialDetentId: .large) {
+			NavigationStack {
+				ConsoleView()
+			}
+		}
+		#endif
     }
 
     public var mainScreenSwitch: some View {

--- a/PresentationLayer/UIComponents/Screens/MainScreen/MainScreenViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/MainScreen/MainScreenViewModel.swift
@@ -55,6 +55,7 @@ class MainScreenViewModel: ObservableObject {
 	}
 	@Published var isWalletMissing: Bool = false
     @Published var showAppUpdatePrompt: Bool = false
+	@Published var showHttpMonitor: Bool = false
 
     let swinjectHelper: SwinjectInterface
 
@@ -103,6 +104,12 @@ class MainScreenViewModel: ObservableObject {
 		}.store(in: &cancellableSet)
 
 		requestNotificationAuthorizationIfNeeded()
+
+		NotificationCenter.default.addObserver(forName: .deviceDidShake,
+											   object: nil,
+											   queue: .main) { [weak self] _ in
+			self?.showHttpMonitor = true
+		}
     }
 
     @Published var showFirmwareUpdate = false

--- a/PresentationLayer/Utils/UIKitUtils/UIKitUtils.swift
+++ b/PresentationLayer/Utils/UIKitUtils/UIKitUtils.swift
@@ -8,6 +8,11 @@
 import UIKit
 import Toolkit
 
+extension Notification.Name {
+	static let deviceDidShake = Notification.Name("deviceDidShake")
+}
+
+
 extension UIApplication {
 
     var currentKeyWindow: UIWindow? {
@@ -57,6 +62,14 @@ extension UIWindow {
         isHidden = true
         windowScene = nil
     }
+
+	open override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+		guard motion == .motionShake else {
+			return
+		}
+
+		NotificationCenter.default.post(name: .deviceDidShake, object: nil)
+	}
 }
 
 /// Used for keeping weak refs on hosting controllers

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -297,6 +297,7 @@
 		267CA6CB2C11C13000ABE599 /* ClaimM5ContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CA6CA2C11C13000ABE599 /* ClaimM5ContainerViewModel.swift */; };
 		267CA6CD2C11C4FD00ABE599 /* ClaimD1ContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CA6CC2C11C4FD00ABE599 /* ClaimD1ContainerViewModel.swift */; };
 		267CA6CF2C11C67800ABE599 /* ClaimHeliumContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CA6CE2C11C67800ABE599 /* ClaimHeliumContainerViewModel.swift */; };
+		267EC3B62CCBDF2C0085B50A /* PulseUI in Frameworks */ = {isa = PBXBuildFile; productRef = 267EC3B52CCBDF2C0085B50A /* PulseUI */; };
 		267EC4262A98C14700F2C37E /* UIKitUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267EC4252A98C14700F2C37E /* UIKitUtils.swift */; };
 		267EC4292A98C3D300F2C37E /* WXMAlertModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267EC4272A98C3D300F2C37E /* WXMAlertModifier.swift */; };
 		267EC42A2A98C3D300F2C37E /* WXMAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267EC4282A98C3D300F2C37E /* WXMAlertView.swift */; };
@@ -1087,6 +1088,7 @@
 				261E9EAA29A927BE00E8EBA3 /* CodeScanner in Frameworks */,
 				B5799E9F28254E3300FEBB85 /* DataLayer.framework in Frameworks */,
 				B5799E9D28254E3000FEBB85 /* DomainLayer.framework in Frameworks */,
+				267EC3B62CCBDF2C0085B50A /* PulseUI in Frameworks */,
 				263B8B552B29FE34001C5060 /* MapboxStatic in Frameworks */,
 				269C968A2BDBD5660035B8F1 /* Mixpanel in Frameworks */,
 				26FFAD682B8DF9C200BF0A6B /* LazyLoadingPager in Frameworks */,
@@ -2699,6 +2701,7 @@
 				261729F32C36A14C00A1CEFA /* SwiftUIIntrospect */,
 				26C801DB2C2B162A00D6AC60 /* FLAnimatedImage */,
 				26A86BFA2C7F68C400F1C2CF /* DGCharts */,
+				267EC3B52CCBDF2C0085B50A /* PulseUI */,
 			);
 			productName = "wxm-ios";
 			productReference = B52BCC712824FB8F00EA3DA5 /* WeatherXM.app */;
@@ -2754,6 +2757,7 @@
 				261729F22C36A14C00A1CEFA /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 				26C801DA2C2B162A00D6AC60 /* XCRemoteSwiftPackageReference "FLAnimatedImage" */,
 				26A86BF92C7F68C400F1C2CF /* XCRemoteSwiftPackageReference "Charts" */,
+				267EC3B42CCBDF2C0085B50A /* XCRemoteSwiftPackageReference "Pulse" */,
 			);
 			productRefGroup = B52BCC722824FB8F00EA3DA5 /* Products */;
 			projectDirPath = "";
@@ -4144,6 +4148,14 @@
 				minimumVersion = 12.4.0;
 			};
 		};
+		267EC3B42CCBDF2C0085B50A /* XCRemoteSwiftPackageReference "Pulse" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kean/Pulse";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.1.2;
+			};
+		};
 		269C96882BDBD5660035B8F1 /* XCRemoteSwiftPackageReference "mixpanel-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mixpanel/mixpanel-swift";
@@ -4261,6 +4273,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 261E9EB629A92BE000E8EBA3 /* XCRemoteSwiftPackageReference "Alamofire" */;
 			productName = Alamofire;
+		};
+		267EC3B52CCBDF2C0085B50A /* PulseUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 267EC3B42CCBDF2C0085B50A /* XCRemoteSwiftPackageReference "Pulse" */;
+			productName = PulseUI;
 		};
 		269C96892BDBD5660035B8F1 /* Mixpanel */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/wxm-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/wxm-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2e3116a5925db1fe7150c03a08565be9319199a74ecea5c3c950e3f110ed83e1",
+  "originHash" : "5805be532f0c6b45837aaa55fee5ad0c95fa51a6e7aa0140094adb54f266fb12",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -29,39 +29,12 @@
       }
     },
     {
-      "identity" : "charts",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ChartsOrg/Charts.git",
-      "state" : {
-        "revision" : "dd9c72e3d7e751e769971092a6bd72d39198ae63",
-        "version" : "5.1.0"
-      }
-    },
-    {
-      "identity" : "codescanner",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/twostraws/CodeScanner",
-      "state" : {
-        "revision" : "9fa582f4b36c69c2a55bff5fb3377eb170ae273c",
-        "version" : "2.5.1"
-      }
-    },
-    {
       "identity" : "firebase-ios-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
         "revision" : "eca84fd638116dd6adb633b5a3f31cc7befcbb7d",
         "version" : "10.29.0"
-      }
-    },
-    {
-      "identity" : "flanimatedimage",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Flipboard/FLAnimatedImage",
-      "state" : {
-        "revision" : "d4f07b6f164d53c1212c3e54d6460738b1981e9f",
-        "version" : "1.0.17"
       }
     },
     {
@@ -128,39 +101,12 @@
       }
     },
     {
-      "identity" : "iqkeyboardmanager",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/hackiftekhar/IQKeyboardManager.git",
-      "state" : {
-        "revision" : "c00b1ae9fa1ad8af4465bb6ca901f6943fc98eba",
-        "version" : "6.5.16"
-      }
-    },
-    {
-      "identity" : "lazyloadingpager",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/WeatherXM/LazyLoadingPager",
-      "state" : {
-        "revision" : "6c3573a3eabb7692b841061b5f3f14c14e50bb27",
-        "version" : "1.0.0"
-      }
-    },
-    {
       "identity" : "leveldb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/leveldb.git",
       "state" : {
         "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
         "version" : "1.22.5"
-      }
-    },
-    {
-      "identity" : "lottie-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/airbnb/lottie-ios.git",
-      "state" : {
-        "revision" : "fe4c6fe3a0aa66cdeb51d549623c82ca9704b9a5",
-        "version" : "4.5.0"
       }
     },
     {
@@ -191,15 +137,6 @@
       }
     },
     {
-      "identity" : "mapboxstatic.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mapbox/MapboxStatic.swift",
-      "state" : {
-        "revision" : "886e17c242fe9f573ab6c27871a26c0795400017",
-        "version" : "0.12.0"
-      }
-    },
-    {
       "identity" : "mixpanel-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mixpanel/mixpanel-swift",
@@ -218,24 +155,6 @@
       }
     },
     {
-      "identity" : "nuke",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kean/Nuke.git",
-      "state" : {
-        "revision" : "0ead44350d2737db384908569c012fe67c421e4d",
-        "version" : "12.8.0"
-      }
-    },
-    {
-      "identity" : "polyline",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/raphaelmor/Polyline.git",
-      "state" : {
-        "revision" : "353f80378dcd8f17eefe8550090c6b1ae3c9da23",
-        "version" : "5.1.0"
-      }
-    },
-    {
       "identity" : "promises",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
@@ -245,12 +164,12 @@
       }
     },
     {
-      "identity" : "pullablescrollview",
+      "identity" : "pulse",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pantelisss/PullableScrollView.git",
+      "location" : "https://github.com/kean/Pulse",
       "state" : {
-        "revision" : "da9d37dc041c2554a7ea163f6bdc5b5d3027cc99",
-        "version" : "1.0.1"
+        "revision" : "c102aaa266ac69a26d08ee6861da710283988e3b",
+        "version" : "5.1.2"
       }
     },
     {
@@ -272,39 +191,12 @@
       }
     },
     {
-      "identity" : "swiftui-introspect",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
-      "state" : {
-        "revision" : "668a65735751432b640260c56dfa621cec568368",
-        "version" : "1.2.0"
-      }
-    },
-    {
-      "identity" : "swinject",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Swinject/Swinject",
-      "state" : {
-        "revision" : "be9dbcc7b86811bc131539a20c6f9c2d3e56919f",
-        "version" : "2.9.1"
-      }
-    },
-    {
       "identity" : "turf-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/turf-swift.git",
       "state" : {
         "revision" : "213050191cfcb3d5aa76e1fa90c6ff1e182a42ca",
         "version" : "2.8.0"
-      }
-    },
-    {
-      "identity" : "veil",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/DanielCardonaRojas/Veil",
-      "state" : {
-        "revision" : "967a2f103972ce5043e28f1920330ee934bcbadc",
-        "version" : "0.2.0"
       }
     },
     {

--- a/wxm-ios/DataLayer/DataLayer.xcodeproj/project.pbxproj
+++ b/wxm-ios/DataLayer/DataLayer.xcodeproj/project.pbxproj
@@ -39,6 +39,9 @@
 		2674EDCE2A3C4C3800616285 /* get_network_stats_alt.json in Resources */ = {isa = PBXBuildFile; fileRef = 2674EDCD2A3C4C3800616285 /* get_network_stats_alt.json */; };
 		267A37872AEBEBBA00469126 /* get_user_device_rewards.json in Resources */ = {isa = PBXBuildFile; fileRef = 267A37862AEBEBBA00469126 /* get_user_device_rewards.json */; };
 		267CA6EF2C1314E300ABE599 /* get_user.json in Resources */ = {isa = PBXBuildFile; fileRef = 267CA6EE2C1314E200ABE599 /* get_user.json */; };
+		267EC3BC2CD0E8BD0085B50A /* MainRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267EC3BB2CD0E8BD0085B50A /* MainRepositoryImpl.swift */; };
+		267EC3BF2CD0ECE60085B50A /* Pulse in Frameworks */ = {isa = PBXBuildFile; productRef = 267EC3BE2CD0ECE60085B50A /* Pulse */; };
+		267EC3C12CD0ECE60085B50A /* PulseProxy in Frameworks */ = {isa = PBXBuildFile; productRef = 267EC3C02CD0ECE60085B50A /* PulseProxy */; };
 		2683A4C42ADECF3100D5C205 /* countries_information.json in Resources */ = {isa = PBXBuildFile; fileRef = 2683A4C32ADECBA800D5C205 /* countries_information.json */; };
 		268ACD052C1B2A3500B30F83 /* DBBundle+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268ACD032C1B2A3500B30F83 /* DBBundle+CoreDataClass.swift */; };
 		268ACD062C1B2A3500B30F83 /* DBBundle+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268ACD042C1B2A3500B30F83 /* DBBundle+CoreDataProperties.swift */; };
@@ -130,6 +133,7 @@
 		2674EDCD2A3C4C3800616285 /* get_network_stats_alt.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = get_network_stats_alt.json; sourceTree = "<group>"; };
 		267A37862AEBEBBA00469126 /* get_user_device_rewards.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = get_user_device_rewards.json; sourceTree = "<group>"; };
 		267CA6EE2C1314E200ABE599 /* get_user.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = get_user.json; sourceTree = "<group>"; };
+		267EC3BB2CD0E8BD0085B50A /* MainRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainRepositoryImpl.swift; sourceTree = "<group>"; };
 		2683A4C32ADECBA800D5C205 /* countries_information.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = countries_information.json; sourceTree = "<group>"; };
 		268ACD032C1B2A3500B30F83 /* DBBundle+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBBundle+CoreDataClass.swift"; sourceTree = "<group>"; };
 		268ACD042C1B2A3500B30F83 /* DBBundle+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBBundle+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -195,7 +199,9 @@
 				B51244012825516A00B66A31 /* Alamofire in Frameworks */,
 				B51243F5282550B100B66A31 /* DomainLayer.framework in Frameworks */,
 				4D49D910294DE53700987DE6 /* MapboxMaps in Frameworks */,
+				267EC3BF2CD0ECE60085B50A /* Pulse in Frameworks */,
 				4D49D90A294DE3B300987DE6 /* MapboxSearch in Frameworks */,
+				267EC3C12CD0ECE60085B50A /* PulseProxy in Frameworks */,
 				264BDA0A298ABF6B005C1F82 /* NordicDFU in Frameworks */,
 				26DD42AF29AF4765008E277E /* Toolkit.framework in Frameworks */,
 			);
@@ -331,6 +337,7 @@
 				264BDA0B298AC792005C1F82 /* FirmwareUpdateImpl.swift */,
 				B56A25ED28A0F5F500928141 /* KeychainRepositoryImpl.swift */,
 				4D1C95CF28FC7EB1001F66C9 /* LocationRepositoryImpl.swift */,
+				267EC3BB2CD0E8BD0085B50A /* MainRepositoryImpl.swift */,
 				74F9229128351E4000CD8FDF /* MeRepositoryImpl.swift */,
 				267401752A376A1400E54E35 /* NetworkRepositoryImpl.swift */,
 				26D47E9D2A177AFB0078723A /* SettingsRepositoryImpl.swift */,
@@ -466,6 +473,8 @@
 				4D49D909294DE3B300987DE6 /* MapboxSearch */,
 				4D49D90F294DE53700987DE6 /* MapboxMaps */,
 				264BDA09298ABF6B005C1F82 /* NordicDFU */,
+				267EC3BE2CD0ECE60085B50A /* Pulse */,
+				267EC3C02CD0ECE60085B50A /* PulseProxy */,
 			);
 			productName = DataLayer;
 			productReference = B5799E7328254CC100FEBB85 /* DataLayer.framework */;
@@ -500,6 +509,7 @@
 				4D49D908294DE3B300987DE6 /* XCRemoteSwiftPackageReference "search-ios" */,
 				4D49D90E294DE53700987DE6 /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */,
 				264BDA08298ABF6B005C1F82 /* XCRemoteSwiftPackageReference "IOS-DFU-Library" */,
+				267EC3BD2CD0ECE60085B50A /* XCRemoteSwiftPackageReference "Pulse" */,
 			);
 			productRefGroup = B5799E7428254CC100FEBB85 /* Products */;
 			projectDirPath = "";
@@ -607,6 +617,7 @@
 				995A0CDE28C0AA400015DAA1 /* UserDefaultsRepositoryImp.swift in Sources */,
 				995A0CDC28C0A9830015DAA1 /* UserDefaultsService.swift in Sources */,
 				26AB9F522A80112900855912 /* UserDevicesService.swift in Sources */,
+				267EC3BC2CD0E8BD0085B50A /* MainRepositoryImpl.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -940,6 +951,14 @@
 				minimumVersion = 4.0.0;
 			};
 		};
+		267EC3BD2CD0ECE60085B50A /* XCRemoteSwiftPackageReference "Pulse" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kean/Pulse";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.1.2;
+			};
+		};
 		4D49D908294DE3B300987DE6 /* XCRemoteSwiftPackageReference "search-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mapbox/search-ios.git";
@@ -971,6 +990,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 264BDA08298ABF6B005C1F82 /* XCRemoteSwiftPackageReference "IOS-DFU-Library" */;
 			productName = NordicDFU;
+		};
+		267EC3BE2CD0ECE60085B50A /* Pulse */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 267EC3BD2CD0ECE60085B50A /* XCRemoteSwiftPackageReference "Pulse" */;
+			productName = Pulse;
+		};
+		267EC3C02CD0ECE60085B50A /* PulseProxy */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 267EC3BD2CD0ECE60085B50A /* XCRemoteSwiftPackageReference "Pulse" */;
+			productName = PulseProxy;
 		};
 		4D49D909294DE3B300987DE6 /* MapboxSearch */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/MainRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/MainRepositoryImpl.swift
@@ -1,0 +1,24 @@
+//
+//  MainRepositoryImpl.swift
+//  DataLayer
+//
+//  Created by Pantelis Giazitsis on 29/10/24.
+//
+
+import Foundation
+import DomainLayer
+#if DEBUG
+import Pulse
+import PulseProxy
+#endif
+
+public struct MainRepositoryImpl: MainRepository {
+	public init() {}
+	
+	public func initializeHttpMonitor() {
+	#if DEBUG
+		NetworkLogger.enableProxy()
+	#endif
+	}
+
+}

--- a/wxm-ios/DomainLayer/DomainLayer.xcodeproj/project.pbxproj
+++ b/wxm-ios/DomainLayer/DomainLayer.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		267401702A375D3800E54E35 /* NetworkStatsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2674016F2A375D3800E54E35 /* NetworkStatsResponse.swift */; };
 		267401722A37687000E54E35 /* NetworkUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267401712A37687000E54E35 /* NetworkUseCase.swift */; };
 		267401742A3768AF00E54E35 /* NetworkRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267401732A3768AF00E54E35 /* NetworkRepository.swift */; };
+		267EC3BA2CD0E85A0085B50A /* MainRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267EC3B92CD0E85A0085B50A /* MainRepository.swift */; };
 		2683A4C22ADEB39800D5C205 /* CountryInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2683A4C12ADEB39800D5C205 /* CountryInfo.swift */; };
 		2691840C2C08ABD300705755 /* BluetoothHeliumError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2691840B2C08ABD300705755 /* BluetoothHeliumError.swift */; };
 		26A3B3DE2B18E41F0002F35F /* NetworkUserRewardsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A3B3DD2B18E41F0002F35F /* NetworkUserRewardsResponse.swift */; };
@@ -111,6 +112,7 @@
 		2674016F2A375D3800E54E35 /* NetworkStatsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStatsResponse.swift; sourceTree = "<group>"; };
 		267401712A37687000E54E35 /* NetworkUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkUseCase.swift; sourceTree = "<group>"; };
 		267401732A3768AF00E54E35 /* NetworkRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRepository.swift; sourceTree = "<group>"; };
+		267EC3B92CD0E85A0085B50A /* MainRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainRepository.swift; sourceTree = "<group>"; };
 		2683A4C12ADEB39800D5C205 /* CountryInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryInfo.swift; sourceTree = "<group>"; };
 		2691840B2C08ABD300705755 /* BluetoothHeliumError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothHeliumError.swift; sourceTree = "<group>"; };
 		26A3B3DD2B18E41F0002F35F /* NetworkUserRewardsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkUserRewardsResponse.swift; sourceTree = "<group>"; };
@@ -309,6 +311,7 @@
 				2612AC212AB4621A00285896 /* FiltersRepository.swift */,
 				264BDA0D298AC7DD005C1F82 /* FirmwareUpdateRepository.swift */,
 				B56A25E928A0F18500928141 /* KeychainRepository.swift */,
+				267EC3B92CD0E85A0085B50A /* MainRepository.swift */,
 				B5E6B88A2833B7730060D050 /* MeRepository.swift */,
 				267401732A3768AF00E54E35 /* NetworkRepository.swift */,
 				26D47E9B2A177A0F0078723A /* SettingsRepository.swift */,
@@ -534,6 +537,7 @@
 				B5E6B85D28338BF20060D050 /* AuthUseCase.swift in Sources */,
 				4D5AE32E28EA4882006F2EBA /* BluetoothDevicesRepository.swift in Sources */,
 				B5667D722833DF4000C08B57 /* ClaimDeviceBody.swift in Sources */,
+				267EC3BA2CD0E85A0085B50A /* MainRepository.swift in Sources */,
 				99BA878828BCF4D9004611AC /* Collection+.swift in Sources */,
 				26C904C32A77DBA90047A388 /* DeviceDetails.swift in Sources */,
 				26C904C12A77DA5A0047A388 /* DeviceDetailsUseCase.swift in Sources */,

--- a/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/MainRepository.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/MainRepository.swift
@@ -1,0 +1,12 @@
+//
+//  MainRepository.swift
+//  DomainLayer
+//
+//  Created by Pantelis Giazitsis on 29/10/24.
+//
+
+import Foundation
+
+public protocol MainRepository {
+	func initializeHttpMonitor()
+}

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/MainUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/MainUseCase.swift
@@ -12,12 +12,17 @@ import Combine
 public class MainUseCase {
 	public var userLoggedInStateNotificationPublisher: NotificationCenter.Publisher
 
+	private let mainRepository: MainRepository
     private let userDefaultsRepository: UserDefaultsRepository
 	private let keychainRepository: KeychainRepository
 	private let meRepository: MeRepository
 	private var cancellableSet: Set<AnyCancellable> = .init()
 
-	public init(userDefaultsRepository: UserDefaultsRepository, keychainRepository: KeychainRepository, meRepository: MeRepository) {
+	public init(mainRepository: MainRepository,
+				userDefaultsRepository: UserDefaultsRepository,
+				keychainRepository: KeychainRepository,
+				meRepository: MeRepository) {
+		self.mainRepository = mainRepository
         self.userDefaultsRepository = userDefaultsRepository
 		self.keychainRepository = keychainRepository
 		self.meRepository = meRepository
@@ -26,6 +31,8 @@ public class MainUseCase {
 		FirebaseManager.shared.fcmTokenPublisher?.sink { [weak self] _ in
 			self?.setFCMTokenIfNeeded()
 		}.store(in: &cancellableSet)
+
+		mainRepository.initializeHttpMonitor()
     }
 
     public func saveOrUpdateWeatherMetric(unitProtocol: UnitsProtocol) {

--- a/wxm-ios/Swinject/SwinjectHelper.swift
+++ b/wxm-ios/Swinject/SwinjectHelper.swift
@@ -31,6 +31,10 @@ class SwinjectHelper: SwinjectInterface {
 		}
 		.inObjectScope(.container)
 
+		container.register(MainRepository.self) { _ in
+			MainRepositoryImpl()
+		}
+
         // MARK: - Settings
 
         container.register(SettingsRepository.self) { _ in
@@ -141,7 +145,8 @@ class SwinjectHelper: SwinjectInterface {
         // MARK: - Main Use Case
 
         container.register(MainUseCase.self) { resolver in
-			MainUseCase(userDefaultsRepository: resolver.resolve(UserDefaultsRepository.self)!,
+			MainUseCase(mainRepository: resolver.resolve(MainRepository.self)!,
+						userDefaultsRepository: resolver.resolve(UserDefaultsRepository.self)!,
 						keychainRepository: resolver.resolve(KeychainRepository.self)!,
 						meRepository: resolver.resolve(MeRepository.self)!)
         }


### PR DESCRIPTION
## **Why?**
We decided to use the [pulse](https://github.com/kean/Pulse) library 
### **How?**
- Declared a main repository to initialize generic stuff for the app, HTTP requests monitoring for now.
- Pulse libraries are imported only in debug builds
### **Testing**
- Run the app, shake the device (ctrl + cmd + z for the simulator) and ensure the pulse modal is presented
- Run the release scheme (`wxm-ios-release`) and ensure the functionality is missing
### **Additional context**
fixes fe-1253


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a debug-specific HTTP monitor that can be displayed when the device is shaken.
  - Added a new repository structure to facilitate HTTP monitoring during development.

- **Bug Fixes**
  - Enhanced handling of device shake events to trigger the HTTP monitor.

- **Chores**
  - Updated project dependencies, integrating the `PulseUI` framework for improved UI logging capabilities.
  - Removed several unused dependencies to streamline the project.

These changes enhance the application's debugging capabilities and maintain a cleaner project structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->