### PR TITLE
Prevent user to go back to terms

### DIFF
--- a/PresentationLayer/Navigation/Router.swift
+++ b/PresentationLayer/Navigation/Router.swift
@@ -271,7 +271,14 @@ class Router: ObservableObject {
 	/// We use this to add an, almost, invisible ovelray above `NavigationStack` to fix an issue with dragging gestures of sheet/popover and navigation stack
 	/// More info https://stackoverflow.com/questions/71714592/sheet-dismiss-gesture-with-swipe-back-gesture-causes-app-to-freeze
 	@Published var showDummyOverlay: Bool = false
-	@Published var showFullScreen = false
+	@Published var showFullScreen = false {
+		didSet {
+			if !showFullScreen {
+				// Set ref to nil in order to deallocate the corresponding view model
+				fullScreenRoute = nil
+			}
+		}
+	}
 	var fullScreenRoute: Route?
 	let navigationHost = HostingWrapper()
 	

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimDeviceContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimDeviceContainerViewModel.swift
@@ -199,9 +199,9 @@ extension ClaimDeviceContainerViewModel {
 			guard let deviceId = device.id else {
 				return
 			}
-			let route = PhotoIntroViewModel.getInitialRoute(deviceId: deviceId, images: [], isNewPhotoVerification: true)
+
 			DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { // The only way found to avoid errors with navigation stack
-				Router.shared.navigateTo(route)
+				PhotoIntroViewModel.startPhotoVerification(deviceId: deviceId, images: [], isNewPhotoVerification: true)
 			}
 
 			WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .goToPhotoVerification,

--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel.swift
@@ -264,8 +264,8 @@ private extension DeviceInfoViewModel {
 				guard let deviceId = device.id else {
 					return
 				}
-				let route = PhotoIntroViewModel.getInitialRoute(deviceId: deviceId, images: [], isNewPhotoVerification: true)
-				Router.shared.navigateTo(route)
+
+				PhotoIntroViewModel.startPhotoVerification(deviceId: deviceId, images: [], isNewPhotoVerification: true)
 
 				WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .goToPhotoVerification,
 																			.source: .settingsSource])

--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/PhotoVerificationState/PhotoVerificationStateViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/PhotoVerificationState/PhotoVerificationStateViewModel.swift
@@ -47,10 +47,9 @@ class PhotoVerificationStateViewModel: ObservableObject {
 	}
 
 	func handleImageTap() {
-		let route = PhotoIntroViewModel.getInitialRoute(deviceId: deviceId,
-														images: allPhotos.compactMap { $0.url },
-														isNewPhotoVerification: false)
-		Router.shared.navigateTo(route)
+		PhotoIntroViewModel.startPhotoVerification(deviceId: deviceId,
+												   images: allPhotos.compactMap { $0.url },
+												   isNewPhotoVerification: false)
 	}
 
 	func retryUpload() {

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroView.swift
@@ -233,8 +233,8 @@ private extension PhotoIntroView {
 					Spacer()
 				}
 				
-				Button {
-					viewModel.handleBeginButtonTap()
+				Button {					
+					viewModel.handleBeginButtonTap(dismiss: dismiss)
 				} label: {
 					Text(LocalizableString.PhotoVerification.letsTakeTheFirstPhoto.localized)
 				}

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/Intro/PhotoIntroViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import DomainLayer
+import SwiftUI
 
 @MainActor
 class PhotoIntroViewModel: ObservableObject {
@@ -49,7 +50,8 @@ class PhotoIntroViewModel: ObservableObject {
 		areTermsAccepted = photoGalleryUseCase.areTermsAccepted
 	}
 
-	func handleBeginButtonTap() {
+	func handleBeginButtonTap(dismiss: DismissAction) {
+		dismiss()
 		let viewModel = ViewModelsFactory.getGalleryViewModel(deviceId: deviceId, images: images, isNewVerification: true)
 		Router.shared.navigateTo(.photoGallery(viewModel))
 	}
@@ -59,7 +61,8 @@ extension PhotoIntroViewModel: HashableViewModel {
 	nonisolated func hash(into hasher: inout Hasher) {
 	}
 
-	static func getInitialRoute(deviceId: String, images: [String], isNewPhotoVerification: Bool) -> Route {
+	@MainActor
+	static func startPhotoVerification(deviceId: String, images: [String], isNewPhotoVerification: Bool) {
 		let useCase = SwinjectHelper.shared.getContainerForSwinject().resolve(PhotoGalleryUseCase.self)!
 		let areTermsAccepted = useCase.areTermsAccepted
 
@@ -67,11 +70,12 @@ extension PhotoIntroViewModel: HashableViewModel {
 			let viewModel = ViewModelsFactory.getGalleryViewModel(deviceId: deviceId,
 																  images: images,
 																  isNewVerification: isNewPhotoVerification)
-			return .photoGallery(viewModel)
+			Router.shared.navigateTo(.photoGallery(viewModel))
+			return
 		}
 
 		let viewModel = ViewModelsFactory.getPhotoIntroViewModel(deviceId: deviceId, images: images)
-		return .photoIntro(viewModel)
+		Router.shared.showFullScreen(.photoIntro(viewModel))
 	}
 }
 


### PR DESCRIPTION
## **Why?**
When the photo verification terms are not accepted, the user can navigate back to the intro view.
### **How?**
We present the intro view as a modal and, on the begin button tap, we dismiss the modal and navigate to gallery screen
### **Testing**
Logout to clear the terms option and ensure that you can't go back to the intro screen 
### **Additional context**
fixes fe-1607
