### PR TITLE
Photo verification memory issues

### DIFF
--- a/PresentationLayer/UIComponents/Modifiers/WXMShareModifier.swift
+++ b/PresentationLayer/UIComponents/Modifiers/WXMShareModifier.swift
@@ -43,7 +43,7 @@ private struct WXMShareModifier: ViewModifier {
 																				  height: 0.0)
 			activityController.popoverPresentationController?.permittedArrowDirections = []
 		}
-		activityController.willDismissCallback = { show = false }
+		activityController.delegate = self
 		hostingWrapper.hostingController = activityController
 		UIApplication.shared.rootViewController?.present(activityController, animated: true)
 	}
@@ -53,19 +53,30 @@ private struct WXMShareModifier: ViewModifier {
 	}
 }
 
+extension WXMShareModifier:  WXMShareModifier.WXMActivityViewControllerDelegate {
+	func willDismissActivityViewController() {
+		show = false
+	}
+}
+
 private extension WXMShareModifier {
 	@MainActor
 	struct Store {
 		var anchorView = UIView()
 	}
 
+	@MainActor
+	protocol WXMActivityViewControllerDelegate {
+		func willDismissActivityViewController()
+	}
+
 	class WXMActivityViewController: UIActivityViewController {
-		var willDismissCallback: VoidCallback?
+		var delegate: WXMActivityViewControllerDelegate?
 
 		override func viewWillDisappear(_ animated: Bool) {
 			super.viewWillDisappear(animated)
 			if isBeingDismissed {
-				willDismissCallback?()
+				delegate?.willDismissActivityViewController()
 			}
 		}
 

--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel.swift
@@ -138,8 +138,8 @@ class DeviceInfoViewModel: ObservableObject {
 			self.photoStateViewModel = nil
 		}
 
-		photoStateViewModel?.$state.sink { state in
-			self.photoVerificationState = state
+		photoStateViewModel?.$state.sink { [weak self] state in
+			self?.photoVerificationState = state
 		}.store(in: &cancellable)
 
 		refresh { [weak self] in

--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/PhotoVerificationState/PhotoVerificationStateViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/PhotoVerificationState/PhotoVerificationStateViewModel.swift
@@ -89,22 +89,22 @@ private extension PhotoVerificationStateViewModel {
 	}
 
 	func observePhotoUploadState() {
-		photoGalleryUseCase?.uploadErrorPublisher.sink { deviceId, error in
-			guard deviceId == self.deviceId else { return }
-			self.updateState()
+		photoGalleryUseCase?.uploadErrorPublisher.sink { [weak self] deviceId, error in
+			guard deviceId == self?.deviceId else { return }
+			self?.updateState()
 			Task { @MainActor [weak self] in
 				await self?.fetchPhotos()
 			}
 		}.store(in: &cancellables)
 
-		photoGalleryUseCase?.uploadProgressPublisher.sink { deviceId, progress in
-			guard deviceId == self.deviceId else { return }
-			self.updateState()
+		photoGalleryUseCase?.uploadProgressPublisher.sink { [weak self] deviceId, progress in
+			guard deviceId == self?.deviceId else { return }
+			self?.updateState()
 		}.store(in: &cancellables)
 
-		photoGalleryUseCase?.uploadCompletedPublisher.sink { deviceId, _ in
-			guard deviceId == self.deviceId else { return }
-			self.updateState()
+		photoGalleryUseCase?.uploadCompletedPublisher.sink { [weak self] deviceId, _ in
+			guard deviceId == self?.deviceId else { return }
+			self?.updateState()
 			Task { @MainActor [weak self] in
 				await self?.fetchPhotos()
 			}

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
@@ -41,7 +41,7 @@ struct GalleryView: View {
 					Spacer()
 
 					Button {
-						viewModel.handleUploadButtonTap()
+						viewModel.handleUploadButtonTap(dismissAction: dismiss)
 					} label: {
 						Text(LocalizableString.PhotoVerification.upload.localized)
 					}

--- a/wxm-ios/DataLayer/DataLayer/Networking/FileUploaderService.swift
+++ b/wxm-ios/DataLayer/DataLayer/Networking/FileUploaderService.swift
@@ -166,6 +166,7 @@ private extension FileUploaderService {
 		task.resume()
 		taskFileBodyUrls[task] = bodyFileURL
 		taskFileUrls[task] = file
+		taskProgresses[task] = 0.0
 	}
 
 	func generateRequestBody(fileData: Data, boundary: String, fields: [String: String]?) -> Data {

--- a/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/post_device_photos.json
+++ b/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/post_device_photos.json
@@ -10,5 +10,17 @@
 			"Policy": "eyJleHBpcmF0aW9uIjoiMi9zMy9hd3M0x3J1cXV1c3QifSx71lgtQW16LURhdGU10ilylOMTIyMFQxMjAxMDJaIn®seyJ[ZXki0¡JleG90аWMtcGVjYW4tYXVyb3JhLzEifV19",
 			"X-Amz-Signature": "7738c4930d8da4d42fe41697f6f1168374e8de5db50f386ec0d910d6c7d6c9c6"
 		}
+	},
+	{
+		"url": "https://wxm-station-photos-dev.s3.eu-west-2.amazonaws.com/",
+		"fields": {
+			"bucket": "wxm-station-photos-dev",
+			"X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+			"X-Amz-Credential": "AKIA5L3Q742TP4MZSCEB/20241220/eu-west-2/s3/aws4_request",
+			"X-Amz-Date": "20241220T120102Z",
+			"key": "exotic-pecan-aurora/1",
+			"Policy": "eyJleHBpcmF0aW9uIjoiMi9zMy9hd3M0x3J1cXV1c3QifSx71lgtQW16LURhdGU10ilylOMTIyMFQxMjAxMDJaIn®seyJ[ZXki0¡JleG90аWMtcGVjYW4tYXVyb3JhLzEifV19",
+			"X-Amz-Signature": "7738c4930d8da4d42fe41697f6f1168374e8de5db50f386ec0d910d6c7d6c9c6"
+		}
 	}
 ]

--- a/wxm-ios/Toolkit/Toolkit/Utils/UIImage+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/UIImage+.swift
@@ -46,7 +46,7 @@ public extension UIImage {
 		let newHeight = self.size.height * scaleFactor
 		let newSize = CGSize(width: newWidth, height: newHeight)
 
-		UIGraphicsBeginImageContextWithOptions(newSize, true, 0.0)
+		UIGraphicsBeginImageContextWithOptions(newSize, true, 1.0)
 		self.draw(in: CGRect(x: 0.0, y: 0.0, width: newWidth, height: newHeight))
 
 		let newImage: UIImage? = UIGraphicsGetImageFromCurrentImageContext()


### PR DESCRIPTION
## **Why?**
Fixed some memory leaks in the device info screen. Because of strong references in `PhotoVerificationStateViewModel`, the `PhotoVerificationStateViewModel` and the DeviceInfoViewModel` were never deallocated.
This issue may be responsible for the bug in the video that is attached in the task (FE-1568)
### **How?**
- Fixed retain cycles
- Fixed the downscale functionality for the shared photos
### **Testing**
- Try to reproduce the issue (I don't know how 😕). If not, this is a good sign
- Share a photo after the upload start and ensure the width is not bigger than  800 pixels
### **Additional context**
fixes FE-1568
