### PR TITLE
Alert message for station inactive owner flow

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/StationLastActiveView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/StationLastActiveView.swift
@@ -21,6 +21,7 @@ struct StationLastActiveView: View {
 			Text(configuration.lastActiveAt?.lastActiveTime() ?? LocalizableString.notAvailable.localized)
                 .font(.system(size: CGFloat(.caption)))
 				.foregroundColor(Color(colorEnum: .text))
+				.lineLimit(1)
         }
 		.WXMCardStyle(backgroundColor: Color(colorEnum: .blueTint),
                       insideHorizontalPadding: CGFloat(.smallSidePadding),

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -136,7 +136,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The station is not sending weather data. Check the outdoor unit’s batteries and the internet connection. If the problem persists, contact our support team."
+            "value" : "The station is not sending weather data. Check your network connection and the outdoor unit’s batteries. If the problem persists, contact our support team."
           }
         }
       }


### PR DESCRIPTION
## **Why?**
Update the alert message for the inactive state of an owned station
### **How?**
Updated localized string
### **Testing**
Ensure the message is updated 
### **Additional context**
fixes fe-1308


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new localization strings for enhanced user feedback and error handling.
	- Updated existing strings to improve clarity regarding device claiming and connection issues.

- **Bug Fixes**
	- Adjusted phrasing in error messages to provide clearer troubleshooting guidance.

- **Style**
	- Set a line limit for the last active time display to prevent text overflow and improve layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->