### PR TITLE
Analytics for device forecast details entry point

### DIFF
--- a/PresentationLayer/UIComponents/Screens/LoggedInViews/LoggedInTabViewContainer.swift
+++ b/PresentationLayer/UIComponents/Screens/LoggedInViews/LoggedInTabViewContainer.swift
@@ -61,9 +61,6 @@ struct LoggedInTabViewContainer: View {
                                             isTabBarShowing: $isTabBarShowing,
                                             tabBarItemsSize: $tabBarItemsSize,
 											isWalletEmpty: $mainViewModel.isWalletMissing)
-                    .onAppear {
-                        WXMAnalytics.shared.trackScreen(.deviceList)
-                    }
                 case .mapTab:
                     explorer
                         .onAppear {

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
@@ -70,9 +70,6 @@ struct StationForecastView: View {
 		}
         .fail(show: Binding(get: { viewModel.viewState == .fail }, set: { _ in }), obj: viewModel.failObj)
         .spinningLoader(show: Binding(get: { viewModel.viewState == .loading }, set: { _ in }), hideContent: true)
-        .onAppear {
-            WXMAnalytics.shared.trackScreen(.forecast)
-        }
     }
 }
 

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Overview/OverviewView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Overview/OverviewView.swift
@@ -37,9 +37,6 @@ struct OverviewView: View {
         }
         .spinningLoader(show: Binding(get: { viewModel.viewState == .loading }, set: { _ in }), hideContent: true)
         .fail(show: Binding(get: { viewModel.viewState == .fail }, set: { _ in }), obj: viewModel.failObj)
-        .onAppear {
-            WXMAnalytics.shared.trackScreen(.currentWeather)
-        }
 		.bottomSheet(show: $viewModel.showStationHealthInfo) {
 			StationHealthInfoView() {
 				viewModel.handleStationHealthBottomSheetButtonTap()

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Rewards/StationRewardsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Rewards/StationRewardsView.swift
@@ -46,9 +46,6 @@ struct StationRewardsView: View {
 				.fail(show: Binding(get: { viewModel.viewState == .fail }, set: { _ in }), obj: viewModel.failObj)
 			}
 		}
-        .onAppear {
-            WXMAnalytics.shared.trackScreen(.rewards)
-        }
     }
 }
 

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsContainerView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsContainerView.swift
@@ -175,10 +175,12 @@ private struct StationDetailsView: View {
 			navigationObject.titleFont = .system(size: CGFloat(.smallTitleFontSize), weight: .bold)
 			navigationObject.subtitleFont = .system(size: CGFloat(.caption))
         }
-        .onChange(of: selectedIndex) { _ in
+        .onChange(of: selectedIndex) { index in
             withAnimation {
                 isHeaderHidden = false
             }
+
+			viewModel.trackScreenViewEvent(for: index)
         }
         .onChange(of: viewModel.shouldHideHeaderToggle) { _ in
             isHeaderHidden = viewModel.isHeaderHidden
@@ -191,6 +193,9 @@ private struct StationDetailsView: View {
 				navigationObject.setNavigationTitle(newValue)
             }
         }
+		.task {
+			viewModel.trackScreenViewEvent(for: selectedIndex)
+		}
     }
 
     @ViewBuilder

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
@@ -139,6 +139,14 @@ class StationDetailsViewModel: ObservableObject {
         showLoginAlert = false
         Router.shared.navigateTo(.register(ViewModelsFactory.getRegisterViewModel()))
     }
+
+	func trackScreenViewEvent(for index: Int) {
+		guard let tab = StationDetailsViewModel.Tab.allCases[safe: index] else {
+			return
+		}
+
+		WXMAnalytics.shared.trackScreen(tab.analyticsScreen)
+	}
 }
 
 extension StationDetailsViewModel: HashableViewModel {
@@ -163,6 +171,17 @@ extension StationDetailsViewModel {
                     return LocalizableString.StationDetails.rewards.localized
             }
         }
+
+		var analyticsScreen: Screen {
+			switch self {
+				case .overview:
+					return .currentWeather
+				case .forecast:
+					return .forecast
+				case .rewards:
+					return .rewards
+			}
+		}
     }
 }
 

--- a/wxm-ios/Toolkit/Toolkit/Analytics/WXMAnalytics.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/WXMAnalytics.swift
@@ -30,10 +30,12 @@ public extension WXMAnalytics {
 	}
 
     func trackScreen(_ screen: Screen, parameters: [Parameter: ParameterValue]? = nil) {
+		print("WXMAalytics screen: \(screen.rawValue)") // TEMP for testing
 		providers.forEach { $0.trackScreen(screen, parameters: parameters) }
     }
 
     func trackEvent(_ event: Event, parameters: [Parameter: ParameterValue]?) {
+		print("WXMAalytics event: \(event.rawValue) parameters: \(parameters?.testString ?? "")") // TEMP for testing
 		providers.forEach { $0.trackEvent(event, parameters: parameters) }
     }
 
@@ -55,5 +57,14 @@ public extension WXMAnalytics {
 
 	func userLoggedOut() {
 		providers.forEach { $0.userLoggedOut() }
+	}
+}
+
+// TEMP for testing
+extension Dictionary where Key == Parameter, Value == ParameterValue {
+	var testString: String {
+		return map { key, value in
+			"\(key): \(value)"
+		}.joined(separator: ", ")
 	}
 }

--- a/wxm-ios/Toolkit/Toolkit/Analytics/WXMAnalytics.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/WXMAnalytics.swift
@@ -30,12 +30,12 @@ public extension WXMAnalytics {
 	}
 
     func trackScreen(_ screen: Screen, parameters: [Parameter: ParameterValue]? = nil) {
-		print("WXMAalytics screen: \(screen.rawValue)") // TEMP for testing
+		print("WXMAnalytics screen: \(screen.rawValue)") // TEMP for testing
 		providers.forEach { $0.trackScreen(screen, parameters: parameters) }
     }
 
     func trackEvent(_ event: Event, parameters: [Parameter: ParameterValue]?) {
-		print("WXMAalytics event: \(event.rawValue) parameters: \(parameters?.testString ?? "")") // TEMP for testing
+		print("WXMAnalytics event: \(event.rawValue) parameters: \(parameters?.testString ?? "")") // TEMP for testing
 		providers.forEach { $0.trackEvent(event, parameters: parameters) }
     }
 


### PR DESCRIPTION
## **Why?**
Fix the inconsistency of screen tracking in station details.
The issue occurred when the user swipes with more "power" from the first tab (Overview) to the second (Forecast). So because of the scroller bounce effect, a small part of the third tab (Rewards) appears and triggers the `onAppear` callback 
### **How?**
Now we track the screen event from the container (`StationDetailsContainerView`) on every `selectedIndex` change
### **Testing**
There are some debug prints in `WXMAnalytics` file which shows in the console every screen and event track. 
Just filter the console output with `WXMAnalytics`.
<img width="500" alt="Screenshot 2025-01-17 at 12 27 34" src="https://github.com/user-attachments/assets/c0f6b658-975b-4da9-90bb-22d28299d4b1" />

This code will be removed once the review is over

### **Additional context**
fixes fe-1529


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Analytics**
	- Removed screen tracking from various views in the app
	- Updated `StationDetailsViewModel` to handle screen view tracking more dynamically
	- Added temporary debugging print statements for analytics tracking

- **Refactor**
	- Simplified screen view event tracking mechanism across multiple views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->