### PR TITLE
Profile tab in case of no wallet

### DIFF
--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
@@ -246,7 +246,7 @@ private extension ProfileViewModel {
 			allocatedRewards = allocated == 0.0 ? noRewardsString : valueString
 		} else if userInfoResponse.wallet?.address == nil {
 			allocatedRewards = LocalizableString.Profile.noRewardsDescription.localized
-		}else {
+		} else {
 			allocatedRewards = LocalizableString.notAvailable.localized
 			isClaimAvailable = false
 		}

--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileViewModel.swift
@@ -204,9 +204,8 @@ private extension ProfileViewModel {
 		do {
 			let userRewardsResponse = try await meUseCase.getUserRewards(wallet: address).toAsync()
 			if let error = userRewardsResponse.error {
-				if error.backendError?.code == FailAPICodeEnum.walletAddressNotFound.rawValue {
-					self.userRewardsResponse = nil
-				}
+				self.userRewardsResponse = nil
+
 				return error
 			}
 
@@ -224,6 +223,8 @@ private extension ProfileViewModel {
 	func updateRewards(additionalClaimed: String? = nil) {
 		if let cumulative = userRewardsResponse?.cumulativeAmount?.toEthDouble {
 			totalEarned = cumulative.toWXMTokenPrecisionString + " " + StringConstants.wxmCurrency
+		} else if userInfoResponse.wallet?.address == nil {
+			totalEarned = 0.0.toWXMTokenPrecisionString + " " + StringConstants.wxmCurrency
 		} else {
 			totalEarned = LocalizableString.notAvailable.localized
 		}
@@ -231,6 +232,8 @@ private extension ProfileViewModel {
 		if let total = userRewardsResponse?.totalClaimed?.toEthDouble {
 			let claimed = total + (additionalClaimed?.toEthDouble ?? 0.0)
 			totalClaimed = claimed.toWXMTokenPrecisionString + " " + StringConstants.wxmCurrency
+		} else if userInfoResponse.wallet?.address == nil {
+			totalClaimed = 0.0.toWXMTokenPrecisionString + " " + StringConstants.wxmCurrency
 		} else {
 			totalClaimed = LocalizableString.notAvailable.localized
 		}
@@ -241,7 +244,9 @@ private extension ProfileViewModel {
 			let noRewardsString = LocalizableString.Profile.noRewardsDescription.localized
 			let valueString = allocated.toWXMTokenPrecisionString + " " + StringConstants.wxmCurrency
 			allocatedRewards = allocated == 0.0 ? noRewardsString : valueString
-		} else {
+		} else if userInfoResponse.wallet?.address == nil {
+			allocatedRewards = LocalizableString.Profile.noRewardsDescription.localized
+		}else {
 			allocatedRewards = LocalizableString.notAvailable.localized
 			isClaimAvailable = false
 		}

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Me/Network/NetworkUserInfoResponse.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Me/Network/NetworkUserInfoResponse.swift
@@ -13,7 +13,7 @@ public struct NetworkUserInfoResponse: Codable, Sendable {
     public var name: String? = ""
     public var firstName: String? = ""
     public var lastName: String? = ""
-    public var wallet: Wallet? = .init()
+    public var wallet: Wallet?
 
     public init() {}
 }

--- a/wxm-ios/Toolkit/Toolkit/FirebaseManager/RemoteConfigManager.swift
+++ b/wxm-ios/Toolkit/Toolkit/FirebaseManager/RemoteConfigManager.swift
@@ -168,6 +168,9 @@ class MockRemoteConfigManager: RemoteConfigManagerImplementation, @unchecked Sen
 	func getConfigValue<T>(type: T.Type, key: RemoteConfigKey) -> T? {
 		switch type {
 			case is String.Type:
+				if key == .iosAppMinimumVersion {
+					return "1.1.1" as? T
+				}
 				return "Dummy Text" as? T
 			case is Bool.Type:
 				return true as? T


### PR DESCRIPTION
## **Why?**
In case of no wallet, the total earned and total claimed fields should be 0.00 $WXM. Allocated Rewards should be "No allocated rewards yet"
### **How?**
Handle case of no wallet
### **Testing**
Ensure the profile UI is the expected in the following cases:
- No wallet
- Wallet and error from withdraw endpoint (dev server)
- Wallet and no error (prod server)
### **Additional context**
fixes 1563


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the clarity of rewards display by handling missing wallet data more consistently, ensuring users see accurate reward totals and descriptions.

- **New Features**
  - Updated configuration management to return a specific minimum version value, helping ensure that version-dependent features and prompts function correctly.
  - Enhanced error handling for user rewards, providing a more generalized response when wallet address information is incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->