### PR TITLE
Upload completed text in home banner

### DIFF
--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/UploadProgressView/UploadProgressView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/UploadProgressView/UploadProgressView.swift
@@ -118,7 +118,7 @@ private extension UploadProgressView {
 						.font(.system(size: CGFloat(.largeTitleFontSize), weight: .bold))
 						.foregroundStyle(Color(colorEnum: .text))
 
-					Text(LocalizableString.completed.localized)
+					Text(LocalizableString.PhotoVerification.photoUploadCompleted.localized)
 						.font(.system(size: CGFloat(.normalFontSize)))
 						.foregroundStyle(Color(colorEnum: .text))
 

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -6226,6 +6226,17 @@
         }
       }
     },
+    "photo_verification_photo_upload_completed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Photo upload completed"
+          }
+        }
+      }
+    },
     "photo_verification_preparing_upload_description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/LocalizableString+PhotoVerification.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+PhotoVerification.swift
@@ -56,6 +56,7 @@ extension LocalizableString {
 		case exitPhotoVerification
 		case exitPhotoVerificationText
 		case exitPhotoVerificationMinimumPhotosText
+		case photoUploadCompleted
 		case uploading
 		case cancelUpload
 		case cancelUploadAlertMessage
@@ -191,6 +192,8 @@ extension LocalizableString.PhotoVerification: WXMLocalizable {
 				"photo_verification_exit_photo_verification_text"
 			case .exitPhotoVerificationMinimumPhotosText:
 				"photo_verification_exit_photo_verification_minimum_photos_text"
+			case .photoUploadCompleted:
+				"photo_verification_photo_upload_completed"
 			case .uploading:
 				"photo_verification_uploading"
 			case .cancelUpload:


### PR DESCRIPTION
## **Why?**
Updated the text of the completed state in progress view in home
### **Testing**
Ensure the text in the uploaded state is correct
For testing in a simulator to upload a photo from phone gallery, in `GalleryVIewModel` ln 251 change the source type to `.photoLibrary`
### **Additional context**
fixes fe-1619


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the feedback message displayed after a photo upload, providing a clearer and more descriptive confirmation.
	- Updated local language support to consistently reflect the enhanced photo upload completion message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->