### PR TITLE
Fixed minimum axis value for uv chart

### DIFF
--- a/PresentationLayer/UIComponents/Screens/ForecastDetails/Components/ForecastChartTypes.swift
+++ b/PresentationLayer/UIComponents/Screens/ForecastDetails/Components/ForecastChartTypes.swift
@@ -95,8 +95,10 @@ enum ForecastChartType: String, ChartCardProtocol {
 	
 	func configureAxis(leftAxis: YAxis, rightAxis: YAxis, for lineData: LineChartData) {
 		switch self {
-			case .temperature, .wind, .humidity, .uv:
+			case .temperature, .wind, .humidity:
 				break
+			case .uv:
+				leftAxis.axisMinimum = 0.0
 			case .precipitation:
 				rightAxis.axisMinimum = 0.0
 				leftAxis.axisMinimum = 0.0


### PR DESCRIPTION
## **Why?**
UV index graph axis should start from 0
### **How?**
Set the minimum value axis to zero for UV index graphs
### **Testing**
Ensure UV index graphs in the forecast graphs start from 0
### **Additional context**
fixes FE-1445


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved UV index chart axis configuration to ensure accurate visual representation of data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->