### PR TITLE
Loader on delete remote image

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/ShimmerEffectLoader/ShimmerEffectLoaderView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/ShimmerEffectLoader/ShimmerEffectLoaderView.swift
@@ -22,8 +22,7 @@ struct ShimmerEffectLoaderView: View {
                                startPoint: startPoint,
                                endPoint: endPoint)
             )
-            .frame(height: 4.0)
-            .padding(.horizontal)
+            .frame(height: 4.0)            
             .safeAreaInset(edge: .top, content: {
                 Color.clear
             })

--- a/PresentationLayer/UIComponents/Screens/Explorer/ExplorerView.swift
+++ b/PresentationLayer/UIComponents/Screens/Explorer/ExplorerView.swift
@@ -35,7 +35,7 @@ struct ExplorerView: View {
             WXMAnalytics.shared.trackScreen(.explorerLanding)
             viewModel.showTopOfMapItems = true
         }
-        .shimmerLoader(show: $viewModel.isLoading)
+		.shimmerLoader(show: $viewModel.isLoading, horizontalPadding: CGFloat(.defaultSidePadding))
     }
 
     var explorerContent: some View {

--- a/PresentationLayer/UIComponents/Screens/LoggedInViews/LoggedInTabViewContainer.swift
+++ b/PresentationLayer/UIComponents/Screens/LoggedInViews/LoggedInTabViewContainer.swift
@@ -116,7 +116,8 @@ private extension LoggedInTabViewContainer {
                 .environmentObject(explorerViewModel)
                 .navigationBarHidden(true)
                 .zIndex(0)
-                .shimmerLoader(show: $explorerViewModel.isLoading)
+                .shimmerLoader(show: $explorerViewModel.isLoading,
+							   horizontalPadding: CGFloat(.defaultSidePadding))
 
             if explorerViewModel.showTopOfMapItems {
                 SearchView(viewModel: explorerViewModel.searchViewModel)
@@ -143,11 +144,7 @@ private extension LoggedInTabViewContainer {
 					netStatsButton
 				}
 			}
-
-			//				.animation(.easeIn, value: explorerViewModel.showTopOfMapItems)
 		}
-		//			.transition(AnyTransition.move(edge: .trailing).animation(.easeIn(duration: 0.5)))
-		//			.animation(.easeOut, value: explorerViewModel.showTopOfMapItems)
     }
 
     @ViewBuilder

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
@@ -16,6 +16,7 @@ struct GalleryView: View {
 		ZStack {
 			Color(colorEnum: .bg)
 				.ignoresSafeArea()
+
 			VStack(spacing: 0.0) {
 				HStack(spacing: CGFloat(.mediumSpacing)) {
 					Button {
@@ -51,6 +52,8 @@ struct GalleryView: View {
 				}
 				.padding(CGFloat(.mediumSidePadding))
 				.background(Color(colorEnum: .top))
+				.shimmerLoader(show: $viewModel.showShimmerLoading,
+							   position: .bottom)
 
 				Group {
 					GeometryReader { proxy in

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
@@ -22,6 +22,7 @@ class GalleryViewModel: ObservableObject {
 	@Published var selectedImage: GalleryView.GalleryImage?
 	@Published var isCameraDenied: Bool = false
 	@Published var showInstructions: Bool = false
+	@Published var showShimmerLoading: Bool = false
 	@Published var showLoading: Bool = false
 	let loadingTitle: String = LocalizableString.PhotoVerification.preparingUploadTitle.localized
 	let loadingSubtitle: String = LocalizableString.PhotoVerification.preparingUploadDescription.localized
@@ -96,6 +97,12 @@ class GalleryViewModel: ObservableObject {
 
 		let action: VoidCallback = { [weak self] in
 			Task { @MainActor in
+				defer {
+					self?.showShimmerLoading = false
+				}
+				
+				self?.showShimmerLoading = true
+
 				do {
 					try await self?.deleteImageImage(selectedImage)
 					self?.selectedImage = self?.images.last


### PR DESCRIPTION
## **Why?**
Show loading indicator on delete photo action 
### **How?**
- Updated `shimmerLoaderView` to support full width
- Show loader on delete photo process
### **Testing**
Delete a remote photo and ensure the loader is visible while the request is in progress
### **Additional context**
fixes fe-1639


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a shimmer loading indicator in the gallery view to enhance visual feedback during image deletion.
  
- **Style**
  - Refined the shimmer loader’s layout by standardizing horizontal spacing across various screens for a more consistent look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->