### PR TITLE
Legal terms

### DIFF
--- a/PresentationLayer/Constants/Strings/DisplayedLinks.swift
+++ b/PresentationLayer/Constants/Strings/DisplayedLinks.swift
@@ -12,6 +12,8 @@ import Toolkit
 enum DisplayedLinks {
 	case emptyValue
 	case termsLink
+	case termsOfUse
+	case privacyPolicy
 	case contactLink
 	case weatherXMWebsiteLink
 	case createWalletsLink
@@ -45,6 +47,10 @@ enum DisplayedLinks {
 				return ""
 			case .termsLink:
 				return "https://weatherxm.com/mobile/terms/"
+			case .termsOfUse:
+				return "https://weatherxm.com/wp-content/uploads/2025/01/WeatherXM-Network-Terms-of-Use-Station-Owners.pdf"
+			case .privacyPolicy:
+				return "https://weatherxm.com/wp-content/uploads/2025/01/WeatherXM-Network-Privacy-Policy-Station-Owners.pdf"
 			case .contactLink:
 				return "https://weatherxm.com/contact/"
 			case .weatherXMWebsiteLink:

--- a/PresentationLayer/Constants/Strings/DisplayedLinks.swift
+++ b/PresentationLayer/Constants/Strings/DisplayedLinks.swift
@@ -48,9 +48,9 @@ enum DisplayedLinks {
 			case .termsLink:
 				return "https://weatherxm.com/mobile/terms/"
 			case .termsOfUse:
-				return "https://weatherxm.com/wp-content/uploads/2025/01/WeatherXM-Network-Terms-of-Use-Station-Owners.pdf"
+				return "https://weatherxm.network/terms-of-use.pdf"
 			case .privacyPolicy:
-				return "https://weatherxm.com/wp-content/uploads/2025/01/WeatherXM-Network-Privacy-Policy-Station-Owners.pdf"
+				return "https://weatherxm.network/privacy-policy.pdf"
 			case .contactLink:
 				return "https://weatherxm.com/contact/"
 			case .weatherXMWebsiteLink:

--- a/PresentationLayer/UIComponents/BaseComponents/WXMAlert/WXMAlertView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WXMAlert/WXMAlertView.swift
@@ -11,6 +11,7 @@ import Toolkit
 struct WXMAlertConfiguration {
     let title: String
     let text: AttributedString
+	var canDismiss: Bool = true
     var buttonsLayout: Layout = .vertical
     var secondaryButtons: [ActionButton] = []
     let primaryButtons: [ActionButton]
@@ -35,6 +36,9 @@ struct WXMAlertView<V: View>: View {
     let configuration: WXMAlertConfiguration
     let bottomView: () -> V
 
+	@State private var showInAppBrowser: Bool = false
+	@State private  var inAppBrowserURL: URL?
+
     var body: some View {
         GeometryReader { proxy in
             VStack {
@@ -45,7 +49,7 @@ struct WXMAlertView<V: View>: View {
 
                     alertView
 						.iPadMaxWidth()
-                        .frame(width: 0.8 * proxy.size.width)
+                        .frame(width: 0.9 * proxy.size.width)
 
                     Spacer()
                 }
@@ -60,7 +64,7 @@ private extension WXMAlertView {
 
     @ViewBuilder
     var alertView: some View {
-        VStack(spacing: CGFloat(.smallSpacing)) {
+		VStack(spacing: CGFloat(.mediumSpacing)) {
             HStack {
                 Text(configuration.title)
                     .foregroundColor(Color(colorEnum: .darkestBlue))
@@ -68,20 +72,23 @@ private extension WXMAlertView {
 
                 Spacer()
 
-                Button {
-                    show = false
-                } label: {
-                    Image(asset: .closeIcon)
-                        .renderingMode(.template)
-                        .foregroundColor(Color(colorEnum: .text))
-                }
-
+				if configuration.canDismiss {
+					Button {
+						show = false
+					} label: {
+						Image(asset: .closeIcon)
+							.renderingMode(.template)
+							.foregroundColor(Color(colorEnum: .text))
+					}
+				}
             }
 
             HStack {
                 Text(configuration.text)
                     .foregroundColor(Color(colorEnum: .text))
                     .font(.system(size: CGFloat(.normalFontSize)))
+					.tint(Color(colorEnum: .wxmPrimary))
+
                 Spacer()
             }
 
@@ -90,6 +97,19 @@ private extension WXMAlertView {
             bottomView()
         }
         .WXMCardStyle()
+		.environment(\.openURL, OpenURLAction { url in
+			self.inAppBrowserURL = url
+			self.showInAppBrowser = true
+			return .handled
+		})
+		.fullScreenCover(isPresented: $showInAppBrowser) {
+			if let inAppBrowserURL {
+				SafariView(url: inAppBrowserURL)
+			} else {
+				EmptyView()
+			}
+		}
+
     }
 
     @ViewBuilder

--- a/PresentationLayer/UIComponents/Screens/ExplorerSignIn/RegisterView.swift
+++ b/PresentationLayer/UIComponents/Screens/ExplorerSignIn/RegisterView.swift
@@ -26,7 +26,6 @@ struct RegisterView: View {
             .padding(.bottom, CGFloat(.defaultSidePadding))
             .padding(.horizontal, CGFloat(.defaultSidePadding))
         }
-        .navigationBarTitle(Text(LocalizableString.createAccount.localized), displayMode: .large)
         .onChange(of: viewModel.userEmail) { email in
             viewModel.userEmail = email.trimWhiteSpaces()
         }

--- a/PresentationLayer/UIComponents/Screens/ExplorerSignIn/RegisterView.swift
+++ b/PresentationLayer/UIComponents/Screens/ExplorerSignIn/RegisterView.swift
@@ -29,7 +29,6 @@ struct RegisterView: View {
         .navigationBarTitle(Text(LocalizableString.createAccount.localized), displayMode: .large)
         .onChange(of: viewModel.userEmail) { email in
             viewModel.userEmail = email.trimWhiteSpaces()
-            viewModel.checkSignUpButtonAvailability()
         }
         .onAppear {
             WXMAnalytics.shared.trackScreen(.signup)
@@ -50,7 +49,10 @@ struct RegisterView: View {
             resisterDescription
             textFields
             Spacer()
-            signUpButton
+			VStack(spacing: CGFloat(.defaultSpacing)) {
+				acknowledgementView
+				signUpButton
+			}
         }
     }
 
@@ -92,6 +94,49 @@ struct RegisterView: View {
         .buttonStyle(WXMButtonStyle.filled())
         .disabled(!viewModel.isSignUpButtonAvailable)
     }
+
+	@ViewBuilder
+	var acknowledgementView: some View {
+		HStack(alignment: .top, spacing: CGFloat(.smallSpacing)) {
+			Toggle("",
+				   isOn: $viewModel.termsAccepted)
+			.labelsHidden()
+			.toggleStyle(WXMToggleStyle.Default)
+
+			Text(termsText)
+				.foregroundColor(Color(colorEnum: .text))
+				.font(.system(size: CGFloat(.normalFontSize)))
+				.tint(Color(colorEnum: .wxmPrimary))
+				.fixedSize(horizontal: false, vertical: true)
+		}
+		.environment(\.openURL, OpenURLAction { url in
+			Router.shared.showFullScreen(.safariView(url))
+			return .handled
+		})
+
+	}
+
+	var termsText: AttributedString {
+		let terms = LocalizableString.Settings.termsOfUse.localized
+		let termsUrl = LocalizableString.url(terms,
+											 DisplayedLinks.termsOfUse.linkURL).localized
+
+		let privacy = LocalizableString.Settings.privacyPolicy.localized
+		let privacyUrl = LocalizableString.url(privacy,
+											   DisplayedLinks.privacyPolicy.linkURL).localized
+
+		var str = LocalizableString.readTermsAndPrivacyPolicy(termsUrl, privacyUrl).localized.attributedMarkdown!
+
+		if let termsRange = str.range(of: terms) {
+			str[termsRange].underlineStyle = .single
+		}
+
+		if let privacyRange = str.range(of: privacy) {
+			str[privacyRange].underlineStyle = .single
+		}
+
+		return str
+	}
 }
 
 struct Previews_RegisterView_Previews: PreviewProvider {

--- a/PresentationLayer/UIComponents/Screens/ExplorerSignIn/RegisterViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ExplorerSignIn/RegisterViewModel.swift
@@ -31,10 +31,12 @@ final class RegisterViewModel: ObservableObject {
     var failSuccessObj: FailSuccessStateObject?
     private var cancellableSet: Set<AnyCancellable> = []
 
-    private final let authUseCase: AuthUseCase
+    private let authUseCase: AuthUseCase
+	private let mainUseCase: MainUseCase
 
-    init(authUseCase: AuthUseCase) {
+	init(authUseCase: AuthUseCase, mainUseCase: MainUseCase) {
         self.authUseCase = authUseCase
+		self.mainUseCase = mainUseCase
     }
 
     func register() {
@@ -105,6 +107,8 @@ final class RegisterViewModel: ObservableObject {
 		failSuccessObj = successObj
 		isFail = false
 		isSuccess = true
+
+		mainUseCase.setTermsOfUseAccepted()
 	}
 }
 

--- a/PresentationLayer/UIComponents/Screens/ExplorerSignIn/RegisterViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ExplorerSignIn/RegisterViewModel.swift
@@ -14,11 +14,20 @@ final class RegisterViewModel: ObservableObject {
     @Published var userEmail: String = ""
     @Published var userName: String = ""
     @Published var userSurname: String = ""
-    @Published var isSignUpButtonAvailable: Bool = false
     @Published var isCallInProgress: Bool = false
+	@Published var termsAccepted = false
     @Published var isSuccess: Bool = false
     @Published var isFail = false
 
+	var isSignUpButtonAvailable: Bool {
+		guard !userEmail.isEmpty &&
+				userEmail.isValidEmail() &&
+				termsAccepted else {
+			return false
+		}
+
+		return true
+	}
     var failSuccessObj: FailSuccessStateObject?
     private var cancellableSet: Set<AnyCancellable> = []
 
@@ -97,14 +106,6 @@ final class RegisterViewModel: ObservableObject {
 		isFail = false
 		isSuccess = true
 	}
-
-    func checkSignUpButtonAvailability() {
-        if userEmail.isEmpty || !userEmail.isValidEmail() {
-            isSignUpButtonAvailable = false
-        } else {
-            isSignUpButtonAvailable = true
-        }
-    }
 }
 
 extension RegisterViewModel: HashableViewModel {

--- a/PresentationLayer/UIComponents/Screens/LoggedInViews/LoggedInTabViewContainer.swift
+++ b/PresentationLayer/UIComponents/Screens/LoggedInViews/LoggedInTabViewContainer.swift
@@ -54,9 +54,6 @@ struct LoggedInTabViewContainer: View {
 			WXMAlertView(show: $mainViewModel.showTermsPrompt,
 						 configuration: mainViewModel.termsAlertConfiguration, bottomView: { EmptyView() })
 		}
-		.onAppear {
-			print("onAppear \(Self.self)")
-		}
     }
 
     @ViewBuilder

--- a/PresentationLayer/UIComponents/Screens/LoggedInViews/LoggedInTabViewContainer.swift
+++ b/PresentationLayer/UIComponents/Screens/LoggedInViews/LoggedInTabViewContainer.swift
@@ -50,6 +50,13 @@ struct LoggedInTabViewContainer: View {
             AnalyticsView(show: $mainViewModel.showAnalyticsPrompt,
                           viewModel: ViewModelsFactory.getAnalyticsViewModel())
         }
+		.wxmAlert(show: $mainViewModel.showTermsPrompt) {
+			WXMAlertView(show: $mainViewModel.showTermsPrompt,
+						 configuration: mainViewModel.termsAlertConfiguration, bottomView: { EmptyView() })
+		}
+		.onAppear {
+			print("onAppear \(Self.self)")
+		}
     }
 
     @ViewBuilder

--- a/PresentationLayer/UIComponents/Screens/MainScreen/MainScreen.swift
+++ b/PresentationLayer/UIComponents/Screens/MainScreen/MainScreen.swift
@@ -8,6 +8,7 @@
 import Network
 import SwiftUI
 import DomainLayer
+import Toolkit
 #if DEBUG
 import PulseUI
 #endif
@@ -42,6 +43,16 @@ public struct MainScreen: View {
         }
 		.onNotificationReceive { notificationResponse in
 			_ = viewModel.deepLinkHandler.handleNotificationReceive(notificationResponse)
+		}
+		.modify { view in
+			if isRunningOnMac {
+				view
+					.onAppear {
+						viewModel.initializeConfigurations()
+					}
+			} else {
+				view
+			}
 		}
 		#if DEBUG
 		.bottomSheet(show: $viewModel.showHttpMonitor, fitContent: false) {

--- a/PresentationLayer/UIComponents/Screens/MainScreen/MainScreenViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/MainScreen/MainScreenViewModel.swift
@@ -334,6 +334,7 @@ class MainScreenViewModel: ObservableObject {
 									 canDismiss: false,
 									 primaryButtons: [.init(title: LocalizableString.iUnderstand.localized,
 															action: { [weak self] in
+			self?.mainUseCase.setTermsOfUseAccepted()
 			self?.showTermsPrompt = false
 		})])
 	}

--- a/PresentationLayer/UIComponents/Screens/MainScreen/MainScreenViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/MainScreen/MainScreenViewModel.swift
@@ -16,16 +16,16 @@ import WidgetKit
 @MainActor
 class MainScreenViewModel: ObservableObject {
 
-    static let shared = MainScreenViewModel()
+	static let shared = MainScreenViewModel()
 
-    @Published private(set) var theme: Theme = .system {
-        willSet {
-            updateThemeOption(newValue)
-        }
+	@Published private(set) var theme: Theme = .system {
+		willSet {
+			updateThemeOption(newValue)
+		}
 
-        didSet {
-            WXMAnalytics.shared.setUserProperty(key: .theme, value: theme.analyticsValue)
-        }
+		didSet {
+			WXMAnalytics.shared.setUserProperty(key: .theme, value: theme.analyticsValue)
+		}
 	}
 	/// The active theme of the device. The value will be only light or dark.
 	/// eg if the user's choice is `system` and the device's theme is dark, the returned value will be dark
@@ -33,43 +33,51 @@ class MainScreenViewModel: ObservableObject {
 		getCurrentActiveTheme()
 	}
 
-    /// The interval to check if should show or hide wallet warning
-    private let showWarningWalletInterval: TimeInterval = 24.0 * TimeInterval.hour // 1 day
-    @Published private(set) var showWalletWarning: Bool = false
+	/// The interval to check if should show or hide wallet warning
+	private let showWarningWalletInterval: TimeInterval = 24.0 * TimeInterval.hour // 1 day
+	@Published private(set) var showWalletWarning: Bool = false
 
-    let deepLinkHandler = DeepLinkHandler(useCase: SwinjectHelper.shared.getContainerForSwinject().resolve(NetworkUseCase.self)!,
+	let deepLinkHandler = DeepLinkHandler(useCase: SwinjectHelper.shared.getContainerForSwinject().resolve(NetworkUseCase.self)!,
 										  explorerUseCase: SwinjectHelper.shared.getContainerForSwinject().resolve(ExplorerUseCase.self)!)
 
-    private let mainUseCase: MainUseCase
+	private let mainUseCase: MainUseCase
 	private let meUseCase: MeUseCase
-    private let settingsUseCase: SettingsUseCase
-    private var cancellableSet: Set<AnyCancellable> = []
-    let networkMonitor: NWPathMonitor
-    @Published var isUserLoggedIn: Bool = false
-    @Published var isInternetAvailable: Bool = false
-    @Published var selectedTab: TabSelectionEnum = .homeTab
-    @Published var showAnalyticsPrompt: Bool = false
+	private let settingsUseCase: SettingsUseCase
+	private var cancellableSet: Set<AnyCancellable> = []
+	let networkMonitor: NWPathMonitor
+	@Published var isUserLoggedIn: Bool = false
+	@Published var isInternetAvailable: Bool = false
+	@Published var selectedTab: TabSelectionEnum = .homeTab
+	@Published var showAnalyticsPrompt: Bool = false
+	@Published var showTermsPrompt: Bool = false {
+		didSet {
+			print("showTermsPrompt \(showTermsPrompt)")
+		}
+	}
 	@Published var userInfo: NetworkUserInfoResponse? {
 		didSet {
 			updateIsWalletMissing()
 		}
 	}
 	@Published var isWalletMissing: Bool = false
-    @Published var showAppUpdatePrompt: Bool = false
+	@Published var showAppUpdatePrompt: Bool = false
 	@Published var showHttpMonitor: Bool = false
 
-    let swinjectHelper: SwinjectInterface
+	lazy var termsAlertConfiguration: WXMAlertConfiguration = {
+		getTermsAlertConfiguration()
+	}()
+	let swinjectHelper: SwinjectInterface
 
-    private init() {
-        self.swinjectHelper = SwinjectHelper.shared
-        mainUseCase = swinjectHelper.getContainerForSwinject().resolve(MainUseCase.self)!
+	private init() {
+		self.swinjectHelper = SwinjectHelper.shared
+		mainUseCase = swinjectHelper.getContainerForSwinject().resolve(MainUseCase.self)!
 		meUseCase = swinjectHelper.getContainerForSwinject().resolve(MeUseCase.self)!
 
-        networkMonitor = NWPathMonitor()
-        settingsUseCase = swinjectHelper.getContainerForSwinject().resolve(SettingsUseCase.self)!
+		networkMonitor = NWPathMonitor()
+		settingsUseCase = swinjectHelper.getContainerForSwinject().resolve(SettingsUseCase.self)!
 
-        checkIfUserIsLoggedIn()
-        settingsUseCase.initializeAnalyticsTracking()
+		checkIfUserIsLoggedIn()
+		settingsUseCase.initializeAnalyticsTracking()
 
 		NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) { _ in
 			WidgetCenter.shared.reloadAllTimelines()
@@ -86,7 +94,7 @@ class MainScreenViewModel: ObservableObject {
 		// Set the cache size in order to handle image download requests
 		URLCache.shared.memoryCapacity = 10_000_000 // ~10 MB memory space
 		URLCache.shared.diskCapacity = 500_000_000 // ~500 MB disk cache space
-        
+
 		RemoteConfigManager.shared.$iosAppLatestVersion.sink { [weak self] latestVersion in
 			guard let latestVersion else {
 				return
@@ -97,10 +105,10 @@ class MainScreenViewModel: ObservableObject {
 
 		RemoteConfigManager.shared.$iosAppMinimumVersion.sink { [weak self] minVersion in
 			guard let minVersion,
-			let latestVersion = RemoteConfigManager.shared.iosAppLatestVersion else {
+				  let latestVersion = RemoteConfigManager.shared.iosAppLatestVersion else {
 				return
 			}
-			
+
 			self?.showAppUpdatePrompt = self?.mainUseCase.shouldShowUpdatePrompt(for: latestVersion, minimumVersion: minVersion) ?? false
 		}.store(in: &cancellableSet)
 
@@ -113,22 +121,23 @@ class MainScreenViewModel: ObservableObject {
 				self?.showHttpMonitor = true
 			}
 		}
-    }
+	}
 
-    @Published var showFirmwareUpdate = false
-    var deviceToUpdate: DeviceDetails?
-    func showFirmwareUpdate(device: DeviceDetails) {
-        showFirmwareUpdate = true
-        deviceToUpdate = device
-    }
-    
-    func initializeConfigurations() {
-        theme = getThemeOption()
-        updateShowWalletWarning()
-        startMonitoring()
-        checkIfShouldShowAnalyticsPrompt(settingsUseCase: settingsUseCase)
-        cleanupAnalyticsUserIdIfNeeded()
-    }
+	@Published var showFirmwareUpdate = false
+	var deviceToUpdate: DeviceDetails?
+	func showFirmwareUpdate(device: DeviceDetails) {
+		showFirmwareUpdate = true
+		deviceToUpdate = device
+	}
+
+	func initializeConfigurations() {
+		theme = getThemeOption()
+		updateShowWalletWarning()
+		startMonitoring()
+		checkIfShouldShowAnalyticsPrompt(settingsUseCase: settingsUseCase)
+		cleanupAnalyticsUserIdIfNeeded()
+		checkIfShouldShowTerms()
+	}
 
 	private func requestNotificationAuthorizationIfNeeded() {
 		Task { @MainActor in
@@ -136,17 +145,17 @@ class MainScreenViewModel: ObservableObject {
 		}
 	}
 
-    private func checkIfUserIsLoggedIn() {
-        let container = swinjectHelper.getContainerForSwinject()
-        let authUseCase = container.resolve(AuthUseCase.self)!
-        isUserLoggedIn = authUseCase.isUserLoggedIn()
+	private func checkIfUserIsLoggedIn() {
+		let container = swinjectHelper.getContainerForSwinject()
+		let authUseCase = container.resolve(AuthUseCase.self)!
+		isUserLoggedIn = authUseCase.isUserLoggedIn()
 		if isUserLoggedIn {
 			selectedTab = .homeTab
 		}
-    }
+	}
 
-    private func startMonitoring() {
-        networkMonitor.pathUpdateHandler = { path in
+	private func startMonitoring() {
+		networkMonitor.pathUpdateHandler = { path in
 			DispatchQueue.main.async {
 				if path.status == .satisfied {
 					self.isInternetAvailable = true
@@ -154,72 +163,72 @@ class MainScreenViewModel: ObservableObject {
 					self.isInternetAvailable = false
 				}
 			}
-        }
-        networkMonitor.start(queue: DispatchQueue.main)
-    }
+		}
+		networkMonitor.start(queue: DispatchQueue.main)
+	}
 
-    // MARK: Temperature userDefaults
+	// MARK: Temperature userDefaults
 
-    private func getTemperatureMetricEnum() -> TemperatureUnitsEnum {
-        guard let temperatureUnits = mainUseCase.readOrCreateWeatherMetric(key: UserDefaults.WeatherUnitKey.temperature.rawValue) as? TemperatureUnitsEnum else {
-            return .celsius
-        }
-        return temperatureUnits
-    }
+	private func getTemperatureMetricEnum() -> TemperatureUnitsEnum {
+		guard let temperatureUnits = mainUseCase.readOrCreateWeatherMetric(key: UserDefaults.WeatherUnitKey.temperature.rawValue) as? TemperatureUnitsEnum else {
+			return .celsius
+		}
+		return temperatureUnits
+	}
 
-    // MARK: Percipitation userDefaults
+	// MARK: Percipitation userDefaults
 
-    private func getPrecipitationMetricEnum() -> PrecipitationUnitsEnum {
-        guard let precipitationUnits = mainUseCase.readOrCreateWeatherMetric(key: UserDefaults.WeatherUnitKey.precipitation.rawValue) as? PrecipitationUnitsEnum else {
-            return .millimeters
-        }
-        return precipitationUnits
-    }
+	private func getPrecipitationMetricEnum() -> PrecipitationUnitsEnum {
+		guard let precipitationUnits = mainUseCase.readOrCreateWeatherMetric(key: UserDefaults.WeatherUnitKey.precipitation.rawValue) as? PrecipitationUnitsEnum else {
+			return .millimeters
+		}
+		return precipitationUnits
+	}
 
-    // MARK: Wind Speed userDefaults
+	// MARK: Wind Speed userDefaults
 
-    private func getWindSpeedMetricEnum() -> WindSpeedUnitsEnum {
-        guard let windSpeedUnits = mainUseCase.readOrCreateWeatherMetric(key: UserDefaults.WeatherUnitKey.windSpeed.rawValue) as? WindSpeedUnitsEnum else {
-            return .kilometersPerHour
-        }
-        return windSpeedUnits
-    }
+	private func getWindSpeedMetricEnum() -> WindSpeedUnitsEnum {
+		guard let windSpeedUnits = mainUseCase.readOrCreateWeatherMetric(key: UserDefaults.WeatherUnitKey.windSpeed.rawValue) as? WindSpeedUnitsEnum else {
+			return .kilometersPerHour
+		}
+		return windSpeedUnits
+	}
 
-    // MARK: Wind Direction userDefaults
+	// MARK: Wind Direction userDefaults
 
-    private func getWindDirectionMetricEnum() -> WindDirectionUnitsEnum {
-        guard let windDirectionUnits = mainUseCase.readOrCreateWeatherMetric(key: UserDefaults.WeatherUnitKey.windDirection.rawValue) as? WindDirectionUnitsEnum else {
-            return .cardinal
-        }
-        return windDirectionUnits
-    }
+	private func getWindDirectionMetricEnum() -> WindDirectionUnitsEnum {
+		guard let windDirectionUnits = mainUseCase.readOrCreateWeatherMetric(key: UserDefaults.WeatherUnitKey.windDirection.rawValue) as? WindDirectionUnitsEnum else {
+			return .cardinal
+		}
+		return windDirectionUnits
+	}
 
-    // MARK: Pressure userDefaults
+	// MARK: Pressure userDefaults
 
-    private func getPressureMetricEnum() -> PressureUnitsEnum {
-        guard let pressureUnits = mainUseCase.readOrCreateWeatherMetric(key: UserDefaults.WeatherUnitKey.pressure.rawValue) as? PressureUnitsEnum else {
-            return .hectopascal
-        }
-        return pressureUnits
-    }
+	private func getPressureMetricEnum() -> PressureUnitsEnum {
+		guard let pressureUnits = mainUseCase.readOrCreateWeatherMetric(key: UserDefaults.WeatherUnitKey.pressure.rawValue) as? PressureUnitsEnum else {
+			return .hectopascal
+		}
+		return pressureUnits
+	}
 
-    // MARK: Display Theme
+	// MARK: Display Theme
 
-    func setTheme(_ theme: Theme) {
-        self.theme = theme
-    }
+	func setTheme(_ theme: Theme) {
+		self.theme = theme
+	}
 
-    private func updateThemeOption(_ option: Theme) {
-        mainUseCase.saveValue(key: UserDefaults.GenericKey.displayTheme.rawValue, value: option.rawValue)
-        UIApplication.shared.currentKeyWindow?.overrideUserInterfaceStyle = option.interfaceStyle
-    }
+	private func updateThemeOption(_ option: Theme) {
+		mainUseCase.saveValue(key: UserDefaults.GenericKey.displayTheme.rawValue, value: option.rawValue)
+		UIApplication.shared.currentKeyWindow?.overrideUserInterfaceStyle = option.interfaceStyle
+	}
 
-    private func getThemeOption() -> Theme {
-        guard let persistedValue: String = mainUseCase.getValue(key: UserDefaults.GenericKey.displayTheme.rawValue) else {
-            return .system
-        }
-        return Theme(rawValue: persistedValue) ?? .system
-    }
+	private func getThemeOption() -> Theme {
+		guard let persistedValue: String = mainUseCase.getValue(key: UserDefaults.GenericKey.displayTheme.rawValue) else {
+			return .system
+		}
+		return Theme(rawValue: persistedValue) ?? .system
+	}
 
 	private func getCurrentActiveTheme() -> Theme? {
 		let interfaceStyle = UIScreen.main.traitCollection.userInterfaceStyle
@@ -227,21 +236,21 @@ class MainScreenViewModel: ObservableObject {
 		return activeTheme
 	}
 
-    // MARK: Wallet warning timestamp
+	// MARK: Wallet warning timestamp
 
-    func hideWalletWarning() {
-        mainUseCase.saveValue(key: UserDefaults.GenericKey.hideWalletTimestamp.rawValue, value: Date.now)
-        updateShowWalletWarning()
-    }
+	func hideWalletWarning() {
+		mainUseCase.saveValue(key: UserDefaults.GenericKey.hideWalletTimestamp.rawValue, value: Date.now)
+		updateShowWalletWarning()
+	}
 
-    private func updateShowWalletWarning() {
-        guard let lastTimestamp: Date = mainUseCase.getValue(key: UserDefaults.GenericKey.hideWalletTimestamp.rawValue) else {
-            showWalletWarning = true
-            return
-        }
+	private func updateShowWalletWarning() {
+		guard let lastTimestamp: Date = mainUseCase.getValue(key: UserDefaults.GenericKey.hideWalletTimestamp.rawValue) else {
+			showWalletWarning = true
+			return
+		}
 
-        showWalletWarning = Date.now.timeIntervalSince(lastTimestamp) > showWarningWalletInterval
-    }
+		showWalletWarning = Date.now.timeIntervalSince(lastTimestamp) > showWarningWalletInterval
+	}
 
 	private func updateIsWalletMissing() {
 		Task { @MainActor in
@@ -254,41 +263,78 @@ class MainScreenViewModel: ObservableObject {
 		}
 	}
 
-    // MARK: Firmware update versions
+	// MARK: Firmware update versions
 
-    func firmwareUpdated(for deviceId: String, version: String) {
-        let versionsData: Data = mainUseCase.getValue(key: UserDefaults.GenericKey.firmwareUpdateVersions.rawValue) ?? Data()
-        var versions: [String: FirmwareVersion] = (try? JSONDecoder().decode([String: FirmwareVersion].self, from: versionsData)) ?? [:]
-        versions[deviceId] = FirmwareVersion(installDate: Date.now, version: version)
+	func firmwareUpdated(for deviceId: String, version: String) {
+		let versionsData: Data = mainUseCase.getValue(key: UserDefaults.GenericKey.firmwareUpdateVersions.rawValue) ?? Data()
+		var versions: [String: FirmwareVersion] = (try? JSONDecoder().decode([String: FirmwareVersion].self, from: versionsData)) ?? [:]
+		versions[deviceId] = FirmwareVersion(installDate: Date.now, version: version)
 
-        if let data = try? JSONEncoder().encode(versions) {
-            mainUseCase.saveValue(key: UserDefaults.GenericKey.firmwareUpdateVersions.rawValue, value: data)
-        }
-    }
+		if let data = try? JSONEncoder().encode(versions) {
+			mainUseCase.saveValue(key: UserDefaults.GenericKey.firmwareUpdateVersions.rawValue, value: data)
+		}
+	}
 
-    func getInstalledFirmwareVersion(for deviceId: String) -> FirmwareVersion? {
-        let versionsData: Data = mainUseCase.getValue(key: UserDefaults.GenericKey.firmwareUpdateVersions.rawValue) ?? Data()
-        let versions: [String: FirmwareVersion]? = (try? JSONDecoder().decode([String: FirmwareVersion].self, from: versionsData))
+	func getInstalledFirmwareVersion(for deviceId: String) -> FirmwareVersion? {
+		let versionsData: Data = mainUseCase.getValue(key: UserDefaults.GenericKey.firmwareUpdateVersions.rawValue) ?? Data()
+		let versions: [String: FirmwareVersion]? = (try? JSONDecoder().decode([String: FirmwareVersion].self, from: versionsData))
 
-        return versions?[deviceId]
-    }
+		return versions?[deviceId]
+	}
 
-    // MARK: Analytics opt in/out
+	// MARK: Analytics opt in/out
 
-    private func checkIfShouldShowAnalyticsPrompt(settingsUseCase: SettingsUseCase) {
-        guard isUserLoggedIn else {
-            return
-        }
+	private func checkIfShouldShowAnalyticsPrompt(settingsUseCase: SettingsUseCase) {
+		guard isUserLoggedIn else {
+			return
+		}
 
-        showAnalyticsPrompt = !settingsUseCase.isAnalyticsOptSet
-    }
+		showAnalyticsPrompt = !settingsUseCase.isAnalyticsOptSet
+	}
 
-    private func cleanupAnalyticsUserIdIfNeeded() {
-        guard isUserLoggedIn else {
-            return
-        }
-        WXMAnalytics.shared.setUserId(nil)
-    }
+	private func cleanupAnalyticsUserIdIfNeeded() {
+		guard isUserLoggedIn else {
+			return
+		}
+		WXMAnalytics.shared.setUserId(nil)
+	}
 
-	// MARK: - App Update
+	private func checkIfShouldShowTerms() {
+		let termsAccepted = mainUseCase.areTermsOfUseAccepted()
+		guard !termsAccepted, isUserLoggedIn else {
+			return
+		}
+
+		DispatchQueue.main.async {
+			self.showTermsPrompt = true
+		}
+	}
+
+	private func getTermsAlertConfiguration() -> WXMAlertConfiguration {
+		let terms = LocalizableString.Settings.termsOfUse.localized
+		let termsUrl = LocalizableString.url(terms,
+											 DisplayedLinks.termsOfUse.linkURL).localized
+
+		let privacy = LocalizableString.Settings.privacyPolicy.localized
+		let privacyUrl = LocalizableString.url(privacy,
+											   DisplayedLinks.privacyPolicy.linkURL).localized
+
+		var str = LocalizableString.termsAlertDescription(termsUrl, privacyUrl).localized.attributedMarkdown!
+
+		if let termsRange = str.range(of: terms) {
+			str[termsRange].underlineStyle = .single
+		}
+
+		if let privacyRange = str.range(of: privacy) {
+			str[privacyRange].underlineStyle = .single
+		}
+
+		return WXMAlertConfiguration(title: LocalizableString.termsAlertTitle.localized,
+									 text: str,
+									 canDismiss: false,
+									 primaryButtons: [.init(title: LocalizableString.iUnderstand.localized,
+															action: { [weak self] in
+			self?.showTermsPrompt = false
+		})])
+	}
 }

--- a/PresentationLayer/UIComponents/Screens/Settings/SettingsEnum.swift
+++ b/PresentationLayer/UIComponents/Screens/Settings/SettingsEnum.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 enum SettingsEnum {
 	case units, account, display, theme, temperature, precipitation, windSpeed, windDirection, pressure, notifications, announcements, analytics, logout, changePassword,
-		 help, about, appVersion(installationId: String?), documentation, contactSupport, deleteAccount, deleteAccountCaption, deleteAccountWarning,
+		 help, legal, termsOfUse, privacyPolicy, about, appVersion(installationId: String?), documentation, contactSupport, deleteAccount, deleteAccountCaption, deleteAccountWarning,
 		 deleteAccountGeneralInfo, deleteAccountMoreInfoLink, toDeleteTitle, toDeleteName, toDeleteAddress, toDeletePersonalData,
 		 notDeleteTitle, notDeleteWeatherData, notDeleteRewards, noCollectDataTitle, contactForSupport, feedback, joinUserPanel
 
@@ -26,6 +26,8 @@ enum SettingsEnum {
 				return LocalizableString.display.localized
 			case .about:
 				return LocalizableString.about.localized
+			case .legal:
+				return LocalizableString.legal.localized
 			case .feedback:
 				return LocalizableString.feedback.localized
 			default:
@@ -67,6 +69,10 @@ enum SettingsEnum {
 				return LocalizableString.appVersion.localized
 			case .joinUserPanel:
 				return LocalizableString.Settings.joinUserPanelTitle.localized
+			case .termsOfUse:
+				return LocalizableString.Settings.termsOfUse.localized
+			case .privacyPolicy:
+				return LocalizableString.Settings.privacyPolicy.localized
 			default:
 				return ""
 		}
@@ -97,6 +103,10 @@ enum SettingsEnum {
 				return LocalizableString.Settings.announcementsDescription.localized
 			case .joinUserPanel:
 				return LocalizableString.Settings.joinUserPanelDescription.localized
+			case .termsOfUse:
+				return LocalizableString.Settings.termsOfUseDescription.localized
+			case .privacyPolicy:
+				return LocalizableString.Settings.privacyPolicyDescription.localized
 			default:
 				return ""
 		}

--- a/PresentationLayer/UIComponents/Screens/Settings/SettingsView.swift
+++ b/PresentationLayer/UIComponents/Screens/Settings/SettingsView.swift
@@ -42,7 +42,6 @@ struct SettingsView: View {
 				helpContainer
 				WXMDivider()
 				legalContainer
-				WXMDivider()
 				aboutContainer
 				WXMDivider()
 				Spacer()
@@ -327,6 +326,8 @@ private extension SettingsView {
 					settingsViewModel.handlePrivacyPolicyTap()
 				}
 			)
+
+			WXMDivider()
 		}
 	}
 

--- a/PresentationLayer/UIComponents/Screens/Settings/SettingsView.swift
+++ b/PresentationLayer/UIComponents/Screens/Settings/SettingsView.swift
@@ -41,6 +41,8 @@ struct SettingsView: View {
 				feedbackContainer
 				helpContainer
 				WXMDivider()
+				legalContainer
+				WXMDivider()
 				aboutContainer
 				WXMDivider()
 				Spacer()
@@ -304,6 +306,27 @@ private extension SettingsView {
 			}
         )
     }
+
+	@ViewBuilder
+	var legalContainer: some View {
+		SettingsSectionTitle(title: .legal)
+
+		SettingsButtonView(
+			settingsCase: .termsOfUse,
+			settingCaption: SettingsEnum.termsOfUse.settingsDescription,
+			action: {
+				settingsViewModel.handleTermsOfUseTap()
+			}
+		)
+
+		SettingsButtonView(
+			settingsCase: .privacyPolicy,
+			settingCaption: SettingsEnum.privacyPolicy.settingsDescription,
+			action: {
+				settingsViewModel.handlePrivacyPolicyTap()
+			}
+		)
+	}
 
     @ViewBuilder
     var aboutContainer: some View {

--- a/PresentationLayer/UIComponents/Screens/Settings/SettingsView.swift
+++ b/PresentationLayer/UIComponents/Screens/Settings/SettingsView.swift
@@ -309,23 +309,25 @@ private extension SettingsView {
 
 	@ViewBuilder
 	var legalContainer: some View {
-		SettingsSectionTitle(title: .legal)
-
-		SettingsButtonView(
-			settingsCase: .termsOfUse,
-			settingCaption: SettingsEnum.termsOfUse.settingsDescription,
-			action: {
-				settingsViewModel.handleTermsOfUseTap()
-			}
-		)
-
-		SettingsButtonView(
-			settingsCase: .privacyPolicy,
-			settingCaption: SettingsEnum.privacyPolicy.settingsDescription,
-			action: {
-				settingsViewModel.handlePrivacyPolicyTap()
-			}
-		)
+		if mainScreenViewModel.isUserLoggedIn {
+			SettingsSectionTitle(title: .legal)
+			
+			SettingsButtonView(
+				settingsCase: .termsOfUse,
+				settingCaption: SettingsEnum.termsOfUse.settingsDescription,
+				action: {
+					settingsViewModel.handleTermsOfUseTap()
+				}
+			)
+			
+			SettingsButtonView(
+				settingsCase: .privacyPolicy,
+				settingCaption: SettingsEnum.privacyPolicy.settingsDescription,
+				action: {
+					settingsViewModel.handlePrivacyPolicyTap()
+				}
+			)
+		}
 	}
 
     @ViewBuilder

--- a/PresentationLayer/UIComponents/Screens/Settings/SettingsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/Settings/SettingsViewModel.swift
@@ -195,6 +195,8 @@ final class SettingsViewModel: ObservableObject {
 	}
 
 	func handleTermsOfUseTap() {
+		WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .termsOfUse])
+
 		guard let url = URL(string: DisplayedLinks.termsOfUse.linkURL) else {
 			return
 		}
@@ -203,6 +205,8 @@ final class SettingsViewModel: ObservableObject {
 	}
 
 	func handlePrivacyPolicyTap() {
+		WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .privacyPolicy])
+
 		guard let url = URL(string: DisplayedLinks.privacyPolicy.linkURL) else {
 			return
 		}

--- a/PresentationLayer/UIComponents/Screens/Settings/SettingsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/Settings/SettingsViewModel.swift
@@ -193,6 +193,22 @@ final class SettingsViewModel: ObservableObject {
 
 		Router.shared.showFullScreen(.safariView(url))
 	}
+
+	func handleTermsOfUseTap() {
+		guard let url = URL(string: DisplayedLinks.termsOfUse.linkURL) else {
+			return
+		}
+
+		Router.shared.showFullScreen(.safariView(url))
+	}
+
+	func handlePrivacyPolicyTap() {
+		guard let url = URL(string: DisplayedLinks.privacyPolicy.linkURL) else {
+			return
+		}
+
+		Router.shared.showFullScreen(.safariView(url))
+	}
 }
 
 private extension SettingsViewModel {

--- a/PresentationLayer/UIComponents/ViewModelsFactory.swift
+++ b/PresentationLayer/UIComponents/ViewModelsFactory.swift
@@ -107,7 +107,8 @@ enum ViewModelsFactory {
 
     static func getRegisterViewModel() -> RegisterViewModel {
         let authUseCase = SwinjectHelper.shared.getContainerForSwinject().resolve(AuthUseCase.self)
-        return RegisterViewModel(authUseCase: authUseCase!)
+		let mainUseCase = SwinjectHelper.shared.getContainerForSwinject().resolve(MainUseCase.self)
+		return RegisterViewModel(authUseCase: authUseCase!, mainUseCase: mainUseCase!)
     }
 
     static func getResetPasswordViewModel() -> ResetPasswordViewModel {

--- a/wxm-ios/DomainLayer/DomainLayer/Extensions/UserDefaults+Constants.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Extensions/UserDefaults+Constants.swift
@@ -41,6 +41,7 @@ public extension UserDefaults {
 		case lastAppVersionPrompt = "com.weatherxm.app.UserDefaults.Key.LastAppVersionPrompt"
 		case lastSurveyId = "com.weatherxm.app.UserDefaults.Key.LastSurveyId"
 		case lastInfoBannerId = "com.weatherxm.app.UserDefaults.Key.LastInfoBannerId"
+		case termsOfUseAcceptedTimestamp = "com.weatherxm.app.UserDefaults.Key.TermsOfUseAcceptedTimestamp"
 
         // MARK: - UserDefaultEntry
 

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/MainUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/MainUseCase.swift
@@ -81,6 +81,14 @@ public class MainUseCase: @unchecked Sendable {
 
 		return currentVersion.semVersionCompare(minimumVersion) == .orderedAscending
 	}
+
+	public func setTermsOfUseAccepted() {
+		userDefaultsRepository.saveValue(key: UserDefaults.GenericKey.termsOfUseAcceptedTimestamp.rawValue, value: Date.now)
+	}
+
+	public func areTermsOfUseAccepted() -> Bool {
+		userDefaultsRepository.getValue(for: UserDefaults.GenericKey.termsOfUseAcceptedTimestamp.rawValue) != nil
+	}
 }
 
 private extension MainUseCase {

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/MainUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/MainUseCase.swift
@@ -87,7 +87,8 @@ public class MainUseCase: @unchecked Sendable {
 	}
 
 	public func areTermsOfUseAccepted() -> Bool {
-		userDefaultsRepository.getValue(for: UserDefaults.GenericKey.termsOfUseAcceptedTimestamp.rawValue) != nil
+		let timestamp: Date? = userDefaultsRepository.getValue(for: UserDefaults.GenericKey.termsOfUseAcceptedTimestamp.rawValue)
+		return timestamp != nil
 	}
 }
 

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -4904,10 +4904,10 @@
         }
       }
     },
-    "Key" : {
+    "Key 1" : {
       "extractionState" : "manual"
     },
-    "Key 1" : {
+    "Key 2" : {
       "extractionState" : "manual"
     },
     "last_name" : {
@@ -4928,6 +4928,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Last updated on %@"
+          }
+        }
+      }
+    },
+    "legal" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Legal"
           }
         }
       }
@@ -7458,6 +7469,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Change Password"
+          }
+        }
+      }
+    },
+    "settings_privacy_policy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy Policy"
+          }
+        }
+      }
+    },
+    "settings_privacy_policy_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Read about our privacy standards."
+          }
+        }
+      }
+    },
+    "settings_terms_of_use" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terms of Use"
+          }
+        }
+      }
+    },
+    "settings_terms_of_use_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Read about our terms and conditions."
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -4860,6 +4860,17 @@
         }
       }
     },
+    "i_understand" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I understand"
+          }
+        }
+      }
+    },
     "illuminance" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -8481,6 +8492,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Temperature"
+          }
+        }
+      }
+    },
+    "terms_alert_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We’ve implemented the new %@ and %@ to better serve you and ensure alignment with best practices and applicable laws. By continuing to use the app for the next 30 days, it is considered that you accept the new terms and privacy policy mentioned above.\n\nBy accepting these Terms of Use and Privacy Policy, you agree that they apply to all prior and future interactions with the app."
+          }
+        }
+      }
+    },
+    "terms_alert_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About our legal terms"
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -5922,6 +5922,17 @@
         }
       }
     },
+    "read_terms_and_privacy_policy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I have read and accept the %@ and %@."
+          }
+        }
+      }
+    },
     "rebooting_station" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/LocalizableConstants.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableConstants.swift
@@ -32,6 +32,9 @@ enum LocalizableString: WXMLocalizable {
 	case owned(Int?)
 	case following(Int?)
 	case readTermsAndPrivacyPolicy(String, String)
+	case termsAlertTitle
+	case termsAlertDescription(String, String)
+	case iUnderstand
 	case resetPassword
 	case sendEmail
 	case signInDescription
@@ -196,7 +199,8 @@ enum LocalizableString: WXMLocalizable {
 					.timeZoneDisclaimer(let text):
 				localized = String(format: localized, text)
 			case .url(let text, let link),
-					.readTermsAndPrivacyPolicy(let text, let link):
+					.readTermsAndPrivacyPolicy(let text, let link),
+					.termsAlertDescription(let text, let link):
 				localized = String(format: localized, text, link)
 			case .percentage(let count):
 				localized = String(format: localized, count)
@@ -260,6 +264,12 @@ extension LocalizableString {
 				return "following_format"
 			case .readTermsAndPrivacyPolicy:
 				return "read_terms_and_privacy_policy"
+			case .termsAlertTitle:
+				return "terms_alert_title"
+			case .termsAlertDescription:
+				return "terms_alert_description"
+			case .iUnderstand:
+				return "i_understand"
 			case .resetPassword:
 				return "reset_password"
 			case .sendEmail:

--- a/wxm-ios/Resources/Localizable/LocalizableConstants.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableConstants.swift
@@ -114,6 +114,7 @@ enum LocalizableString: WXMLocalizable {
 	case extreme
 	case display
 	case about
+	case legal
 	case feedback
 	case theme
 	case appVersion
@@ -421,6 +422,8 @@ extension LocalizableString {
 				return "display"
 			case .about:
 				return "about"
+			case .legal:
+				return "legal"
 			case .feedback:
 				return "feedback"
 			case .theme:

--- a/wxm-ios/Resources/Localizable/LocalizableConstants.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableConstants.swift
@@ -31,6 +31,7 @@ enum LocalizableString: WXMLocalizable {
 	case total(Int?)
 	case owned(Int?)
 	case following(Int?)
+	case readTermsAndPrivacyPolicy(String, String)
 	case resetPassword
 	case sendEmail
 	case signInDescription
@@ -194,7 +195,8 @@ enum LocalizableString: WXMLocalizable {
 					.hiddenContentDescription(let text),
 					.timeZoneDisclaimer(let text):
 				localized = String(format: localized, text)
-			case .url(let text, let link):
+			case .url(let text, let link),
+					.readTermsAndPrivacyPolicy(let text, let link):
 				localized = String(format: localized, text, link)
 			case .percentage(let count):
 				localized = String(format: localized, count)
@@ -256,6 +258,8 @@ extension LocalizableString {
 				}
 
 				return "following_format"
+			case .readTermsAndPrivacyPolicy:
+				return "read_terms_and_privacy_policy"
 			case .resetPassword:
 				return "reset_password"
 			case .sendEmail:

--- a/wxm-ios/Resources/Localizable/LocalizableString+Settings.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+Settings.swift
@@ -26,6 +26,10 @@ extension LocalizableString {
 		case notificationAlertDisableDescription
 		case joinUserPanelTitle
 		case joinUserPanelDescription
+		case termsOfUse
+		case termsOfUseDescription
+		case privacyPolicy
+		case privacyPolicyDescription
     }
 }
 
@@ -70,6 +74,14 @@ extension LocalizableString.Settings: WXMLocalizable {
 				return "settings_join_user_panel_title"
 			case .joinUserPanelDescription:
 				return "settings_join_user_panel_description"
+			case .termsOfUse:
+				return "settings_terms_of_use"
+			case .termsOfUseDescription:
+				return "settings_terms_of_use_description"
+			case .privacyPolicy:
+				return "settings_privacy_policy"
+			case .privacyPolicyDescription:
+				return "settings_privacy_policy_description"
 		}
 	}
 }

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
@@ -103,6 +103,10 @@ extension ParameterValue: RawRepresentable {
 				return "Change Password"
 			case .announcements:
 				return "Announcements"
+			case .termsOfUse:
+				return "Terms of Use"
+			case .privacyPolicy:
+				return "Privacy Policy"
 			case .login:
 				return "Login"
 			case .email:

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
@@ -127,6 +127,8 @@ public enum ParameterValue {
 	case change
 	case changePassword
 	case announcements
+	case termsOfUse
+	case privacyPolicy
 	case heliumBLEPopupError
 	case heliumBLEPopup
 	case searchLocation


### PR DESCRIPTION
## **Why?**
Show terms of user prompt for logged in users and terms toggle in the Register screen. 
Added a new section in the settings screen 
### **How?**
- Declared new User Defaults entry to store the "accept terms" timestamp (`com.weatherxm.app.UserDefaults.Key.TermsOfUseAcceptedTimestamp`)
- Added toggle to accept terms in `RegisterView`. Once the signup is successful, we store the timestamp in User defaults
- A custom alert is shown for logged in users and blocks the UI until the user accepts the terms
### **Testing**
- Ensure the new section in settings works as expected 
- Ensure the prompt is presented as expected
- Ensure the flow with a new registraion works as expected 
Delete the app and install it again to clear the stored in UD value
### **Additional context**
Closes fe-1556, fe-1557, fe-1569


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added Terms of Use and Privacy Policy sections in app settings.
	- Introduced user acknowledgement for terms and conditions during registration.
	- Enhanced legal information accessibility with a new legal settings section.
	- New alert for terms prompt displayed when applicable.
	- Added functionality to track acceptance timestamps for Terms of Use.

- **User Experience**
	- Added ability to view Terms of Use and Privacy Policy documents.
	- Improved registration flow with terms acceptance toggle.
	- Enhanced alert configuration for external links.
	- Adjusted layout of registration and settings screens for better organization.

- **Localization**
	- Added new localization strings for legal documents and terms.
	- Expanded support for legal document descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->