### PR TITLE
Hide warning banner when stations has 99 score

### DIFF
--- a/PresentationLayer/Extensions/DomainExtensions/NetworkDeviceRewardDetailsResponse+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/NetworkDeviceRewardDetailsResponse+.swift
@@ -10,7 +10,19 @@ import DomainLayer
 
 @MainActor
 extension NetworkDeviceRewardDetailsResponse {
+	var shouldShowAnnotation: Bool {
+		guard let rewardScore = base?.rewardScore else {
+			return false
+		}
+
+		return rewardScore < 99
+	}
+
 	var mainAnnotation: RewardAnnotation? {
+		guard shouldShowAnnotation else {
+			return nil
+		}
+
 		if let annotation = annotations?.first(where: { $0.severity == .error }) {
 			return annotation
 		} else if let annotation = annotations?.first(where: { $0.severity == .warning }) {

--- a/PresentationLayer/Extensions/DomainExtensions/NetworkDeviceRewardsSummaryResponse+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/NetworkDeviceRewardsSummaryResponse+.swift
@@ -37,12 +37,21 @@ extension NetworkDeviceRewardsSummary: @retroactive Identifiable {
 								 isOwned: isOwned)
 	}
 
+	var shouldShowIssues: Bool {
+		guard let baseRewardScore else {
+			return true
+		}
+
+		return baseRewardScore < 99
+	}
+
 	var timelineTransactionDateString: String {
 		timestamp?.transactionsDateFormat(timeZone: .UTCTimezone ?? .current) ?? ""
 	}
 
 	private var warningType: CardWarningType? {
-		guard let annotationSummary else {
+		guard shouldShowIssues,
+			  let annotationSummary else {
 			return nil
 		}
 

--- a/PresentationLayer/UIComponents/Screens/DailyRewards/RewardDetailsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/DailyRewards/RewardDetailsViewModel.swift
@@ -120,7 +120,7 @@ class RewardDetailsViewModel: ObservableObject {
 	}
 
 	func boostsSubtitle() -> String? {
-		guard let reward = rewardDetailsResponse?.boost?.totalReward else {
+		guard let reward = rewardDetailsResponse?.boost?.totalReward, reward > 0 else {
 			return nil
 		}
 		return LocalizableString.RewardDetails.earnedBoosts(reward.toWXMTokenPrecisionString).localized


### PR DESCRIPTION
## **Why?**
Hide warnings if the reward score is greater than 99%
### **How?**
Added conditions to hide warnings in `NetworkDeviceRewardsSummaryResponse` and `NetworkDeviceRewardDetailsResponse` presentation layer extensions
### **Testing**
Ensure the warnings are hidden in cases of >=99% reward scrore in station rewards tab, reward details screen and rewards timeline
### **Additional context**
fixes fe-1636


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved reward details display to only show annotations when reward scores meet specific quality thresholds.
	- Enhanced warning messages to better reflect data quality by conditionally displaying issues.
	- Adjusted the rewards subtitle logic so that it appears only when valid, positive reward amounts are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->