### PR TITLE
Fixes 4.3.0

### DIFF
--- a/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
@@ -294,6 +294,7 @@ extension DeviceDetails {
 	static var mockDevice: DeviceDetails {
 		var device = DeviceDetails.emptyDeviceDetails
 		device.name = "Test name"
+		device.friendlyName = "Friendly name"
 		device.id = "0"
 		device.label = "AE:66:F7:21:1F:21:75:11:EC"
 		device.address = "This is an address"

--- a/PresentationLayer/UIComponents/Screens/ForecastDetails/ForecastDetailsView.swift
+++ b/PresentationLayer/UIComponents/Screens/ForecastDetails/ForecastDetailsView.swift
@@ -22,8 +22,8 @@ struct ForecastDetailsView: View {
 			ScrollViewReader { proxy in
 				ScrollView(showsIndicators: false) {
 					VStack(spacing: CGFloat(.largeSpacing)) {
-						NavigationTitleView(title: .constant(viewModel.device.displayName),
-											subtitle: .constant(viewModel.device.address)) {
+						NavigationTitleView(title: .constant(viewModel.navigationTitle),
+											subtitle: .constant(viewModel.navigationSubtitle)) {
 							Group {
 								if let faIcon = viewModel.followState?.state.FAIcon {
 									Text(faIcon.icon.rawValue)

--- a/PresentationLayer/UIComponents/Screens/ForecastDetails/ForecastDetailsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ForecastDetails/ForecastDetailsViewModel.swift
@@ -14,6 +14,8 @@ class ForecastDetailsViewModel: ObservableObject {
 	let forecasts: [NetworkDeviceForecastResponse]
 	let device: DeviceDetails
 	let followState: UserDeviceFollowState?
+	let navigationTitle: String
+	let navigationSubtitle: String?
 	@Published private(set) var isTransitioning: Bool = false
 	@Published private(set) var chartDelegate: ChartDelegate = ChartDelegate()
 	@Published var selectedForecastIndex: Int? {
@@ -38,6 +40,8 @@ class ForecastDetailsViewModel: ObservableObject {
 		self.forecasts = configuration.forecasts
 		self.device = configuration.device
 		self.followState = configuration.followState
+		self.navigationTitle = device.displayName
+		self.navigationSubtitle = device.friendlyName.isNilOrEmpty ? nil : device.name
 		if !forecasts.isEmpty {
 			self.selectedForecastIndex = configuration.selectedforecastIndex
 		}

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationChipsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationChipsView.swift
@@ -15,7 +15,6 @@ struct StationChipsView: View {
 	let issues: IssuesChip?
 	var isScrollable: Bool = true
 	var warningAction: VoidCallback?
-	var statusAction: VoidCallback?
 
 	var body: some View {
 		HStack(spacing: CGFloat(.smallSpacing)) {
@@ -44,13 +43,7 @@ extension StationChipsView {
 private extension StationChipsView {
 	@ViewBuilder
 	var statusChip: some View {
-		Button {
-			statusAction?()
-		} label: {
-			StationLastActiveView(device: device)
-		}
-		.allowsHitTesting(statusAction != nil)
-
+		StationLastActiveView(device: device)
 	}
 
 	@ViewBuilder

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsContainerView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsContainerView.swift
@@ -196,8 +196,7 @@ private struct StationDetailsView: View {
             VStack {
 				StationChipsView(device: device, issues: viewModel.issues,
 								 isScrollable: true,
-								 warningAction: { viewModel.warningTapped() },
-								 statusAction: { viewModel.statusTapped() })
+								 warningAction: { viewModel.warningTapped() })
                 .sizeObserver(size: $titleViewAddressSize)
 
                 CustomSegmentView(options: StationDetailsViewModel.Tab.allCases.map { $0.description },

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsTypes.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsTypes.swift
@@ -29,7 +29,6 @@ struct StationAddressTitleView: View {
     let isStateIconEnabled: Bool
     let tapStateIconAction: VoidCallback?
 	let tapWarningAction: VoidCallback?
-	let tapStatusAction: VoidCallback?
 
     var body: some View {
         VStack(spacing: CGFloat(.minimumSpacing)) {
@@ -60,8 +59,7 @@ struct StationAddressTitleView: View {
 			StationChipsView(device: device,
 							 issues: issues,
 							 isScrollable: areChipsScrollable,
-							 warningAction: tapWarningAction,
-							 statusAction: tapStatusAction)
+							 warningAction: tapWarningAction)
         }
     }
 }
@@ -74,8 +72,7 @@ extension StationAddressTitleView {
 		 areChipsScrollable: Bool = true,
 		 showStateIcon: Bool = true,
 		 tapStateIconAction: VoidCallback? = nil,
-		 tapWarningAction: VoidCallback? = nil,
-		 tapStatusAction: VoidCallback? = nil) {
+		 tapWarningAction: VoidCallback? = nil) {
 		self.device = device
 		self.followState = followState
 		self.issues = issues
@@ -85,6 +82,5 @@ extension StationAddressTitleView {
         self.isStateIconEnabled = followState?.state.isActionable ?? true
         self.tapStateIconAction = tapStateIconAction
 		self.tapWarningAction = tapWarningAction
-		self.tapStatusAction = tapStatusAction
     }
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
@@ -99,13 +99,6 @@ class StationDetailsViewModel: ObservableObject {
 		navigateToAlerts()
 	}
 
-	func statusTapped() {
-		guard device?.isActive == false else {
-			return
-		}
-		navigateToAlerts()
-	}
-
 	@MainActor
     func handleShareButtonTap() {
         WXMAnalytics.shared.trackEvent(.userAction, parameters: [.actionName: .deviceDetailsShare])


### PR DESCRIPTION
## **Why?**
- Remove tap action from the status chip ("Just now", "12 min. ago") in station details
- Show station name instead of address in forecast details
### **Testing**
Ensure everything looks as expected 
### **Additional context**
fixes fe-1354, fe-1355, fe-1356
