### PR TITLE
Helium migration

### DIFF
--- a/PresentationLayer/Extensions/DomainExtensions/Common/NetworkErrorResponse+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/Common/NetworkErrorResponse+.swift
@@ -18,8 +18,8 @@ extension NetworkErrorResponse {
 #if MAIN_APP
 		@MainActor
 		func defaultFailObject(type: SuccessFailEnum,
-										  failMode: FailView.Mode = .default,
-										  retryAction: VoidCallback?) -> FailSuccessStateObject {
+							   failMode: FailView.Mode = .default,
+							   retryAction: VoidCallback?) -> FailSuccessStateObject {
 			let obj = FailSuccessStateObject(type: type,
 											 failMode: failMode,
 											 title: title,

--- a/PresentationLayer/UIComponents/Screens/ChangeFrequency/ChangeFrequencyView.swift
+++ b/PresentationLayer/UIComponents/Screens/ChangeFrequency/ChangeFrequencyView.swift
@@ -73,7 +73,7 @@ struct ChangeFrequencyView_Set_Previews: PreviewProvider {
 		device.bundle = .mock(name: .h1)
 
         return NavigationContainerView {
-            ChangeFrequencyView(viewModel: ChangeFrequencyViewModel(device: device, useCase: nil))
+			ChangeFrequencyView(viewModel: ViewModelsFactory.getChangeFrequencyViewModel(device: device))
         }
     }
 }
@@ -82,7 +82,7 @@ struct ChangeFrequencyView_Change_Previews: PreviewProvider {
     static var previews: some View {
         var device = DeviceDetails.emptyDeviceDetails
 		device.bundle = .mock(name: .h1)
-        let vm = ChangeFrequencyViewModel(device: device, useCase: nil)
+        let vm = ViewModelsFactory.getChangeFrequencyViewModel(device: device)
         vm.state = .changeFrequency
         return NavigationContainerView {
             ChangeFrequencyView(viewModel: vm)
@@ -94,7 +94,7 @@ struct ChangeFrequencyView_Fail_Previews: PreviewProvider {
     static var previews: some View {
         var device = DeviceDetails.emptyDeviceDetails
 		device.bundle = .mock(name: .h1)
-        let vm = ChangeFrequencyViewModel(device: device, useCase: nil)
+        let vm = ViewModelsFactory.getChangeFrequencyViewModel(device: device)
         vm.state = .failed(.mockErrorObj)
         return NavigationContainerView {
             ChangeFrequencyView(viewModel: vm)
@@ -106,7 +106,7 @@ struct ChangeFrequencyView_Success_Previews: PreviewProvider {
     static var previews: some View {
         var device = DeviceDetails.emptyDeviceDetails
 		device.bundle = .mock(name: .h1)
-        let vm = ChangeFrequencyViewModel(device: device, useCase: nil)
+        let vm = ViewModelsFactory.getChangeFrequencyViewModel(device: device)
         vm.state = .success(.mockSuccessObj)
         return NavigationContainerView {
             ChangeFrequencyView(viewModel: vm)

--- a/PresentationLayer/UIComponents/Screens/ChangeFrequency/ChangeFrequencyView.swift
+++ b/PresentationLayer/UIComponents/Screens/ChangeFrequency/ChangeFrequencyView.swift
@@ -19,38 +19,51 @@ struct ChangeFrequencyView: View {
         ZStack {
             Color(colorEnum: .top)
                 .ignoresSafeArea()
+			GeometryReader { _ in
+				VStack {
+					if viewModel.state == .setFrequency {
+						VStack(spacing: 0.0) {
+							SelectFrequencyView(selectedFrequency: $viewModel.selectedFrequency,
+												isFrequencyAcknowledged: $viewModel.isFrequencyAcknowledged)
 
-            VStack {
-                if viewModel.state == .setFrequency {
-                    VStack(spacing: 0.0) {
-                        SelectFrequencyView(selectedFrequency: $viewModel.selectedFrequency,
-                                            isFrequencyAcknowledged: $viewModel.isFrequencyAcknowledged)
+							HStack(spacing: CGFloat(.mediumSpacing)) {
+								Button {
+									viewModel.cancelButtonTapped()
+								} label: {
+									Text(LocalizableString.cancel.localized)
+								}
+								.buttonStyle(WXMButtonStyle())
 
-                        HStack(spacing: CGFloat(.mediumSpacing)) {
-                            Button {
-                                viewModel.cancelButtonTapped()
-                            } label: {
-                                Text(LocalizableString.cancel.localized)
-                            }
-                            .buttonStyle(WXMButtonStyle())
+								Button {
+									viewModel.changeButtonTapped()
+								} label: {
+									Text(LocalizableString.change.localized)
+								}
+								.buttonStyle(WXMButtonStyle.filled())
+								.disabled(!viewModel.isFrequencyAcknowledged)
+							}
+						}
+					} else {
+						VStack {
+							Spacer()
 
-                            Button {
-                                viewModel.changeButtonTapped()
-                            } label: {
-                                Text(LocalizableString.change.localized)
-                            }
-                            .buttonStyle(WXMButtonStyle.filled())
-                            .disabled(!viewModel.isFrequencyAcknowledged)
-                        }
-                    }
-                } else {
-                    DeviceUpdatesLoadingView(title: LocalizableString.changingFrequency.localized,
-                                             subtitle: nil,
-                                             steps: viewModel.steps,
-                                             currentStepIndex: $viewModel.currentStepIndex,
-                                             progress: .constant(nil))
-                }
-            }
+							HStack {
+								Spacer()
+
+								DeviceUpdatesLoadingView(title: LocalizableString.changingFrequency.localized,
+														 subtitle: nil,
+														 steps: viewModel.steps,
+														 currentStepIndex: $viewModel.currentStepIndex,
+														 progress: .constant(nil))
+
+								Spacer()
+							}
+
+							Spacer()
+						}
+					}
+				}
+			}
             .fail(show: Binding(get: { viewModel.state.isFailed }, set: { _ in }), obj: viewModel.state.stateObject)
             .success(show: Binding(get: { viewModel.state.isSuccess }, set: { _ in }), obj: viewModel.state.stateObject)
             .animation(.easeIn, value: viewModel.state)

--- a/PresentationLayer/UIComponents/Screens/ChangeFrequency/ChangeFrequencyViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ChangeFrequency/ChangeFrequencyViewModel.swift
@@ -149,6 +149,10 @@ private extension ChangeFrequencyViewModel {
 		Task { @MainActor [weak self] in
 			do {
 				if let apiError = try await self?.meUseCase?.setFrequncy(serialNumber, frequency: frequency) {
+					let uiInfo = apiError.uiInfo
+					let obj = uiInfo.defaultFailObject(type: .changeFrequency,
+													   retryAction: { [weak self] in self?.dismissToggle.toggle() })
+					self?.state = .failed(obj)
 					return
 				}
 			} catch {

--- a/PresentationLayer/UIComponents/Screens/ChangeFrequency/ChangeFrequencyViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ChangeFrequency/ChangeFrequencyViewModel.swift
@@ -141,8 +141,8 @@ private extension ChangeFrequencyViewModel {
     }
 
 	func upateApiFrequency(frequency: Frequency) {
-		guard let serialNumber = device.label else {
-			
+		guard let serialNumber = device.label?.replacingOccurrences(of: ":", with: "") else {
+
 			return
 		}
 

--- a/PresentationLayer/UIComponents/Screens/ChangeFrequency/ChangeFrequencyViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ChangeFrequency/ChangeFrequencyViewModel.swift
@@ -133,14 +133,14 @@ private extension ChangeFrequencyViewModel {
                     case .failed(let error):
                         self?.handleFrequencyError(error)
                     case .finished:
-						self?.upateApiFrequency(frequency: selectedFrequency)
+						self?.updateApiFrequency(frequency: selectedFrequency)
                 }
                 self?.updateSteps()
             }
         }.store(in: &cancellables)
     }
 
-	func upateApiFrequency(frequency: Frequency) {
+	func updateApiFrequency(frequency: Frequency) {
 		guard let serialNumber = device.label?.replacingOccurrences(of: ":", with: "") else {
 
 			return
@@ -148,7 +148,7 @@ private extension ChangeFrequencyViewModel {
 
 		Task { @MainActor [weak self] in
 			do {
-				if let apiError = try await self?.meUseCase?.setFrequncy(serialNumber, frequency: frequency) {
+				if let apiError = try await self?.meUseCase?.setFrequency(serialNumber, frequency: frequency) {
 					let uiInfo = apiError.uiInfo
 					let obj = uiInfo.defaultFailObject(type: .changeFrequency,
 													   retryAction: { [weak self] in self?.dismissToggle.toggle() })
@@ -156,6 +156,12 @@ private extension ChangeFrequencyViewModel {
 					return
 				}
 			} catch {
+				let uiInfo = NetworkErrorResponse.UIInfo(title: LocalizableString.Error.genericMessage.localized,
+														 description: nil)
+				let obj = uiInfo.defaultFailObject(type: .changeFrequency,
+												   retryAction: { [weak self] in self?.dismissToggle.toggle() })
+				self?.state = .failed(obj)
+
 				return
 			}
 

--- a/PresentationLayer/UIComponents/Screens/ChangeFrequency/ChangeFrequencyViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ChangeFrequency/ChangeFrequencyViewModel.swift
@@ -142,7 +142,7 @@ private extension ChangeFrequencyViewModel {
 
 	func updateApiFrequency(frequency: Frequency) {
 		guard let serialNumber = device.label?.replacingOccurrences(of: ":", with: "") else {
-
+			self.showGenericError()
 			return
 		}
 
@@ -156,11 +156,7 @@ private extension ChangeFrequencyViewModel {
 					return
 				}
 			} catch {
-				let uiInfo = NetworkErrorResponse.UIInfo(title: LocalizableString.Error.genericMessage.localized,
-														 description: nil)
-				let obj = uiInfo.defaultFailObject(type: .changeFrequency,
-												   retryAction: { [weak self] in self?.dismissToggle.toggle() })
-				self?.state = .failed(obj)
+				self?.showGenericError()
 
 				return
 			}
@@ -190,6 +186,14 @@ private extension ChangeFrequencyViewModel {
             steps[index].setCompleted(index < currentStepIndex)
         }
     }
+
+	func showGenericError() {
+		let uiInfo = NetworkErrorResponse.UIInfo(title: LocalizableString.Error.genericMessage.localized,
+												 description: nil)
+		let obj = uiInfo.defaultFailObject(type: .changeFrequency,
+										   retryAction: { [weak self] in self?.dismissToggle.toggle() })
+		state = .failed(obj)
+	}
 
     func handleFrequencyError(_ error: ChangeFrequencyError) {
 		guard let failTuple = getFailDecsriptionAndAction(error: error) else {

--- a/PresentationLayer/UIComponents/Screens/ChangeFrequency/ChangeFrequencyViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ChangeFrequency/ChangeFrequencyViewModel.swift
@@ -22,12 +22,17 @@ class ChangeFrequencyViewModel: ObservableObject {
 	private let mainVM: MainScreenViewModel = .shared
 
     private let useCase: DeviceInfoUseCase?
+	private let meUseCase: MeUseCase?
     let device: DeviceDetails
     private var cancellables: Set<AnyCancellable> = []
 
-    init(device: DeviceDetails, useCase: DeviceInfoUseCase?, frequency: Frequency? = Frequency.allCases.first) {
+    init(device: DeviceDetails,
+		 useCase: DeviceInfoUseCase?,
+		 meUseCase: MeUseCase?,
+		 frequency: Frequency? = Frequency.allCases.first) {
         self.device = device
         self.useCase = useCase
+		self.meUseCase = meUseCase
         self.selectedFrequency = frequency
     }
 
@@ -128,22 +133,40 @@ private extension ChangeFrequencyViewModel {
                     case .failed(let error):
                         self?.handleFrequencyError(error)
                     case .finished:
-						let subtitle = LocalizableString.DeviceInfo.stationFrequencyChangedDescription(selectedFrequency.rawValue).localized
-                        let obj = FailSuccessStateObject(type: .changeFrequency,
-														 title: LocalizableString.DeviceInfo.stationFrequencyChanged.localized,
-                                                         subtitle: subtitle.attributedMarkdown,
-                                                         cancelTitle: nil,
-														 retryTitle: LocalizableString.DeviceInfo.stationBackToSettings.localized,
-                                                         contactSupportAction: nil,
-                                                         cancelAction: nil,
-                                                         retryAction: { [weak self] in self?.dismissToggle.toggle() })
-                        self?.state = .success(obj)
-
+						self?.upateApiFrequency(frequency: selectedFrequency)
                 }
                 self?.updateSteps()
             }
         }.store(in: &cancellables)
     }
+
+	func upateApiFrequency(frequency: Frequency) {
+		guard let serialNumber = device.label else {
+			
+			return
+		}
+
+		Task { @MainActor [weak self] in
+			do {
+				if let apiError = try await self?.meUseCase?.setFrequncy(serialNumber, frequency: frequency) {
+					return
+				}
+			} catch {
+				return
+			}
+
+			let subtitle = LocalizableString.DeviceInfo.stationFrequencyChangedDescription(frequency.rawValue).localized
+			let obj = FailSuccessStateObject(type: .changeFrequency,
+											 title: LocalizableString.DeviceInfo.stationFrequencyChanged.localized,
+											 subtitle: subtitle.attributedMarkdown,
+											 cancelTitle: nil,
+											 retryTitle: LocalizableString.DeviceInfo.stationBackToSettings.localized,
+											 contactSupportAction: nil,
+											 cancelAction: nil,
+											 retryAction: { [weak self] in self?.dismissToggle.toggle() })
+			self?.state = .success(obj)
+		}
+	}
 
     func updateSteps() {
         guard let currentStepIndex else {

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimHeliumContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimHeliumContainerViewModel.swift
@@ -107,14 +107,25 @@ private extension ClaimHeliumContainerViewModel {
 				return
 			}
 
-			if let apiFrequencyError = await self.setApiHeliumFrequency() {
-				let uiInfo = apiFrequencyError.uiInfo
+			do {
+				if let apiFrequencyError = try await self.setApiHeliumFrequency() {
+					let uiInfo = apiFrequencyError.uiInfo
+					let failObj = uiInfo.defaultFailObject(type: .claimDeviceFlow, failMode: .default) { [weak self] in
+						self?.showLoading = false
+					}
+					loadingState = .fail(failObj)
+					return
+				}
+			} catch {
+				let uiInfo = NetworkErrorResponse.UIInfo(title: LocalizableString.Error.genericMessage.localized,
+														 description: nil)
 				let failObj = uiInfo.defaultFailObject(type: .claimDeviceFlow, failMode: .default) { [weak self] in
 					self?.showLoading = false
 				}
 				loadingState = .fail(failObj)
 				return
 			}
+
 
 			steps[0].isCompleted = true
 
@@ -157,12 +168,12 @@ private extension ClaimHeliumContainerViewModel {
 		return error
 	}
 
-	func setApiHeliumFrequency() async -> NetworkErrorResponse? {
+	func setApiHeliumFrequency() async throws -> NetworkErrorResponse? {
 		guard let heliumFrequency, let serialNumber = serialNumber?.replacingOccurrences(of: ":", with: "") else {
-			return nil
+			throw NSError(domain: "", code: -1)
 		}
 
-		let error = try? await useCase.setFrequncy(serialNumber, frequency: heliumFrequency)
+		let error = try? await useCase.setFrequency(serialNumber, frequency: heliumFrequency)
 		return error
 	}
 

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimHeliumContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimHeliumContainerViewModel.swift
@@ -91,6 +91,15 @@ private extension ClaimHeliumContainerViewModel {
 				return
 			}
 
+			if let apiFrequencyError = await self.setApiHeliumFrequency() {
+				let uiInfo = apiFrequencyError.uiInfo
+				let failObj = uiInfo.defaultFailObject(type: .claimDeviceFlow, failMode: .retry) { [weak self] in
+					self?.showLoading = false
+				}
+				loadingState = .fail(failObj)
+				return
+			}
+
 			steps[0].isCompleted = true
 
 			// Reboot
@@ -143,6 +152,15 @@ private extension ClaimHeliumContainerViewModel {
 		}
 
 		let error = await devicesUseCase.setHeliumFrequency(btDevice, frequency: heliumFrequency)
+		return error
+	}
+
+	func setApiHeliumFrequency() async -> NetworkErrorResponse? {
+		guard let heliumFrequency, let serialNumber else {
+			return nil
+		}
+
+		let error = try? await useCase.setFrequncy(serialNumber, frequency: heliumFrequency)
 		return error
 	}
 

--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel.swift
@@ -89,7 +89,7 @@ class DeviceInfoViewModel: ObservableObject {
     }
     @Published var showChangeFrequency = false
     var changeFrequencyViewModel: ChangeFrequencyViewModel {
-        ChangeFrequencyViewModel(device: device, useCase: deviceInfoUseCase)
+		ViewModelsFactory.getChangeFrequencyViewModel(device: device)
     }
 
     @Published var showAccountConfirmation = false

--- a/PresentationLayer/UIComponents/ViewModelsFactory.swift
+++ b/PresentationLayer/UIComponents/ViewModelsFactory.swift
@@ -257,13 +257,13 @@ enum ViewModelsFactory {
 		return ClaimDeviceSetFrequencyViewModel(completion: completion)
 	}
 
-	static func getChangeFrequencyViewModel(device: DeviceDetails, frequncy: Frequency? = Frequency.allCases.first) -> ChangeFrequencyViewModel {
+	static func getChangeFrequencyViewModel(device: DeviceDetails, frequency: Frequency? = Frequency.allCases.first) -> ChangeFrequencyViewModel {
 		let deviceInfoUseCase = SwinjectHelper.shared.getContainerForSwinject().resolve(DeviceInfoUseCase.self)!
 		let meUseCase = SwinjectHelper.shared.getContainerForSwinject().resolve(MeUseCase.self)!
 		return ChangeFrequencyViewModel(device: device,
 										useCase: deviceInfoUseCase,
 										meUseCase: meUseCase,
-										frequency: frequncy)
+										frequency: frequency)
 	}
 
 	static func getRewardAnalyticsViewModel(devices: [DeviceDetails]) -> RewardAnalyticsViewModel {

--- a/PresentationLayer/UIComponents/ViewModelsFactory.swift
+++ b/PresentationLayer/UIComponents/ViewModelsFactory.swift
@@ -257,6 +257,15 @@ enum ViewModelsFactory {
 		return ClaimDeviceSetFrequencyViewModel(completion: completion)
 	}
 
+	static func getChangeFrequencyViewModel(device: DeviceDetails, frequncy: Frequency? = Frequency.allCases.first) -> ChangeFrequencyViewModel {
+		let deviceInfoUseCase = SwinjectHelper.shared.getContainerForSwinject().resolve(DeviceInfoUseCase.self)!
+		let meUseCase = SwinjectHelper.shared.getContainerForSwinject().resolve(MeUseCase.self)!
+		return ChangeFrequencyViewModel(device: device,
+										useCase: deviceInfoUseCase,
+										meUseCase: meUseCase,
+										frequency: frequncy)
+	}
+
 	static func getRewardAnalyticsViewModel(devices: [DeviceDetails]) -> RewardAnalyticsViewModel {
 		let useCase = SwinjectHelper.shared.getContainerForSwinject().resolve(MeUseCase.self)!
 		return RewardAnalyticsViewModel(useCase: useCase, devices: devices)

--- a/wxm-ios/DataLayer/DataLayer/Networking/ApiRequestBuilders/MeApiRequestBuilder.swift
+++ b/wxm-ios/DataLayer/DataLayer/Networking/ApiRequestBuilders/MeApiRequestBuilder.swift
@@ -41,6 +41,7 @@ enum MeApiRequestBuilder: URLRequestConvertible {
 	case getDevices
 	case claimDevice(claimDeviceBody: ClaimDeviceBody)
 	case disclaimDevice(serialNumber: String)
+	case setDeviceFrequency(serialNumber: String, frequency: String)
 	case getFirmwares(testSearch: String)
 	case getUserDeviceById(deviceId: String)
 	case getUserDeviceInfoById(deviceId: String)
@@ -66,7 +67,7 @@ enum MeApiRequestBuilder: URLRequestConvertible {
 					.getUserDeviceHistoryById, .getUserDeviceForecastById, .getUserDeviceRewards, 
 					.getUserDevicesRewards, .getDeviceFirmwareById, .getUserDeviceInfoById:
 				return .get
-			case .saveUserWallet, .claimDevice, .setFriendlyName, .disclaimDevice, .follow, .setDeviceLocation, .setFCMToken:
+			case .saveUserWallet, .claimDevice, .setDeviceFrequency, .setFriendlyName, .disclaimDevice, .follow, .setDeviceLocation, .setFCMToken:
 				return .post
 			case .deleteAccount, .deleteFriendlyName, .unfollow:
 				return .delete
@@ -99,6 +100,8 @@ enum MeApiRequestBuilder: URLRequestConvertible {
 				return "me/devices"
 			case .claimDevice:
 				return "me/devices/claim"
+			case .setDeviceFrequency:
+				return "me/devices/frequency"
 			case .disclaimDevice:
 				return "me/devices/disclaim"
 			case .getFirmwares:
@@ -141,6 +144,9 @@ enum MeApiRequestBuilder: URLRequestConvertible {
 				return [ParameterConstants.Me.address: address]
 			case let .claimDevice(claimDeviceBody):
 				return claimDeviceBody.dictionaryRepresentation
+			case let .setDeviceFrequency(serialNumber, frequency):
+				return [ParameterConstants.Me.serialNumber: serialNumber,
+						ParameterConstants.Me.freq: frequency]
 			case let .disclaimDevice(serialNumber):
 				return [ParameterConstants.Me.serialNumber: serialNumber]
 			case let .getFirmwares(testSearch):

--- a/wxm-ios/DataLayer/DataLayer/Networking/Constants/ParameterConstants.swift
+++ b/wxm-ios/DataLayer/DataLayer/Networking/Constants/ParameterConstants.swift
@@ -22,6 +22,7 @@ struct ParameterConstants {
     enum Me {
         static let address = "address"
         static let serialNumber = "serialNumber"
+		static let freq = "freq"
         static let location = "location"
         static let testSearch = "testSearch"
         static let deviceId = "deviceId"

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/DeviceInfoRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/DeviceInfoRepositoryImpl.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@preconcurrency import DomainLayer
+import DomainLayer
 @preconcurrency import Combine
 import Alamofire
 
@@ -62,15 +62,16 @@ extension DeviceInfoRepositoryImpl {
 
 	public func changeFrequency(device: DeviceDetails, frequency: Frequency) -> AnyPublisher<ChangeFrequencyState, Never> {
 		let valueSubject = CurrentValueSubject<ChangeFrequencyState, Never>(.connect)
-		Task {
+
+		Task { @MainActor [weak self, valueSubject] in
 			valueSubject.send(.connect)
-			if let error = await bluetoothWrapper.connect(device: device) {
+			if let error = await self?.bluetoothWrapper.connect(device: device) {
 				valueSubject.send(.failed(error.toChangeFrequencyError))
 				return
 			}
 
 			valueSubject.send(.changing)
-			if let error = await bluetoothWrapper.setFrequency(device: device, frequency: frequency) {
+			if let error = await self?.bluetoothWrapper.setFrequency(device: device, frequency: frequency) {
 				valueSubject.send(.failed(error.toChangeFrequencyError))
 				return
 			}

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/MeRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/MeRepositoryImpl.swift
@@ -63,6 +63,13 @@ public struct MeRepositoryImpl: MeRepository {
         try userDevicesService.claimDevice(claimDeviceBody: claimDeviceBody)
     }
 
+	public func setFrequency(serialNumber: String, frequency: String) throws -> AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never> {
+		let builder = MeApiRequestBuilder.setDeviceFrequency(serialNumber: serialNumber, frequency: frequency)
+		let urlRequest = try builder.asURLRequest()
+
+		return ApiClient.shared.requestCodableAuthorized(urlRequest, mockFileName: builder.mockFileName)
+	}
+
     public func getFirmwares(testSearch: String) throws -> AnyPublisher<DataResponse<[NetworkFirmwareResponse], NetworkErrorResponse>, Never> {
         let urlRequest = try MeApiRequestBuilder.getFirmwares(testSearch: testSearch).asURLRequest()
         return ApiClient.shared.requestCodableAuthorized(urlRequest)

--- a/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/MeRepository.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/MeRepository.swift
@@ -44,6 +44,7 @@ public protocol MeRepository {
 	func getDevices(useCache: Bool) throws -> AnyPublisher<DataResponse<[NetworkDevicesResponse], NetworkErrorResponse>, Never>
 	func getCachedDevices() -> [NetworkDevicesResponse]?
     func claimDevice(claimDeviceBody: ClaimDeviceBody) throws -> AnyPublisher<DataResponse<NetworkDevicesResponse, NetworkErrorResponse>, Never>
+	func setFrequency(serialNumber: String, frequency: String) throws -> AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never>
     func getFirmwares(testSearch: String) throws -> AnyPublisher<DataResponse<[NetworkFirmwareResponse], NetworkErrorResponse>, Never>
     func getUserDeviceById(deviceId: String) throws -> AnyPublisher<DataResponse<NetworkDevicesResponse, NetworkErrorResponse>, Never>
     func getUserDeviceHourlyHistoryById(deviceId: String,

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/Frequency.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/Frequency.swift
@@ -5,7 +5,7 @@
 //  Created by Manolis Katsifarakis on 26/11/22.
 //
 
-public enum Frequency: String, CaseIterable, Identifiable, Equatable, Codable {
+public enum Frequency: String, CaseIterable, Identifiable, Equatable, Codable, Sendable {
     case EU868
     case US915
     case AU915

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/MeUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/MeUseCase.swift
@@ -55,7 +55,7 @@ public struct MeUseCase: @unchecked Sendable {
         return claimDevice.convertedToDeviceDetailsResultPublisher
     }
 
-	public func setFrequncy(_ serialNumber: String, frequency: Frequency) async throws -> NetworkErrorResponse? {
+	public func setFrequency(_ serialNumber: String, frequency: Frequency) async throws -> NetworkErrorResponse? {
 		let response = try await meRepository.setFrequency(serialNumber: serialNumber, frequency: frequency.rawValue).toAsync()
 		return response.error
 	}

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/MeUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/MeUseCase.swift
@@ -55,6 +55,11 @@ public struct MeUseCase: @unchecked Sendable {
         return claimDevice.convertedToDeviceDetailsResultPublisher
     }
 
+	public func setFrequncy(_ serialNumber: String, frequency: Frequency) async throws -> NetworkErrorResponse? {
+		let response = try await meRepository.setFrequency(serialNumber: serialNumber, frequency: frequency.rawValue).toAsync()
+		return response.error
+	}
+
     public func getFirmwares(testSearch: String) throws -> AnyPublisher<DataResponse<[NetworkFirmwareResponse], NetworkErrorResponse>, Never> {
         let getFirmwares = try meRepository.getFirmwares(testSearch: testSearch)
         return getFirmwares


### PR DESCRIPTION
## **Why?**
Post the selected frequency to our backend in the claim flow and the change frequency screen
### **How?**
- Declared the set frequency endpoint
- Post the selected frequency after it's updated successfully via Bluetooth in the claim flow
- In the change frequency screen, we post the selected frequency, keeping the same logic as the claim flow
### **Testing**
Ensure everything works as expected 
### **Additional context**
fixes fe-1492, fe-1567


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added ability to set device frequency via API.
  - Introduced centralized view model factory for creating change frequency view models.
  - Added new asynchronous method to set frequency in the use case.

- **Improvements**
  - Enhanced error handling for frequency change process.
  - Improved concurrency support for frequency-related operations.
  - Streamlined device claiming workflow.

- **Technical Updates**
  - Updated API request builder to support device frequency setting.
  - Added new repository methods for frequency management.
  - Updated the `Frequency` enum to support concurrency.
  - Added a new constant for frequency parameters.
  - Modified layout and structure of the Change Frequency view for better usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->