### PR TITLE
Updated station inactive text

### DIFF
--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -1,10 +1,10 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    " " : {
+    "" : {
 
     },
-    "-" : {
+    " " : {
 
     },
     "%@" : {
@@ -16,16 +16,6 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "%1$@  %2$@"
-          }
-        }
-      }
-    },
-    "%@ **[%@](%@)**" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ **[%2$@](%3$@)**"
           }
         }
       }
@@ -168,7 +158,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Station Inactive"
+            "value" : "Inactive"
           }
         }
       }
@@ -8226,7 +8216,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Station inactive"
+            "value" : "Inactive"
           }
         }
       }


### PR DESCRIPTION
## **Why?**
Update station inactive wording
### **Additional context**
Fixes FE-1374


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated localization strings for improved clarity and conciseness.
	- Simplified the "Station Inactive" message to "Inactive".

- **Bug Fixes**
	- Adjusted whitespace in certain string keys for a cleaner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->