### PR TITLE
Photo verification fixes

### DIFF
--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel.swift
@@ -234,8 +234,8 @@ private extension DeviceInfoViewModel {
 			case .rewardSplit:
 				break
 			case .photos:
-				let viewModel = ViewModelsFactory.getPhotoIntroViewModel()
-				Router.shared.navigateTo(.photoIntro(viewModel))
+				let route = PhotoIntroViewModel.getInitialRoute()
+				Router.shared.navigateTo(route)
 		}
 	}
 

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroExamplesView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroExamplesView.swift
@@ -63,10 +63,10 @@ struct PhotoIntroExamplesView: View {
 			.disableScrollClip()
 			.scrollIndicators(.hidden)
 		}
-		.padding(CGFloat(.mediumSidePadding))
+		.padding(.vertical, CGFloat(.mediumSidePadding))
+		.padding(.horizontal, CGFloat(.mediumToLargeSidePadding))
 		.background {
 			Color(colorEnum: tintColor)
-				.cornerRadius(CGFloat(.cardCornerRadius))
 		}
     }
 }

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroView.swift
@@ -20,17 +20,22 @@ struct PhotoIntroView: View {
 				ScrollView {
 					VStack(spacing: CGFloat(.XLSpacing)) {
 						titleView
+							.padding(.horizontal, CGFloat(.mediumToLargeSidePadding))
+
 
 						instructionsView
+							.padding(.horizontal, CGFloat(.mediumToLargeSidePadding))
 
 						examplesView(containerWidth: proxy.size.width)
 
 						uploadPhotosView
+							.padding(.horizontal, CGFloat(.mediumToLargeSidePadding))
 
 						termsView
+							.padding(.horizontal, CGFloat(.mediumToLargeSidePadding))
+
 					}
 					.padding(.top, -proxy.safeAreaInsets.top)
-					.padding(.horizontal, CGFloat(.mediumToLargeSidePadding))
 					.padding(.bottom, CGFloat(.mediumToLargeSidePadding))
 					.overlay {
 						VStack {
@@ -172,6 +177,7 @@ private extension PhotoIntroView {
 
 				Spacer()
 			}
+			.padding(.horizontal, CGFloat(.mediumToLargeSidePadding))
 
 			let recommendedExamples = viewModel.recommendedExamples
 			PhotoIntroExamplesView(containerWidth: containerWidth,

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroView.swift
@@ -218,7 +218,7 @@ private extension PhotoIntroView {
 		if viewModel.showTerms {
 			VStack(spacing: CGFloat(.defaultSpacing)) {
 				HStack(spacing: CGFloat(.smallSpacing)) {
-					Toggle("", isOn: $viewModel.isTermsAccepted)
+					Toggle("", isOn: $viewModel.areTermsAccepted)
 						.labelsHidden()
 						.toggleStyle(WXMToggleStyle.Default)
 					
@@ -239,7 +239,7 @@ private extension PhotoIntroView {
 				}
 				.buttonStyle(WXMButtonStyle(textColor: .top,
 											fillColor: .wxmPrimary))
-				.disabled(!viewModel.isTermsAccepted)
+				.disabled(!viewModel.areTermsAccepted)
 			}
 		}
 	}

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroViewModel.swift
@@ -6,10 +6,15 @@
 //
 
 import Foundation
+import DomainLayer
 
 @MainActor
 class PhotoIntroViewModel: ObservableObject {
-	@Published var isTermsAccepted: Bool = false
+	@Published var areTermsAccepted: Bool {
+		didSet {
+			photoGalleryUseCase.setTermsAccepted(areTermsAccepted)
+		}
+	}
 
 	var closeButtonIcon: FontIcon { .xmark }
 	var showTerms: Bool { true }
@@ -32,6 +37,13 @@ class PhotoIntroViewModel: ObservableObject {
 	lazy var faultExamples: (title: String, examples: [PhotoIntroExamplesView.Example]) = {
 		(LocalizableString.PhotoVerification.notLikeThis.localized, Self.getFaultExamples())
 	}()
+
+	private let photoGalleryUseCase: PhotoGalleryUseCase
+
+	init(photoGalleryUseCase: PhotoGalleryUseCase) {
+		self.photoGalleryUseCase = photoGalleryUseCase
+		areTermsAccepted = photoGalleryUseCase.areTermsAccepted
+	}
 
 	func handleBeginButtonTap() {
 		let viewModel = ViewModelsFactory.getGalleryViewModel()

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroViewModel.swift
@@ -54,6 +54,19 @@ class PhotoIntroViewModel: ObservableObject {
 extension PhotoIntroViewModel: HashableViewModel {
 	nonisolated func hash(into hasher: inout Hasher) {
 	}
+
+	static func getInitialRoute() -> Route {
+		let useCase = SwinjectHelper.shared.getContainerForSwinject().resolve(PhotoGalleryUseCase.self)!
+		let areTermsAccepted = useCase.areTermsAccepted
+
+		if areTermsAccepted {
+			let viewModel = ViewModelsFactory.getGalleryViewModel()
+			return .photoGallery(viewModel)
+		}
+
+		let viewModel = ViewModelsFactory.getPhotoIntroViewModel()
+		return .photoIntro(viewModel)
+	}
 }
 
 private extension PhotoIntroViewModel {

--- a/PresentationLayer/UIComponents/ViewModelsFactory.swift
+++ b/PresentationLayer/UIComponents/ViewModelsFactory.swift
@@ -262,11 +262,13 @@ enum ViewModelsFactory {
 	}
 
 	static func getPhotoIntroViewModel() -> PhotoIntroViewModel {
-		return PhotoIntroViewModel()
+		let useCase = SwinjectHelper.shared.getContainerForSwinject().resolve(PhotoGalleryUseCase.self)!
+		return PhotoIntroViewModel(photoGalleryUseCase: useCase)
 	}
 
 	static func getPhotoInstructionsViewModel() -> PhotoInstructionsViewModel {
-		return PhotoInstructionsViewModel()
+		let useCase = SwinjectHelper.shared.getContainerForSwinject().resolve(PhotoGalleryUseCase.self)!
+		return PhotoInstructionsViewModel(photoGalleryUseCase: useCase)
 	}
 
 	static func getGalleryViewModel() -> GalleryViewModel {

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/PhotosRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/PhotosRepositoryImpl.swift
@@ -18,9 +18,20 @@ private enum Constants: String {
 public struct PhotosRepositoryImpl: PhotosRepository {
 
 	nonisolated(unsafe) private let locationManager = WXMLocationManager()
+	nonisolated(unsafe) private let userDefaultsService = UserDefaultsService()
+	private let termsAcceptedKey = UserDefaults.GenericKey.arePhotoVerificationTermsAccepted.rawValue
+
+	public var areTermsAccepted: Bool {
+		let accepted: Bool? = userDefaultsService.get(key: termsAcceptedKey)
+		return accepted == true
+	}
 
 	public init() {}
-	
+
+	public func setTermsAccepted(_ termsAccepted: Bool) {
+		userDefaultsService.save(value: termsAccepted, key: termsAcceptedKey)
+	}
+
 	public func saveImage(_ image: UIImage, metadata: NSDictionary?) async throws -> String? {
 		let fileName = self.folderPath.appendingPathComponent("image_\(UUID().uuidString).jpg")
 		let fixedMetadata = await injectLocationInMetadata(metadata ?? .init())

--- a/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/PhotosRepository.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/PhotosRepository.swift
@@ -10,6 +10,8 @@ import UIKit
 import AVFoundation
 
 public protocol PhotosRepository: Sendable {
+	var areTermsAccepted: Bool { get }
+	func setTermsAccepted(_ termsAccepted: Bool)	
 	func saveImage(_ image: UIImage, metadata: NSDictionary?) async throws -> String?
 	func deleteImage(_ imageUrl: String) throws
 	func getCameraPermission() -> AVAuthorizationStatus

--- a/wxm-ios/DomainLayer/DomainLayer/Extensions/UserDefaults+Constants.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Extensions/UserDefaults+Constants.swift
@@ -41,11 +41,12 @@ public extension UserDefaults {
 		case lastAppVersionPrompt = "com.weatherxm.app.UserDefaults.Key.LastAppVersionPrompt"
 		case lastSurveyId = "com.weatherxm.app.UserDefaults.Key.LastSurveyId"
 		case lastInfoBannerId = "com.weatherxm.app.UserDefaults.Key.LastInfoBannerId"
+		case arePhotoVerificationTermsAccepted = "com.weatherxm.app.UserDefaults.Key.ArePhotoVerificationTermsAccepted"
 
         // MARK: - UserDefaultEntry
 
         static var userKeys: [String] {
-			let keys: [GenericKey] = [.hideWalletTimestamp, .sortByDevicesOption, .filterDevicesOption, .groupByDevicesOption, .userDevicesFollowStates, .userDevices, .lastSurveyId, .lastInfoBannerId]
+			let keys: [GenericKey] = [.hideWalletTimestamp, .sortByDevicesOption, .filterDevicesOption, .groupByDevicesOption, .userDevicesFollowStates, .userDevices, .lastSurveyId, .lastInfoBannerId, .arePhotoVerificationTermsAccepted]
             return keys.map { $0.rawValue }
         }
     }

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/PhotoGalleryUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/PhotoGalleryUseCase.swift
@@ -11,10 +11,16 @@ import AVFoundation
 
 public struct PhotoGalleryUseCase: Sendable {
 
+	public var areTermsAccepted: Bool { photosRepository.areTermsAccepted }
+
 	private let photosRepository: PhotosRepository
 
 	public init(photosRepository: PhotosRepository) {
 		self.photosRepository = photosRepository
+	}
+
+	public func setTermsAccepted(_ termsAccepted: Bool) {
+		photosRepository.setTermsAccepted(termsAccepted)
 	}
 
 	public func saveImage(_ image: UIImage, metadata: NSDictionary?) async throws -> String? {

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -9118,7 +9118,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "I have read and accept the "
+            "value" : "I have read and accept the"
           }
         }
       }


### PR DESCRIPTION
## **Why?**
Fixes in Photo verification screens
### **How?**
- Made intro examples' background full width
- Persist accept terms option in the intro screen and skip it when it's true
### **Testing**
Ensure everything looks as expected and the intro screen is not presented when the terms are accepted
### **Additional context**
fixes fe-1489, fe-1490


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a photo verification feature with new views and functionalities, including `GalleryView`, `PhotoIntroView`, and associated view models.
  - Added support for various photo-related functionalities, including image uploading, deletion, and camera permissions.
  - Enhanced user interface with new button styles and improved visual feedback for actions.
  - Expanded asset identifiers and added new dimensions for UI components.

- **Bug Fixes**
  - Updated links and corrected inconsistencies in user interface elements.

- **Localization**
  - Added new localized strings for photo verification instructions and user interface elements.

- **Assets**
  - Introduced new image assets for photo verification, including recommended and incorrect installation visuals.

- **Dependency Injection**
  - Registered new services for photo management in the dependency injection container.

- **Documentation**
  - Updated project documentation to reflect new features and functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->