### PR TITLE
Unhandled errors in logout process

### DIFF
--- a/wxm-ios/DataLayer/DataLayer/Networking/Interceptors/AuthInterceptor.swift
+++ b/wxm-ios/DataLayer/DataLayer/Networking/Interceptors/AuthInterceptor.swift
@@ -32,6 +32,7 @@ class AuthInterceptor: @unchecked Sendable, RequestInterceptor {
         let networkTokenResponse = keychainHelperService.getNetworkTokenResponse()
         guard let refreshToken = networkTokenResponse?.refreshToken, let statusCode = request.response?.statusCode else {
             completion(.doNotRetry)
+			NotificationCenter.default.post(name: .AuthRefreshTokenExpired, object: nil)
             return
         }
         switch statusCode {

--- a/wxm-ios/DomainLayer/DomainLayer/Services/LoginService.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Services/LoginService.swift
@@ -89,7 +89,7 @@ private extension LoginServiceImpl {
 		}.store(in: &cancellableSet)
 	}
 
-	func logoutPublisher(ignoreError: Bool = false) throws -> AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never> {
+	func logoutPublisher(ignoreError: Bool = false) -> AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never> {
 		getInstallationId().flatMap { [weak self] installationId in
 			guard let self else {
 				let error = NetworkErrorResponse(initialError: AFError.explicitlyCancelled, backendError: nil)
@@ -130,7 +130,7 @@ private extension LoginServiceImpl {
 
 
 	func performLogout() {
-		_ = try? logoutPublisher(ignoreError: true).sink { _ in
+		logoutPublisher(ignoreError: true).sink { _ in
 
 		}.store(in: &cancellableSet)
 	}

--- a/wxm-ios/DomainLayer/DomainLayer/Services/LoginService.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Services/LoginService.swift
@@ -128,7 +128,6 @@ private extension LoginServiceImpl {
 		}.eraseToAnyPublisher()
 	}
 
-
 	func performLogout() {
 		logoutPublisher(ignoreError: true).sink { _ in
 

--- a/wxm-ios/DomainLayer/DomainLayer/Services/LoginService.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Services/LoginService.swift
@@ -108,11 +108,11 @@ private extension LoginServiceImpl {
 			} catch {
 				let error = NetworkErrorResponse(initialError: AFError.explicitlyCancelled, backendError: nil)
 				let dummyResponse: DataResponse<EmptyEntity, NetworkErrorResponse> = DataResponse(request: nil,
-																						response: nil,
-																						data: nil,
-																						metrics: nil,
-																						serializationDuration: 0,
-																						result: .failure(error))
+																								  response: nil,
+																								  data: nil,
+																								  metrics: nil,
+																								  serializationDuration: 0,
+																								  result: .failure(error))
 				return Just(dummyResponse).eraseToAnyPublisher()
 			}
 		}.flatMap { [weak self] response in


### PR DESCRIPTION
## **Why?**
Handle any case in the logout process once the access token is expired
### **How?**
Enforce logout when the access token entry is missing from the keychain 
### **Testing**
The easiest way to test is to run the app as Mac app and edit the keychain entries.
Play with `SaveNetworkTokenService` and `SaveAccountInfo` entries of the keychain
- Delete `SaveNetworkTokenService` -> Logout
- Edit the `SaveNetworkTokenService` value (change the access or/and refresh token)  and `SaveAccountInfo`
  - Only Access token -> Remain logged in
  - Both tokens -> Remain logged in
  - Both entries, `SaveNetworkTokenService` and `SaveAccountInfo` -> Logout
### **Screenshots (if applicable)**
<img width="500" alt="Screenshot 2025-02-12 at 13 23 10" src="https://github.com/user-attachments/assets/7428e18b-9a92-4440-94c2-88f83e2521a7" />


<img width="500" alt="Screenshot 2025-02-12 at 13 23 35" src="https://github.com/user-attachments/assets/532da534-cf2b-4e19-a294-dbf004e4b68e" />

### **Additional context**
fixes fe-1378


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced authentication management that automatically notifies the system when a session token expires.
	- Improved logout handling that now manages errors internally for a more seamless user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->