### PR TITLE
Updated low battery text

### DIFF
--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -8293,7 +8293,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Your station is reporting low battery. This may lead to data gaps at night, or in low-sunlight conditions and, eventually, lose rewards. Read more on how to replace your station batteries."
+            "value" : "Your station is reporting low battery. This will lead to data gaps and eventually loss of rewards. Read more on how to replace your station batteries."
           }
         }
       }


### PR DESCRIPTION
## **Why?**
Updated low battery warning text
### **Testing**
Make sure the low battery warning text is rendered as expected in the station alerts screen
### **Additional context**
fixes fe-1329


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new localization strings for weather station alerts, including low battery notifications and connection issues.
	- Enhanced user guidance for account management tasks like password reset and account deletion.
- **Bug Fixes**
	- Improved clarity of existing strings related to low battery conditions and their impact on data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->