### PR TITLE
Generate an image file with exif data included

### DIFF
--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
@@ -114,8 +114,9 @@ private class ImagePickerDelegate: NSObject, UIImagePickerControllerDelegate, UI
 	}
 
 	func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+		let metadata = info[.mediaMetadata] as? NSDictionary
 		if let image = info[.originalImage] as? UIImage,
-		   let imageUrl = try? useCase.saveImage(image) {
+		   let imageUrl = try? useCase.saveImage(image, metadata: metadata) {
 			imageCallback?(imageUrl)
 		}
 

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
@@ -115,9 +115,11 @@ private class ImagePickerDelegate: NSObject, UIImagePickerControllerDelegate, UI
 
 	func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
 		let metadata = info[.mediaMetadata] as? NSDictionary
-		if let image = info[.originalImage] as? UIImage,
-		   let imageUrl = try? useCase.saveImage(image, metadata: metadata) {
-			imageCallback?(imageUrl)
+		Task { @MainActor in
+			if let image = info[.originalImage] as? UIImage,
+			   let imageUrl = try? await useCase.saveImage(image, metadata: metadata) {
+				imageCallback?(imageUrl)
+			}
 		}
 
 		picker.dismiss(animated: true)

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/PhotosRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/PhotosRepositoryImpl.swift
@@ -27,7 +27,7 @@ public struct PhotosRepositoryImpl: PhotosRepository {
 		guard saveImageWithEXIF(image: image, metadata: fixedMetadata, saveFilename: fileName) else {
 			return nil
 		}
-
+		print("Image saved in \(fileName.path())")
 		return fileName.absoluteString
 	}
 

--- a/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/PhotosRepository.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/PhotosRepository.swift
@@ -10,7 +10,7 @@ import UIKit
 import AVFoundation
 
 public protocol PhotosRepository: Sendable {
-	func saveImage(_ image: UIImage) throws -> String?
+	func saveImage(_ image: UIImage, metadata: NSDictionary?) throws -> String?
 	func deleteImage(_ imageUrl: String) throws
 	func getCameraPermission() -> AVAuthorizationStatus
 	func reqeustCameraPermission() async -> AVAuthorizationStatus

--- a/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/PhotosRepository.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/PhotosRepository.swift
@@ -10,7 +10,7 @@ import UIKit
 import AVFoundation
 
 public protocol PhotosRepository: Sendable {
-	func saveImage(_ image: UIImage, metadata: NSDictionary?) throws -> String?
+	func saveImage(_ image: UIImage, metadata: NSDictionary?) async throws -> String?
 	func deleteImage(_ imageUrl: String) throws
 	func getCameraPermission() -> AVAuthorizationStatus
 	func reqeustCameraPermission() async -> AVAuthorizationStatus

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/PhotoGalleryUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/PhotoGalleryUseCase.swift
@@ -17,8 +17,8 @@ public struct PhotoGalleryUseCase: Sendable {
 		self.photosRepository = photosRepository
 	}
 
-	public func saveImage(_ image: UIImage, metadata: NSDictionary?) throws -> String? {
-		try photosRepository.saveImage(image, metadata: metadata)
+	public func saveImage(_ image: UIImage, metadata: NSDictionary?) async throws -> String? {
+		try await photosRepository.saveImage(image, metadata: metadata)
 	}
 
 	public func deleteImage(_ imageUrl: String) throws {

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/PhotoGalleryUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/PhotoGalleryUseCase.swift
@@ -17,8 +17,8 @@ public struct PhotoGalleryUseCase: Sendable {
 		self.photosRepository = photosRepository
 	}
 
-	public func saveImage(_ image: UIImage) throws -> String? {
-		try photosRepository.saveImage(image)
+	public func saveImage(_ image: UIImage, metadata: NSDictionary?) throws -> String? {
+		try photosRepository.saveImage(image, metadata: metadata)
 	}
 
 	public func deleteImage(_ imageUrl: String) throws {


### PR DESCRIPTION
## **Why?**
The functionality to merge the captured photo with its metadata in a new file.
### **How?**
We pass the captured image along with its metadata In `PhotoGalleryUseCase`.
`PhotosRepositoryImpl` injects the current location, if exists, and saves the new file in the photos folder
### **Testing**
An easy way to check the metadata of an image is by uploading the file [here](https://raw.pics.io/photo-metadata-viewer). 
So you should find the captured photo and check if the metadata are there.
To find the captured photo:
- **On a Mac app**: For some reason, the picker on a Mac app doesn't return any metadata, so we include only gps stuff. To find where is located the saved file, search in console the log starting with "Image saved in...".
- **On a physical device**: Go to files app -> Browse -> On My iPhone -> WXM Dev folder and upload it to the site mentioned above 
### **Screenshots (if applicable)**
If your changes include visual updates, please provide screenshots or gifs.
### **Additional context**
fixes fe-1419
