### PR TITLE
Photo verification qa

### DIFF
--- a/Configuration/Version.xcconfig
+++ b/Configuration/Version.xcconfig
@@ -1,3 +1,3 @@
 // Don't edit this file.
 // The contents will be replaced from git_version script
-AppVersion = 4.1.1;
+AppVersion = 4.4.1;

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
@@ -172,8 +172,10 @@ extension GalleryView {
 private extension GalleryView {
 	@ViewBuilder
 	var galleryScroller: some View {
-		let normalSize = CGSize(width: 50.0, height: 70.0)
-		let selectedSize = CGSize(width: 62.0, height: 88.0)
+		let normalWidth = 50.0
+		let normalHeight = 70.0
+		let selectedScale: CGFloat = 1.25
+		let selectedSize = CGSize(width: normalWidth * selectedScale, height: normalHeight * selectedScale)
 
 		GeometryReader { proxy in
 			ScrollView(.horizontal) {
@@ -183,19 +185,17 @@ private extension GalleryView {
 					HStack(spacing: CGFloat(.smallSpacing)) {
 						ForEach(viewModel.images) { image in
 							let isSelected = viewModel.selectedImage == image
-							let size = isSelected ? selectedSize : normalSize
 
-							Button {
-								viewModel.selectedImage = image
-							} label: {
+							Group {
 								if let imageUrl = image.remoteUrl {
 									LazyImage(url: URL(string: imageUrl)) { state in
 										if let image = state.image {
 											image
 												.resizable()
 												.aspectRatio(contentMode: .fill)
-												.frame(width: size.width, height: size.height)
+												.frame(width: normalWidth, height: normalHeight)
 												.cornerRadius(CGFloat(.buttonCornerRadius))
+												.contentShape(Rectangle())
 												.indication(show: .constant(isSelected),
 															borderColor: Color(colorEnum: .wxmPrimary),
 															borderWidth: 2.0,
@@ -204,14 +204,15 @@ private extension GalleryView {
 															content: { EmptyView() })
 										} else {
 											ProgressView()
-												.frame(width: normalSize.width, height: normalSize.height)
+												.frame(width: normalWidth, height: normalHeight)
 										}
 									}
 								} else if let imageView = image.image {
 									imageView
 										.resizable()
 										.aspectRatio(contentMode: .fill)
-										.frame(width: size.width, height: size.height)
+										.frame(width: normalWidth, height: normalHeight)
+										.contentShape(Rectangle())
 										.cornerRadius(CGFloat(.buttonCornerRadius))
 										.indication(show: .constant(isSelected),
 													borderColor: Color(colorEnum: .wxmPrimary),
@@ -223,6 +224,12 @@ private extension GalleryView {
 									EmptyView()
 								}
 							}
+							.onTapGesture {
+								viewModel.selectedImage = image
+							}
+							.frame(width: normalWidth, height: normalHeight)
+							.scaleEffect(isSelected ? selectedScale : 1.0)
+							.animation(.easeIn(duration: 0.1), value: viewModel.selectedImage)
 						}
 
 						if viewModel.isPlusButtonVisible {
@@ -232,7 +239,7 @@ private extension GalleryView {
 								Text(FontIcon.plus.rawValue)
 									.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.mediumFontSize)))
 									.foregroundStyle(Color(colorEnum: .wxmPrimary))
-									.frame(width: normalSize.width, height: normalSize.height)
+									.frame(width: normalWidth, height: normalHeight)
 									.background(Color(colorEnum: .layer1))
 									.cornerRadius(CGFloat(.buttonCornerRadius))
 							}
@@ -297,7 +304,8 @@ private extension GalleryView {
 
 #Preview {
 	GalleryView(viewModel: ViewModelsFactory.getGalleryViewModel(deviceId: "",
-																 images: ["https://wxm-station-photos-dev.s3.eu-west-2.amazonaws.com/daring-garnet-gust/81B2CA91-DBC5-45A1-AF33-6FA031604EA2.jpg",
-																		 "https://wxm-station-photos-dev.s3.eu-west-2.amazonaws.com/daring-garnet-gust/ADDF4312-640F-44C7-AFB6-B437C6FBBBC7.jpg"],
+																 images: ["https://i0.wp.com/weatherxm.com/wp-content/uploads/2023/12/Home-header-image-1200-x-1200-px-2.png?w=1200&ssl=1",
+																		 "https://i0.wp.com/weatherxm.com/wp-content/uploads/2024/09/Home-header-image-1200-x-1200-px-15-1.png?w=1200&ssl=1",
+																		 "https://i0.wp.com/weatherxm.com/wp-content/uploads/2024/05/Untitled-design-_41_.webp?w=700&ssl=1"],
 																 isNewVerification: true))
 }

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
@@ -269,12 +269,13 @@ private extension GalleryViewModel {
 	}
 
 	func showExitAlert(message: String, dismissAction: @escaping VoidCallback) {
-		let exitAction: AlertHelper.AlertObject.Action = (LocalizableString.exit.localized, { _ in  dismissAction() })
+		let exitAction: AlertHelper.AlertObject.Action = (LocalizableString.exitAnyway.localized, { _ in  dismissAction() })
+		let verifyAction: AlertHelper.AlertObject.Action = (LocalizableString.PhotoVerification.stayAndVerify.localized, { _ in  })
 		let alertObject = AlertHelper.AlertObject(title: LocalizableString.PhotoVerification.exitPhotoVerification.localized,
 												  message: message,
-												  cancelActionTitle: LocalizableString.back.localized,
-												  cancelAction: {},
-												  okAction: exitAction)
+												  cancelActionTitle: exitAction.title,
+												  cancelAction: { exitAction.action(nil) },
+												  okAction: verifyAction)
 
 		AlertHelper().showAlert(alertObject)
 	}

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroView.swift
@@ -57,7 +57,7 @@ struct PhotoIntroView: View {
 							Spacer()
 						}
 						.padding(.top, CGFloat(.smallSidePadding))
-						.padding(.leading, CGFloat(.largeSidePadding))
+						.padding(.leading, CGFloat(.defaultSidePadding))
 					}
 				}
 				.scrollIndicators(.hidden)

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroView.swift
@@ -225,7 +225,7 @@ private extension PhotoIntroView {
 					let termsTitle = LocalizableString.PhotoVerification.acceptanceUsePolicy.localized
 					let termsLink = DisplayedLinks.acceptanceUsePolicy.linkURL
 					let termsText = Text("**[\(termsTitle)](\(termsLink))**".attributedMarkdown!).underline(color: Color(colorEnum: .wxmPrimary))
-					Text("\(LocalizableString.Wallet.acceptTermsOfService.localized) \(termsText)")
+					Text("\(LocalizableString.Wallet.acceptTermsOfService.localized) \(termsText).")
 						.tint(Color(colorEnum: .wxmPrimary))
 						.foregroundColor(Color(colorEnum: .text))
 						.font(.system(size: CGFloat(.normalFontSize)))

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -30,6 +30,16 @@
         }
       }
     },
+    "%@ %@." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@."
+          }
+        }
+      }
+    },
     "%@:" : {
 
     },
@@ -6321,7 +6331,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Uploaded %d file"
+            "value" : "Uploaded %d photo"
           }
         }
       }
@@ -6332,7 +6342,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Uploaded %d files"
+            "value" : "Uploaded %d photo"
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -6342,7 +6342,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Uploaded %d photo"
+            "value" : "Uploaded %d photos"
           }
         }
       }
@@ -6353,7 +6353,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Upload your photos"
+            "value" : "Upload your photo"
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -4147,6 +4147,17 @@
         }
       }
     },
+    "exit_anyway" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exit anyway"
+          }
+        }
+      }
+    },
     "explorer_list_cell_capacity" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -6061,6 +6072,17 @@
         }
       }
     },
+    "photo_verification_keep_taking_photos" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep taking photos"
+          }
+        }
+      }
+    },
     "photo_verification_lets_take_the_first_photo" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -6244,6 +6266,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Station photos"
+          }
+        }
+      }
+    },
+    "photo_verification_stay_and_verify" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stay & verify"
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/LocalizableConstants.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableConstants.swift
@@ -24,6 +24,7 @@ enum LocalizableString: WXMLocalizable {
 	case done
 	case back
 	case exit
+	case exitAnyway
 	case skip
 	case delete
 	case firstName
@@ -243,6 +244,8 @@ extension LocalizableString {
 				return "back"
 			case .exit:
 				return "exit"
+			case .exitAnyway:
+				return "exit_anyway"
 			case .skip:
 				return "skip"
 			case .delete:

--- a/wxm-ios/Resources/Localizable/LocalizableString+PhotoVerification.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+PhotoVerification.swift
@@ -75,6 +75,7 @@ extension LocalizableString {
 		case deletePhotoAlertMessage
 		case uploadPhotosAlertTitle
 		case uploadPhotosAlertMessage
+		case stayAndVerify
 	}
 }
 
@@ -226,6 +227,8 @@ extension LocalizableString.PhotoVerification: WXMLocalizable {
 				"photo_verification_upload_photos_alert_title"
 			case .uploadPhotosAlertMessage:
 				"photo_verification_upload_photos_alert_message"
+			case .stayAndVerify:
+				"photo_verification_stay_and_verify"
 		}
 	}
 }


### PR DESCRIPTION
## **Why?**
QA fixes
### **How?**
- Fixed wrong side padding in instructions view ([FE-1590](https://linear.app/weatherxm/issue/FE-1590/wrong-left-margin-in-the-back-icon-on-instructions))
- Fixed the transition of selected photo in gallery screen ([FE-1594](https://linear.app/weatherxm/issue/FE-1594/remove-the-button-effect))
- UI fix in terms text in instructions screen ([FE-1598](https://linear.app/weatherxm/issue/FE-1598/user-agreement-text-font-increase-and-add-stop-mark-at-the-end))
- Fixed the issue with wrong notification message in some cases ([FE-1592](https://linear.app/weatherxm/issue/FE-1592/wrong-notification-message)). This usually happens when the app goes to the background after the upload starts. Now, we keep in a dedicated dictionary the count of the files to be uploaded for a specific device
- Updated exit alert button texts ([FE-1602](https://linear.app/weatherxm/issue/FE-1602/exit-confirmation-button-labels-changes))
### **Testing**
Ensure the issues mentioned above are fixed
### **Additional context**
fixes FE-1590, FE-1594, FE-1598, FE-1592, FE-1602
