### PR TITLE
Find a way for the bottom sheet to fit its content

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/CustomSheet/BottomSheetModifier.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/CustomSheet/BottomSheetModifier.swift
@@ -59,8 +59,8 @@ private struct BottomSheetContainerView<V: View>: View {
 							.sizeObserver(size: $contentSize)
 					}
 					.scrollIndicators(.hidden)
-					.padding(.top)
 				}
+				.padding(.top)
 		}
 		.if(fitContent) { view in
 			view

--- a/PresentationLayer/UIComponents/BaseComponents/CustomSheet/BottomSheetModifier.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/CustomSheet/BottomSheetModifier.swift
@@ -67,12 +67,12 @@ private struct BottomSheetContainerView<V: View>: View {
 							view
 						}
 					}
-					.padding(.top, CGFloat(.defaultSidePadding))
 				}
 				.if(fitContent) { view in
 					view
 						.presentationDetents([.height(contentSize.height + CGFloat(.defaultSidePadding))])
 				}
+				.padding(.top, CGFloat(.defaultSidePadding))
 		}
 		.presentationDragIndicator(.visible)
 	}

--- a/PresentationLayer/UIComponents/BaseComponents/CustomSheet/BottomSheetModifier.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/CustomSheet/BottomSheetModifier.swift
@@ -59,12 +59,20 @@ private struct BottomSheetContainerView<V: View>: View {
 							.sizeObserver(size: $contentSize)
 					}
 					.scrollIndicators(.hidden)
+					.modify { view in
+						if #available(iOS 16.4, *) {
+							view
+								.scrollBounceBehavior(.basedOnSize, axes: [.vertical])
+						} else {
+							view
+						}
+					}
+					.padding(.top, CGFloat(.defaultSidePadding))
 				}
-				.padding(.top)
-		}
-		.if(fitContent) { view in
-			view
-				.presentationDetents([.height(contentSize.height)])
+				.if(fitContent) { view in
+					view
+						.presentationDetents([.height(contentSize.height + CGFloat(.defaultSidePadding))])
+				}
 		}
 		.presentationDragIndicator(.visible)
 	}

--- a/PresentationLayer/UIComponents/BaseComponents/CustomSheet/BottomSheetModifier.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/CustomSheet/BottomSheetModifier.swift
@@ -81,7 +81,7 @@ private struct BottomSheetContainerView<V: View>: View {
 
 	var body: some View {
 		ZStack {
-			Color(colorEnum: .layer1)
+			Color(colorEnum: .bottomSheetBg)
 				.ignoresSafeArea()
 
 			content()

--- a/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCard.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherStationCard/WeatherStationCard.swift
@@ -55,6 +55,7 @@ private extension WeatherStationCard {
 				Text(device.qodStatusText)
 					.font(.system(size: CGFloat(.caption)))
 					.foregroundStyle(Color(colorEnum: .text))
+					.lineLimit(1)
 					.fixedSize()
 			}
 
@@ -67,7 +68,7 @@ private extension WeatherStationCard {
 				Text(device.locationText)
 					.font(.system(size: CGFloat(.caption)))
 					.foregroundStyle(Color(colorEnum: .text))
-					.lineLimit(2)
+					.lineLimit(1)
 					.fixedSize(horizontal: false, vertical: true)
 			}
 

--- a/PresentationLayer/UIComponents/Screens/MainScreen/MainScreen.swift
+++ b/PresentationLayer/UIComponents/Screens/MainScreen/MainScreen.swift
@@ -44,7 +44,7 @@ public struct MainScreen: View {
 			_ = viewModel.deepLinkHandler.handleNotificationReceive(notificationResponse)
 		}
 		#if DEBUG
-		.bottomSheet(show: $viewModel.showHttpMonitor, initialDetentId: .large) {
+		.bottomSheet(show: $viewModel.showHttpMonitor, fitContent: false) {
 			NavigationStack {
 				ConsoleView()
 			}

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsView.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsView.swift
@@ -35,7 +35,7 @@ struct NetworkStatsView: View {
 
             WXMAnalytics.shared.trackScreen(.networkStats)
         }
-        .bottomSheet(show: $viewModel.showInfo, fitContent: true) {
+        .bottomSheet(show: $viewModel.showInfo) {
 			bottomInfoView(info: viewModel.info)
         }
     }

--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileView.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileView.swift
@@ -43,7 +43,7 @@ private struct ContentView: View {
 			.zIndex(0)
 		}
 		.spinningLoader(show: $viewModel.isLoading, hideContent: true)
-		.bottomSheet(show: $viewModel.showInfo, fitContent: true) {
+		.bottomSheet(show: $viewModel.showInfo) {
 			bottomInfoView(info: viewModel.info)
 		}
 		.onAppear {

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeView.swift
@@ -105,7 +105,7 @@ private struct ContentView: View {
             viewModel.mainVM = mainVM
 			viewModel.getDevices()
         }
-		.bottomSheet(show: $showFilters) {
+		.bottomSheet(show: $showFilters, fitContent: false) {
 			FilterView(show: $showFilters, viewModel: ViewModelsFactory.getFilterViewModel())
 		}
     }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeView.swift
@@ -105,7 +105,7 @@ private struct ContentView: View {
             viewModel.mainVM = mainVM
 			viewModel.getDevices()
         }
-		.bottomSheet(show: $showFilters, initialDetentId: .large) {
+		.bottomSheet(show: $showFilters) {
 			FilterView(show: $showFilters, viewModel: ViewModelsFactory.getFilterViewModel())
 		}
     }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Overview/StationHealthInfoView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Overview/StationHealthInfoView.swift
@@ -13,7 +13,7 @@ struct StationHealthInfoView: View {
 
 	var body: some View {
 		ZStack {
-			Color(colorEnum: .layer1)
+			Color(colorEnum: .bottomSheetBg)
 				.ignoresSafeArea()
 
 			VStack {

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Overview/StationHealthInfoView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Overview/StationHealthInfoView.swift
@@ -17,26 +17,23 @@ struct StationHealthInfoView: View {
 				.ignoresSafeArea()
 
 			VStack {
-				ScrollView {
-					VStack(spacing: CGFloat(.defaultSpacing)) {
-						HStack {
-							Text(LocalizableString.StationDetails.stationHealth.localized)
-								.font(.system(size: CGFloat(.smallTitleFontSize), weight: .bold))
-								.foregroundStyle(Color(colorEnum: .text))
-
-							Spacer()
-						}
-
-						paragraph(title: LocalizableString.RewardDetails.dataQuality.localized,
-								  text: LocalizableString.StationDetails.dataQualityDescription.localized)
-
-						paragraph(title: LocalizableString.RewardDetails.locationQuality.localized,
-								  text: LocalizableString.StationDetails.locationQualityDescription.localized)
-
+				VStack(spacing: CGFloat(.defaultSpacing)) {
+					HStack {
+						Text(LocalizableString.StationDetails.stationHealth.localized)
+							.font(.system(size: CGFloat(.smallTitleFontSize), weight: .bold))
+							.foregroundStyle(Color(colorEnum: .text))
+						
+						Spacer()
 					}
-					.padding(CGFloat(.defaultSidePadding))
+					
+					paragraph(title: LocalizableString.RewardDetails.dataQuality.localized,
+							  text: LocalizableString.StationDetails.dataQualityDescription.localized)
+					
+					paragraph(title: LocalizableString.RewardDetails.locationQuality.localized,
+							  text: LocalizableString.StationDetails.locationQualityDescription.localized)
+					
 				}
-				.scrollIndicators(.hidden)
+				.padding(CGFloat(.defaultSidePadding))
 				.padding(.top)
 
 				Button(action: buttonAction) {

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Overview/StationHealthInfoView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Overview/StationHealthInfoView.swift
@@ -39,7 +39,7 @@ struct StationHealthInfoView: View {
 				Button(action: buttonAction) {
 					Text(LocalizableString.RewardDetails.readMore.localized)
 				}
-				.buttonStyle(WXMButtonStyle.transparent(fillColor: .top))
+				.buttonStyle(WXMButtonStyle.transparent(fillColor: .bottomSheetButton))
 				.padding(CGFloat(.defaultSidePadding))
 
 			}


### PR DESCRIPTION
## **Why?**
Make the bottom sheets to fit its content across the app
### **How?**
Updated the bottom sheet modifier and internally calculate the content height
### **Testing**
Make sure the bottom sheets in the following screens are rendered properly  
- HTTP monitoring (shake device) should be full-screen
- Profile tab infos should fit
- Filters should be full-screen
- Reward details infos should fit
- Cell list info should fit
- History data calendar should fit
- Net stats info should fit
- Forecast infos should fit
- Station overview info (health) should fit

Also, check the dark mode and smaller screens (eg. iPhone SE)
### **Additional context**
fixes fe-1252


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new `BottomSheetContainerView` for improved management of bottom sheet content.
	- Enhanced `ProfileView` with better handling of rewards and wallet address visibility.

- **Bug Fixes**
	- Adjusted text display limits in `WeatherStationCard` for a cleaner UI.

- **Improvements**
	- Simplified bottom sheet presentation logic across various screens, including `MainScreen`, `NetworkStatsView`, and `WeatherStationsHomeView`.
	- Streamlined layout in `StationHealthInfoView` for better accessibility and user experience.
	- Updated background color and structure in `StationHealthInfoView` for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->