### PR TITLE
Remove the icon next to every external link

### DIFF
--- a/PresentationLayer/UIComponents/Screens/ConnectWallet/MyWalletView.swift
+++ b/PresentationLayer/UIComponents/Screens/ConnectWallet/MyWalletView.swift
@@ -119,10 +119,6 @@ private extension MyWalletView {
                                                                                   .itemId: .custom(viewModel.wallet?.address ?? "")])
                         })
 
-					Text(FontIcon.externalLink.rawValue)
-						.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.caption)))
-						.foregroundColor(Color(colorEnum: .wxmPrimary))
-
                     Spacer()
                 }
             }
@@ -145,15 +141,10 @@ private extension MyWalletView {
 			Button {
 				viewModel.handleCheckCompatibilityTap()
 			} label: {
-				HStack {
-					Text(LocalizableString.Wallet.compatibilityCheck.localized)
-						.font(.system(size: CGFloat(.caption), weight: .bold))
-						.frame(maxWidth: .infinity)
-					
-					Text(FontIcon.externalLink.rawValue)
-						.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.normalFontSize)))
-				}
-				.padding(.horizontal, CGFloat(.defaultSidePadding))
+				Text(LocalizableString.Wallet.compatibilityCheck.localized)
+					.font(.system(size: CGFloat(.caption), weight: .bold))
+					.frame(maxWidth: .infinity)
+					.padding(.horizontal, CGFloat(.defaultSidePadding))
 			}
 			.buttonStyle(WXMButtonStyle.transparent)
 			.padding(.top, CGFloat(.smallSidePadding))


### PR DESCRIPTION
## **Why?**
Removed the external link icon from texts across the app.
### **Testing**
Ensure the icon is removed in the following cases
- Info banner button
- My wallet screen 
- Announcement banner button (Profile tab)
- Device info screen in rssi field warning
- Network stats external links
### **Additional context**
fixes fe-1604


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the wallet view by removing specific icons and streamlining the layout.
  - Enhanced the appearance of compatibility checks with a cleaner, padded text display for improved visual clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->