### PR TITLE
Favorite icon state

### DIFF
--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
@@ -192,19 +192,15 @@ private extension StationDetailsViewModel {
                 return
             }
             LoaderView.shared.show()
-            Task { [weak self] in
+			Task { @MainActor [weak self] in
                 guard let self,
 					  let result = try await self.useCase?.followStation(deviceId: self.deviceId) else {
                     return
                 }
 
-                DispatchQueue.main.async {
-                    LoaderView.shared.dismiss {
-                        Task {
-                            await self.handleFollowResult(result)
-                        }
-                    }
-                }
+				await self.handleFollowResult(result)
+
+				LoaderView.shared.dismiss()
             }
         }
 
@@ -218,19 +214,15 @@ private extension StationDetailsViewModel {
     func performUnFollow() {
         let okAction = {
             LoaderView.shared.show()
-            Task { [weak self] in
+			Task { @MainActor [weak self] in
                 guard let self,
                       let result = try await self.useCase?.unfollowStation(deviceId: self.deviceId) else {
                     return
                 }
 
-                DispatchQueue.main.async {
-                    LoaderView.shared.dismiss {
-                        Task {
-                            await self.handleFollowResult(result)
-                        }
-                    }
-                }
+				await self.handleFollowResult(result)
+
+				LoaderView.shared.dismiss()
             }
         }
 

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
@@ -195,6 +195,7 @@ private extension StationDetailsViewModel {
 			Task { @MainActor [weak self] in
                 guard let self,
 					  let result = try await self.useCase?.followStation(deviceId: self.deviceId) else {
+					LoaderView.shared.dismiss()
                     return
                 }
 
@@ -217,6 +218,7 @@ private extension StationDetailsViewModel {
 			Task { @MainActor [weak self] in
                 guard let self,
                       let result = try await self.useCase?.unfollowStation(deviceId: self.deviceId) else {
+					LoaderView.shared.dismiss()
                     return
                 }
 


### PR DESCRIPTION
## **Why?**
The "follow"  process in the station details screen has two steps. Firstly, we perform the follow request and once is completed successfully, we fetch the device again in order to update the UI.
The weird thing now is that we used to show the full screen loader only during the first API request (follow).
### **How?**
Now we show the loader during the whole process
### **Testing**
Ensure the loader is dismissed once the UI is updated properly
### **Additional context**
fixes fe-1480


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Enhanced thread safety for follow and unfollow actions in weather station details.
	- Simplified asynchronous handling of UI updates.
	- Improved main thread management for follow/unfollow operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->