### PR TITLE
Photo verification fixes

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/SpinningLoader/SpinningLoader.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/SpinningLoader/SpinningLoader.swift
@@ -46,6 +46,7 @@ struct SpinningLoaderModifier: ViewModifier {
 						}
 						.multilineTextAlignment(.center)
 					}
+					.padding(CGFloat(.defaultSidePadding))
 				}
 			}
 	}

--- a/PresentationLayer/UIComponents/Modifiers/WXMShareModifier.swift
+++ b/PresentationLayer/UIComponents/Modifiers/WXMShareModifier.swift
@@ -15,6 +15,7 @@ private struct WXMShareModifier: ViewModifier {
 	@Binding var show: Bool
 	let text: String
 	let images: [UIImage]
+	let disablePopοver: Bool
 	@State private var hostingWrapper: HostingWrapper = HostingWrapper()
 	@State private var store = Store()
 
@@ -35,6 +36,13 @@ private struct WXMShareModifier: ViewModifier {
 		items.append(contentsOf: images.map { getItemSource(image: $0) })
 		let activityController = WXMActivityViewController(activityItems: items, applicationActivities: nil)
 		activityController.popoverPresentationController?.sourceView = sourceView
+		if disablePopοver {
+			activityController.popoverPresentationController?.sourceRect = CGRect(x: UIScreen.main.bounds.width / 2.0,
+																				  y: UIScreen.main.bounds.height / 2.0,
+																				  width: 0.0,
+																				  height: 0.0)
+			activityController.popoverPresentationController?.permittedArrowDirections = []
+		}
 		activityController.willDismissCallback = { show = false }
 		hostingWrapper.hostingController = activityController
 		UIApplication.shared.rootViewController?.present(activityController, animated: true)
@@ -104,7 +112,7 @@ private extension WXMShareModifier {
 
 extension View {
 	@ViewBuilder
-	func wxmShareDialog(show: Binding<Bool>, text: String, images: [UIImage] = []) -> some View {
-		modifier(WXMShareModifier(show: show, text: text, images: images))
+	func wxmShareDialog(show: Binding<Bool>, text: String, images: [UIImage] = [], disablePopοver: Bool = false) -> some View {
+		modifier(WXMShareModifier(show: show, text: text, images: images, disablePopοver: disablePopοver))
 	}
 }

--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel+Content.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel+Content.swift
@@ -38,8 +38,8 @@ extension DeviceInfoViewModel {
 
         static func heliumSections(for followState: UserDeviceFollowState?) -> [[Field]] {
             if followState?.state == .owned {
-				return [[.photos],
-						[.name, .frequency, .reboot],						
+				return [[.name, .frequency, .reboot],
+						[.photos],
 						[.stationLocation]]
             }
 

--- a/PresentationLayer/UIComponents/Screens/MainScreen/MainScreenViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/MainScreen/MainScreenViewModel.swift
@@ -319,9 +319,11 @@ class MainScreenViewModel: ObservableObject {
 		}.store(in: &cancellableSet)
 
 		photosUseCase.uploadErrorPublisher.sink { deviceId, _ in
-			LocalNotificationScheduler().postNotification(id: deviceId,
-														  title: LocalizableString.PhotoVerification.uploadFailedNotificationFailedTitle.localized,
-														  body: LocalizableString.PhotoVerification.uploadFailedNotificationFailedDescription.localized)
+			if self.photosUseCase.getUploadState(deviceId: deviceId)  == .failed {
+				LocalNotificationScheduler().postNotification(id: deviceId,
+															  title: LocalizableString.PhotoVerification.uploadFailedNotificationFailedTitle.localized,
+															  body: LocalizableString.PhotoVerification.uploadFailedNotificationFailedDescription.localized)
+			}
 		}.store(in: &cancellableSet)
 	}
 

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
@@ -143,7 +143,10 @@ struct GalleryView: View {
 		.task {
 			viewModel.viewLoaded()
 		}
-		.wxmShareDialog(show: $viewModel.showShareSheet, text: "", images: viewModel.shareImages ?? [])
+		.wxmShareDialog(show: $viewModel.showShareSheet,
+						text: "",
+						images: viewModel.shareImages ?? [],
+						disablePopοver: true)
     }
 }
 

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
@@ -240,6 +240,13 @@ private extension GalleryView {
 						}
 					}
 				}
+			}.modify { view in
+				if #available(iOS 16.4, *) {
+					view
+						.scrollBounceBehavior(.basedOnSize, axes: .horizontal)
+				} else {
+					view
+				}
 			}
 			.scrollIndicators(.hidden)
 			.animation(.easeIn(duration: 0.1), value: viewModel.selectedImage)
@@ -288,6 +295,7 @@ private extension GalleryView {
 
 #Preview {
 	GalleryView(viewModel: ViewModelsFactory.getGalleryViewModel(deviceId: "",
-																 images: [],
+																 images: ["https://wxm-station-photos-dev.s3.eu-west-2.amazonaws.com/daring-garnet-gust/81B2CA91-DBC5-45A1-AF33-6FA031604EA2.jpg",
+																		 "https://wxm-station-photos-dev.s3.eu-west-2.amazonaws.com/daring-garnet-gust/ADDF4312-640F-44C7-AFB6-B437C6FBBBC7.jpg"],
 																 isNewVerification: true))
 }

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
@@ -65,6 +65,7 @@ struct GalleryView: View {
 												   height: proxy.size.height - 2 * CGFloat(.defaultSidePadding),
 												   alignment: .center)
 											.clipped()
+											.contentShape(Rectangle())
 											.position(x: proxy.frame(in: .local).midX,
 													  y: proxy.frame(in: .local).midY)
 									} else {
@@ -81,6 +82,7 @@ struct GalleryView: View {
 										   height: proxy.size.height - 2 * CGFloat(.defaultSidePadding),
 										   alignment: .center)
 									.clipped()
+									.contentShape(Rectangle())
 									.position(x: proxy.frame(in: .local).midX,
 											  y: proxy.frame(in: .local).midY)
 							}

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
@@ -31,7 +31,7 @@ class GalleryViewModel: ObservableObject {
 	private(set) var failObject: FailSuccessStateObject?
 	@Published var showShareSheet: Bool = false
 	var shareImages: [UIImage]? {
-		images.compactMap { $0.uiImage }
+		images.compactMap { $0.uiImage?.scaleDown(newWidth: 800.0) }
 	}
 	var localImages: [GalleryView.GalleryImage]? {
 		images.filter { $0.uiImage != nil }

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
@@ -90,20 +90,29 @@ class GalleryViewModel: ObservableObject {
 			return
 		}
 
-		Task { @MainActor in
-			do {
-				try await deleteImageImage(selectedImage)
-				self.selectedImage = images.last
-			} catch PhotosError.networkError(let error) {
-				let info = error.uiInfo
-				if let message = info.description?.attributedMarkdown {
-					Toast.shared.show(text: message)
+		let action: VoidCallback = { [weak self] in
+			Task { @MainActor in
+				do {
+					try await self?.deleteImageImage(selectedImage)
+					self?.selectedImage = self?.images.last
+				} catch PhotosError.networkError(let error) {
+					let info = error.uiInfo
+					if let message = info.description?.attributedMarkdown {
+						Toast.shared.show(text: message)
+					}
+				}
+				catch {
+					Toast.shared.show(text: error.localizedDescription.attributedMarkdown ?? "")
 				}
 			}
-			catch {
-				Toast.shared.show(text: error.localizedDescription.attributedMarkdown ?? "")
-			}
 		}
+
+		if selectedImage.remoteUrl != nil {
+			showDeleteAlert(dismissAction: action)
+			return
+		}
+
+		action()
 	}
 
 	func handleInstructionsButtonTap() {
@@ -116,23 +125,30 @@ class GalleryViewModel: ObservableObject {
 		guard let localImages = localImages else {
 			return
 		}
-		Task { @MainActor [localImages] in
-			do {
-				showLoading = true
-				try useCase.clearLocalImages(deviceId: deviceId)
-				let fileUrls = await localImages.asyncCompactMap { try? await useCase.saveImage($0.uiImage!, deviceId: deviceId, metadata: $0.metadata)}
-				try await useCase.startFilesUpload(deviceId: deviceId, files: fileUrls.compactMap { try? $0.asURL() })
-				showLoading = false
-				showUploadStarted()
-			} catch PhotosError.networkError(let error) {
-				showLoading = false
-				showFail(error: error)
-			}
-			catch {
-				showLoading = false
-				Toast.shared.show(text: error.localizedDescription.attributedMarkdown ?? "")
+
+		let action: VoidCallback = { [weak self] in
+			Task { @MainActor in
+				guard let self else { return }
+
+				do {
+					self.showLoading = true
+					try self.useCase.clearLocalImages(deviceId: self.deviceId)
+					let fileUrls = await localImages.asyncCompactMap { try? await self.useCase.saveImage($0.uiImage!, deviceId: self.deviceId, metadata: $0.metadata)}
+					try await self.useCase.startFilesUpload(deviceId: self.deviceId, files: fileUrls.compactMap { try? $0.asURL() })
+					self.showLoading = false
+					self.showUploadStarted()
+				} catch PhotosError.networkError(let error) {
+					self.showLoading = false
+					self.showFail(error: error)
+				}
+				catch {
+					self.showLoading = false
+					Toast.shared.show(text: error.localizedDescription.attributedMarkdown ?? "")
+				}
 			}
 		}
+
+		showUploadAlert(dismissAction: action)
 	}
 
 	func handleOpenSettingsTap() {
@@ -281,6 +297,31 @@ private extension GalleryViewModel {
 
 		uploadStartedObject = obj
 		showUploadStartedSuccess = true
+	}
+
+	func showUploadAlert(dismissAction: @escaping VoidCallback) {
+		let message = LocalizableString.PhotoVerification.uploadPhotosAlertMessage.localized
+		let exitAction: AlertHelper.AlertObject.Action = (LocalizableString.PhotoVerification.upload.localized, { _ in  dismissAction() })
+		let alertObject = AlertHelper.AlertObject(title: LocalizableString.PhotoVerification.uploadPhotosAlertTitle.localized,
+												  message: message,
+												  cancelActionTitle: LocalizableString.back.localized,
+												  cancelAction: {},
+												  okAction: exitAction)
+
+		AlertHelper().showAlert(alertObject)
+	}
+
+
+	func showDeleteAlert(dismissAction: @escaping VoidCallback) {
+		let message = LocalizableString.PhotoVerification.deletePhotoAlertMessage.localized
+		let exitAction: AlertHelper.AlertObject.Action = (LocalizableString.delete.localized, { _ in  dismissAction() })
+		let alertObject = AlertHelper.AlertObject(title: LocalizableString.PhotoVerification.deletePhotoAlertTitle.localized,
+												  message: message,
+												  cancelActionTitle: LocalizableString.back.localized,
+												  cancelAction: {},
+												  okAction: exitAction)
+
+		AlertHelper().showAlert(alertObject)
 	}
 
 	func showFail(error: NetworkErrorResponse) {

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroView.swift
@@ -247,7 +247,7 @@ private extension PhotoIntroView {
 }
 
 #Preview {
-	PhotoIntroView(viewModel: ViewModelsFactory.getPhotoIntroViewModel(deviceId: ""))
+	PhotoIntroView(viewModel: ViewModelsFactory.getPhotoIntroViewModel(deviceId: "", images: []))
 }
 
 #Preview {

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroViewModel.swift
@@ -39,16 +39,18 @@ class PhotoIntroViewModel: ObservableObject {
 	}()
 
 	private let deviceId: String
+	private let images: [String]
 	private let photoGalleryUseCase: PhotoGalleryUseCase
 
-	init(deviceId: String, photoGalleryUseCase: PhotoGalleryUseCase) {
+	init(deviceId: String, images: [String], photoGalleryUseCase: PhotoGalleryUseCase) {
 		self.deviceId = deviceId
+		self.images = images
 		self.photoGalleryUseCase = photoGalleryUseCase
 		areTermsAccepted = photoGalleryUseCase.areTermsAccepted
 	}
 
 	func handleBeginButtonTap() {
-		let viewModel = ViewModelsFactory.getGalleryViewModel(deviceId: deviceId, images: [], isNewVerification: true)
+		let viewModel = ViewModelsFactory.getGalleryViewModel(deviceId: deviceId, images: images, isNewVerification: true)
 		Router.shared.navigateTo(.photoGallery(viewModel))
 	}
 }
@@ -68,7 +70,7 @@ extension PhotoIntroViewModel: HashableViewModel {
 			return .photoGallery(viewModel)
 		}
 
-		let viewModel = ViewModelsFactory.getPhotoIntroViewModel(deviceId: deviceId)
+		let viewModel = ViewModelsFactory.getPhotoIntroViewModel(deviceId: deviceId, images: images)
 		return .photoIntro(viewModel)
 	}
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeView.swift
@@ -189,44 +189,48 @@ private struct ContentView: View {
 						}
 					}
 
+					if mainVM.showWalletWarning && isWalletEmpty {
+						CardWarningView(configuration: .init(title: LocalizableString.walletAddressMissingTitle.localized,
+															 message: LocalizableString.walletAddressMissingText.localized) {
+
+							WXMAnalytics.shared.trackEvent(.prompt, parameters: [.promptName: .walletMissing,
+																				 .promptType: .warnPromptType,
+																				 .action: .dismissAction])
+
+							withAnimation {
+								mainVM.hideWalletWarning()
+							}
+						}) {
+							HStack {
+								Button {
+									Router.shared.navigateTo(.wallet(ViewModelsFactory.getMyWalletViewModel()))
+									WXMAnalytics.shared.trackEvent(.prompt, parameters: [.promptName: .walletMissing,
+																						 .promptType: .warnPromptType,
+																						 .action: .action])
+
+								} label: {
+									Text(LocalizableString.addWalletTitle.localized)
+										.foregroundColor(Color(colorEnum: .wxmPrimary))
+										.font(.system(size: CGFloat(.smallFontSize), weight: .bold))
+								}
+
+								Spacer()
+							}
+						}
+						.onAppear {
+							WXMAnalytics.shared.trackEvent(.prompt, parameters: [.promptName: .walletMissing,
+																				 .promptType: .warnPromptType,
+																				 .action: .viewAction])
+						}
+					}
+
+
 					NavigationTitleView(title: .constant(LocalizableString.weatherStationsHomeTitle.localized),
 										subtitle: .constant(nil)) {
 						navigationBarRightView
 					}
 					
 					VStack(spacing: CGFloat(.smallSpacing)) {
-
-						if mainVM.showWalletWarning && isWalletEmpty {
-							CardWarningView(configuration: .init(title: LocalizableString.walletAddressMissingTitle.localized,
-																 message: LocalizableString.walletAddressMissingText.localized) {
-								
-								WXMAnalytics.shared.trackEvent(.prompt, parameters: [.promptName: .walletMissing,
-																					 .promptType: .warnPromptType,
-																					 .action: .dismissAction])
-								
-								withAnimation {
-									mainVM.hideWalletWarning()
-								}
-							}) {
-								Button {
-									Router.shared.navigateTo(.wallet(ViewModelsFactory.getMyWalletViewModel()))
-									WXMAnalytics.shared.trackEvent(.prompt, parameters: [.promptName: .walletMissing,
-																						 .promptType: .warnPromptType,
-																						 .action: .action])
-									
-								} label: {
-									Text(LocalizableString.addWalletTitle.localized)
-										.foregroundColor(Color(colorEnum: .wxmPrimary))
-										.font(.system(size: CGFloat(.smallFontSize), weight: .bold))
-								}
-							}
-							.onAppear {
-								WXMAnalytics.shared.trackEvent(.prompt, parameters: [.promptName: .walletMissing,
-																					 .promptType: .warnPromptType,
-																					 .action: .viewAction])
-							}
-						}
-						
 						weatherStationsList(devices: devices)
 					}
 				}

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
@@ -123,6 +123,9 @@ public final class WeatherStationsHomeViewModel: ObservableObject {
 			updateProgressUpload()
 		}
 
+		// Refresh the user to handle some corner cases with the wallet state
+		_ = try? meUseCase.getUserInfo()
+		
         do {
             shouldShowFullScreenLoader = !refreshMode
             try meUseCase.getDevices()

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
@@ -119,6 +119,10 @@ public final class WeatherStationsHomeViewModel: ObservableObject {
     ///   - refreshMode: Set true if coming from pull to refresh to prevent showing full screen loader
     ///   - completion: Called once the request is finished
     func getDevices(refreshMode: Bool = false, completion: (() -> Void)? = nil) {
+		if refreshMode {
+			updateProgressUpload()
+		}
+
         do {
             shouldShowFullScreenLoader = !refreshMode
             try meUseCase.getDevices()

--- a/PresentationLayer/UIComponents/ViewModelsFactory.swift
+++ b/PresentationLayer/UIComponents/ViewModelsFactory.swift
@@ -264,14 +264,14 @@ enum ViewModelsFactory {
 		return RewardAnalyticsViewModel(useCase: useCase, devices: devices)
 	}
 
-	static func getPhotoIntroViewModel(deviceId: String) -> PhotoIntroViewModel {
+	static func getPhotoIntroViewModel(deviceId: String, images: [String]) -> PhotoIntroViewModel {
 		let useCase = SwinjectHelper.shared.getContainerForSwinject().resolve(PhotoGalleryUseCase.self)!
-		return PhotoIntroViewModel(deviceId: deviceId, photoGalleryUseCase: useCase)
+		return PhotoIntroViewModel(deviceId: deviceId, images: images, photoGalleryUseCase: useCase)
 	}
 
 	static func getPhotoInstructionsViewModel(deviceId: String) -> PhotoInstructionsViewModel {
 		let useCase = SwinjectHelper.shared.getContainerForSwinject().resolve(PhotoGalleryUseCase.self)!
-		return PhotoInstructionsViewModel(deviceId: deviceId, photoGalleryUseCase: useCase)
+		return PhotoInstructionsViewModel(deviceId: deviceId, images: [], photoGalleryUseCase: useCase)
 	}
 
 	static func getGalleryViewModel(deviceId: String, images: [String], isNewVerification: Bool) -> GalleryViewModel {

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -3977,7 +3977,7 @@
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wxm-ios/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "WXM Dev";
+				INFOPLIST_KEY_CFBundleDisplayName = "WXM Mock";
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "WeatherXM uses Bluetooth to connect to your Helium device and allow you to claim it automatically.";
@@ -4200,7 +4200,7 @@
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "wxm-ios/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "WXM Dev";
+				INFOPLIST_KEY_CFBundleDisplayName = WeatherXM;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "WeatherXM uses Bluetooth to connect to your Helium device and allow you to claim it automatically.";

--- a/wxm-ios/DataLayer/DataLayer/Networking/FileUploaderService.swift
+++ b/wxm-ios/DataLayer/DataLayer/Networking/FileUploaderService.swift
@@ -68,7 +68,7 @@ public final class FileUploaderService: Sendable {
 				return
 			}
 
-			if (error as NSError).code == NSURLErrorCancelled {
+			if task.isCancelled {
 				self?.removeFile(for: task)
 			}
 
@@ -130,7 +130,7 @@ public final class FileUploaderService: Sendable {
 
 		// If there is no progress but there are still file url entries with existing files for this id,
 		// we assume the process is failed
-		let tasks = taskFileUrls.keys.filter { $0.taskDescription == deviceId }
+		let tasks = taskFileUrls.keys.filter { ($0.taskDescription == deviceId) && !$0.isCancelled }
 		let files = tasks.compactMap { taskFileUrls[$0] }
 		if files.first(where: { FileManager.default.fileExists(atPath: $0.path()) }) != nil {
 			return .failed
@@ -290,5 +290,11 @@ private final class SessionDelegate: NSObject, @unchecked Sendable, URLSessionDa
 private extension Int {
 	var isSuccessCode: Bool {
 		200..<300 ~= self
+	}
+}
+
+private extension URLSessionTask {
+	var isCancelled: Bool {
+		(error as? NSError)?.code == NSURLErrorCancelled 
 	}
 }

--- a/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/PhotosRepository.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/PhotosRepository.swift
@@ -53,7 +53,7 @@ public enum PhotosError: CustomStringConvertible, Error {
 	case uploadFailed(Error)
 }
 
-public enum PhotoUploadState {
+public enum PhotoUploadState: Equatable {
 	case uploading(Double)
 	case failed
 }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -2300,6 +2300,17 @@
         }
       }
     },
+    "delete" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
+          }
+        }
+      }
+    },
     "delete_account_cancel_deletion" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -5853,6 +5864,28 @@
         }
       }
     },
+    "photo_verification_delete_photo_alert_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This photo is already uploaded, are you sure you want to delete it?"
+          }
+        }
+      }
+    },
+    "photo_verification_delete_photo_alert_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete this photo?"
+          }
+        }
+      }
+    },
     "photo_verification_exit_photo_verification" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -6283,6 +6316,28 @@
       }
     },
     "photo_verification_upload_photos" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Upload your photos"
+          }
+        }
+      }
+    },
+    "photo_verification_upload_photos_alert_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure that your photos follow our guidelines?\nIf you are having second thoughts you can go back and retake any of them!"
+          }
+        }
+      }
+    },
+    "photo_verification_upload_photos_alert_title" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {

--- a/wxm-ios/Resources/Localizable/LocalizableConstants.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableConstants.swift
@@ -25,6 +25,7 @@ enum LocalizableString: WXMLocalizable {
 	case back
 	case exit
 	case skip
+	case delete
 	case firstName
 	case lastName
 	case password
@@ -237,6 +238,8 @@ extension LocalizableString {
 				return "exit"
 			case .skip:
 				return "skip"
+			case .delete:
+				return "delete"
 			case .firstName:
 				return "first_name"
 			case .lastName:

--- a/wxm-ios/Resources/Localizable/LocalizableString+PhotoVerification.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+PhotoVerification.swift
@@ -71,6 +71,10 @@ extension LocalizableString {
 		case uploadFinishedNotificationTitle(Int)
 		case uploadFailedNotificationFailedTitle
 		case uploadFailedNotificationFailedDescription
+		case deletePhotoAlertTitle
+		case deletePhotoAlertMessage
+		case uploadPhotosAlertTitle
+		case uploadPhotosAlertMessage
 	}
 }
 
@@ -214,6 +218,14 @@ extension LocalizableString.PhotoVerification: WXMLocalizable {
 				"photo_verification_upload_failed_notification_failed_title"
 			case .uploadFailedNotificationFailedDescription:
 				"photo_verification_upload_failed_notification_failed_description"
+			case .deletePhotoAlertTitle:
+				"photo_verification_delete_photo_alert_title"
+			case .deletePhotoAlertMessage:
+				"photo_verification_delete_photo_alert_message"
+			case .uploadPhotosAlertTitle:
+				"photo_verification_upload_photos_alert_title"
+			case .uploadPhotosAlertMessage:
+				"photo_verification_upload_photos_alert_message"
 		}
 	}
 }

--- a/wxm-ios/Toolkit/Toolkit/Utils/UIImage+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/UIImage+.swift
@@ -35,4 +35,24 @@ public extension UIImage {
 		UIGraphicsEndImageContext()
 		return tintedImage
 	}
+
+	func scaleDown(newWidth: CGFloat) -> UIImage {
+		guard size.width >= newWidth else {
+			return self
+		}
+
+		let scaleFactor = newWidth / self.size.width
+
+		let newHeight = self.size.height * scaleFactor
+		let newSize = CGSize(width: newWidth, height: newHeight)
+
+		UIGraphicsBeginImageContextWithOptions(newSize, true, 0.0)
+		self.draw(in: CGRect(x: 0.0, y: 0.0, width: newWidth, height: newHeight))
+
+		let newImage: UIImage? = UIGraphicsGetImageFromCurrentImageContext()
+
+		UIGraphicsEndImageContext()
+
+		return newImage ?? self
+	}
 }


### PR DESCRIPTION
## **Why?**
Fixes in issues came from QA
### **How?**
- Added missing alerts on delete and upload button taps ([FE-1544](https://linear.app/weatherxm/issue/FE-1544/before-uploading-or-deleting-photos-a-warning-box-should-be-presented))
- Fixed case of error notification when the upload is canceled ([FE-1545](https://linear.app/weatherxm/issue/FE-1545/when-the-upload-is-manually-cancelled-error-appear-on-notification))
- Fixed the position of photo cards in helium station settings ([FE-1535](https://linear.app/weatherxm/issue/FE-1535/wrong-placement-to-start-photo-verifications-from-stations-settings))
- ~Scale down the shared photo to avoid lags when the share button is tapped ([FE-1536](https://linear.app/weatherxm/issue/FE-1536/share-button-either-does-not-work-or-share-text))~
- Disabled bounce in gallery scroller ([FE-1539](https://linear.app/weatherxm/issue/FE-1539/on-station-gallery-swapping-only-moves-the-element-not-the-photos))
- ~Potential fix for continue button issue (FE-1538)~
- Fixed the issue with no wallet warning after successful claim (FE-1560)
### **Testing**
Ensure the tasks mentioned above are fixed
### **Additional context**
fixes FE-1544, FE-1545, FE-1535, FE-1539, FE-1560
