### PR TITLE
Investigate freeze in home tab for ios 16

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScroller.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScroller.swift
@@ -30,7 +30,7 @@ struct TrackableScroller<V: View>: UIViewControllerRepresentable {
 	}
 
 	func updateUIViewController(_ uiViewController: ContainerViewController, context: Context) {
-		let sizeChanged = contentSize != uiViewController.scrollView.contentSize
+		let sizeChanged = !(contentSize ~== uiViewController.scrollView.contentSize)
 		guard sizeChanged else {
 			return
 		}

--- a/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScroller.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScroller.swift
@@ -1,0 +1,86 @@
+//
+//  TrackableScroller.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 5/11/24.
+//
+
+import Foundation
+import SwiftUI
+
+struct TrackableScroller<V: View>: UIViewControllerRepresentable {
+
+	var offsetObject: TrackableScrollOffsetObject?
+	let content: () -> V
+
+	func makeUIViewController(context: Context) -> UIViewController {
+		let vc = ContainerViewController()
+		vc.scrollView.delegate = context.coordinator
+		let hostVc = UIHostingController(rootView: content())
+		hostVc.view.backgroundColor = .clear
+		_ = vc.view
+		vc.insertChildVC(hostVc)
+		return vc
+	}
+
+	func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+
+	}
+
+	func makeCoordinator() -> TrackableCoordinator {
+		let coordinator = TrackableCoordinator()
+		coordinator.offsetObject = offsetObject
+		return coordinator
+	}
+}
+
+class TrackableCoordinator: NSObject, UIScrollViewDelegate {
+	weak var offsetObject: TrackableScrollOffsetObject?
+
+	func scrollViewDidScroll(_ scrollView: UIScrollView) {
+		offsetObject?.contentSize = scrollView.contentSize
+		offsetObject?.scrollerSize = scrollView.frame.size
+		offsetObject?.contentOffset = scrollView.contentOffset.y
+		print(scrollView.contentOffset.y)
+	}
+}
+
+private class ContainerViewController: UIViewController {
+	
+	lazy var scrollView: UIScrollView = {
+		let scrollView = UIScrollView(frame: .zero)
+		scrollView.backgroundColor = .red
+		scrollView.alwaysBounceVertical = true
+		return scrollView
+	}()
+
+	override func viewDidLoad() {
+		scrollView.translatesAutoresizingMaskIntoConstraints = false
+		view.addSubview(scrollView)
+		scrollView.topAnchor.constraint(equalTo: view.topAnchor, constant: 0).isActive = true
+		scrollView.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor, constant: 0).isActive = true
+		scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0).isActive = true
+		scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0).isActive = true
+	}
+
+	func insertChildVC(_ vc: UIViewController) {
+		vc.view.translatesAutoresizingMaskIntoConstraints = false
+		addChild(vc)
+		scrollView.addSubview(vc.view)
+
+		NSLayoutConstraint.activate([
+			vc.view.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+			vc.view.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+			vc.view.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+			vc.view.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+			vc.view.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
+		])
+	}
+}
+
+
+#Preview {
+	TrackableScroller {
+		Text("Text")
+	}
+}

--- a/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScroller.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScroller.swift
@@ -128,7 +128,7 @@ class ContainerViewController: UIViewController {
 	NavigationStack {
 		NavigationContainerView {
 			TrackableScroller(contentSize: .constant(.zero)) {
-				Text("Text")
+				Text(verbatim: "Text")
 			}
 		}
 	}

--- a/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScroller.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScroller.swift
@@ -11,12 +11,14 @@ import Toolkit
 
 struct TrackableScroller<V: View>: UIViewControllerRepresentable {
 	@Binding var contentSize: CGSize
+	var showIndicators: Bool = true
 	var offsetObject: TrackableScrollOffsetObject?
 	let content: () -> V
 
 	func makeUIViewController(context: Context) -> ContainerViewController {
 		let vc = ContainerViewController()
 		vc.scrollView.delegate = context.coordinator
+		vc.scrollView.showsVerticalScrollIndicator = showIndicators
 		let hostVc = UIHostingController(rootView: content())
 		hostVc.view.backgroundColor = .clear
 		_ = vc.view

--- a/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScroller.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/TrackableScrollView/TrackableScroller.swift
@@ -30,13 +30,13 @@ struct TrackableScroller<V: View>: UIViewControllerRepresentable {
 	}
 
 	func updateUIViewController(_ uiViewController: ContainerViewController, context: Context) {
+		(context.coordinator.hostVC as? UIHostingController<V>)?.rootView = content()
+
 		let sizeChanged = !(contentSize ~== uiViewController.scrollView.contentSize)
-		guard sizeChanged else {
+		guard sizeChanged, !uiViewController.scrollView.isDragging else {
 			return
 		}
-
-		uiViewController.scrollView.contentSize = contentSize
-
+		
 		if let vc = context.coordinator.hostVC {
 			vc.view.removeFromSuperview()
 			uiViewController.insertChildVC(vc)
@@ -102,6 +102,7 @@ class ContainerViewController: UIViewController {
 		vc.view.translatesAutoresizingMaskIntoConstraints = false
 		addChild(vc)
 		scrollView.addSubview(vc.view)
+		vc.didMove(toParent: self)
 
 		NSLayoutConstraint.activate([
 			vc.view.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
@@ -128,8 +129,20 @@ class ContainerViewController: UIViewController {
 	NavigationStack {
 		NavigationContainerView {
 			TrackableScroller(contentSize: .constant(.zero)) {
-				Text(verbatim: "Text")
+				TestView()
 			}
+		}
+	}
+}
+
+private struct TestView: View {
+	@State private var toggle: Bool = false
+	
+	var body: some View {
+		Button {
+			toggle.toggle()
+		} label: {
+			Text("\(toggle)")
 		}
 	}
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeView.swift
@@ -79,7 +79,7 @@ private struct ContentView: View {
     @Binding private var isTabBarShowing: Bool
     @Binding private var tabBarItemsSize: CGSize
     @Binding private var isWalletEmpty: Bool
-	private let mainVM: MainScreenViewModel = .shared
+	@StateObject var mainVM: MainScreenViewModel = .shared
 
     init(vieModel: WeatherStationsHomeViewModel, isTabBarShowing: Binding<Bool>, tabBarItemsSize: Binding<CGSize>, isWalletEmpty: Binding<Bool>) {
         _viewModel = StateObject(wrappedValue: vieModel)

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		26052B5C2CDA2EE7009A7D92 /* TrackableScroller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26052B5B2CDA2EE7009A7D92 /* TrackableScroller.swift */; };
 		2608A7902C09D3AC00452E40 /* ClaimDeviceSetFrequencyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2608A78F2C09D3AC00452E40 /* ClaimDeviceSetFrequencyView.swift */; };
 		2608A7922C09D3BC00452E40 /* ClaimDeviceSetFrequencyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2608A7912C09D3BC00452E40 /* ClaimDeviceSetFrequencyViewModel.swift */; };
 		2608A7942C09F67A00452E40 /* DeviceLocation+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2608A7932C09F67A00452E40 /* DeviceLocation+.swift */; };
@@ -594,6 +595,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		26052B5B2CDA2EE7009A7D92 /* TrackableScroller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackableScroller.swift; sourceTree = "<group>"; };
 		2608A78F2C09D3AC00452E40 /* ClaimDeviceSetFrequencyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaimDeviceSetFrequencyView.swift; sourceTree = "<group>"; };
 		2608A7912C09D3BC00452E40 /* ClaimDeviceSetFrequencyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaimDeviceSetFrequencyViewModel.swift; sourceTree = "<group>"; };
 		2608A7932C09F67A00452E40 /* DeviceLocation+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeviceLocation+.swift"; sourceTree = "<group>"; };
@@ -2017,6 +2019,7 @@
 			children = (
 				2675473C29A9181E008BCF40 /* TrackableScrollView.swift */,
 				26A3B3DB2B18D2480002F35F /* TabBarVisibilityHandler.swift */,
+				26052B5B2CDA2EE7009A7D92 /* TrackableScroller.swift */,
 			);
 			path = TrackableScrollView;
 			sourceTree = "<group>";
@@ -3128,6 +3131,7 @@
 				266BAF632AA88996004F5DE0 /* LocalizableString+Search.swift in Sources */,
 				266CC4CF2AB30CD900EC794C /* LocalizableString+SelectFrequency.swift in Sources */,
 				26C624572AB09C78007A3162 /* LocalizableString+Settings.swift in Sources */,
+				26052B5C2CDA2EE7009A7D92 /* TrackableScroller.swift in Sources */,
 				26DF3D202C85BB86005F6FC1 /* ExplorerData+.swift in Sources */,
 				26A9619C2AA705FE00646A25 /* LocalizableString+StationDetails.swift in Sources */,
 				263B8B4E2B29EAF9001C5060 /* MapBoxSnapshotUrlGenerator.swift in Sources */,

--- a/wxm-ios/Toolkit/Toolkit/Utils/Double+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/Double+.swift
@@ -45,3 +45,10 @@ public extension Double {
 		return formatter.string(from: self as NSNumber) ?? "-"
 	}
 }
+
+infix operator ~==
+public extension FloatingPoint {
+	static func ~== (lhs: Self, rhs: Self) -> Bool {
+		lhs == rhs || lhs.nextDown == rhs || lhs.nextUp == rhs
+	}
+}

--- a/wxm-ios/Toolkit/Toolkit/Utils/FoundationExtensions.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/FoundationExtensions.swift
@@ -202,3 +202,10 @@ public extension Int {
 		Float(self)
 	}
 }
+
+infix operator ~==
+public extension CGSize {
+	static func ~== (lhs: Self, rhs: Self) -> Bool {
+		(lhs.width ~== rhs.width) && (lhs.height ~== rhs.height)
+	}
+}


### PR DESCRIPTION
## **Why?**
Scrolling in home view freezes the app in iOS 16 builds
### **How?**
- Implemented a new container, which eventually will replace the `TrackableSrollView`
- `TrackableScroller`  is a container that encapsulates the scrolling offset calculation using the UIKit
### **Testing**
Run the app on iOS 16 and iOS 17 devices and make sure nothing is broken on the home screen
### **Additional context**
fixes fe-1315
