### PR TITLE
Crashes

### DIFF
--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/SerialNumber/ClaimDeviceSerialNumberViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/SerialNumber/ClaimDeviceSerialNumberViewModel.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import AVFoundation
+@preconcurrency import AVFoundation
 import Toolkit
 
 @MainActor
@@ -102,11 +102,11 @@ private extension ClaimDeviceSerialNumberViewModel {
 	func requestCameraPermission() {
 		switch AVCaptureDevice.authorizationStatus(for: .video) {
 			case .notDetermined:
-				AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+				AVCaptureDevice.requestAccess(for: .video) { @Sendable [weak self] granted in
 					if granted {
-						self?.showQrScanner = true
-					} else {
-						
+						DispatchQueue.main.async {
+							self?.showQrScanner = true
+						}
 					}
 				}
 			case .restricted:

--- a/PresentationLayer/UIComponents/Screens/UpdateFirmware/ViewModel/UpdateFirmwareViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/UpdateFirmware/ViewModel/UpdateFirmwareViewModel.swift
@@ -76,10 +76,8 @@ private extension UpdateFirmwareViewModel {
 
         UIApplication.shared.isIdleTimerDisabled = true
         let publisher = firmwareUseCase?.updateDeviceFirmware(device: device, firmwareDeviceId: firmwareDeviceId)
-        publisher?.sink { [weak self] state in
-            DispatchQueue.main.async {
-                self?.handleState(state: state)
-            }
+		publisher?.receive(on: DispatchQueue.main).sink { [weak self] state in
+			self?.handleState(state: state)
         }.store(in: &cancellableSet)
     }
 


### PR DESCRIPTION
## **Why?**
We detect two consistent crashes
- On a fresh install in the claim flow, when the user taps to open the QR scanner and then "allow" on the permission alert the app crashes
- In the update firmware flow, the app crashes just after the "connect" step
### **How?**
Each issue had to do with threading in Swift 6. Now, the actions are dispatched to the correct thread.
### **Testing**
Ensure the app doesn't crash
- On fresh install in the claim flow with QR
- In the update flow
### **Additional context**
fixes fe-1605, fe-1609


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the camera permission flow to ensure UI updates occur smoothly.
  - Updated the firmware update process to handle state changes reliably on the main thread for improved responsiveness and organized error tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->