### PR TITLE
Rename total earned label

### DIFF
--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeView.swift
@@ -47,18 +47,18 @@ struct WeatherStationsHomeView: View {
 
 	@ViewBuilder
 	var navigationBarRightView: some View {
-		if let totalEarnedTitle = viewModel.totalEarnedTitle {
+		if let stationRewardsTitle = viewModel.stationRewardsTitle {
 			Button {
 				viewModel.handleRewardAnalyticsTap()
 			} label: {
 				HStack(spacing: CGFloat(.mediumSpacing)) {
 					VStack(alignment: .leading, spacing: 0.0) {
-						Text(totalEarnedTitle)
+						Text(stationRewardsTitle)
 							.font(.system(size: CGFloat(.caption)))
 							.foregroundStyle(Color(colorEnum: .text))
 
-						if let totalEarnedValueText = viewModel.totalEarnedValueText {
-							Text(totalEarnedValueText)
+						if let stationRewardsValueText = viewModel.stationRewardsValueText {
+							Text(stationRewardsValueText)
 								.font(.system(size: CGFloat(.normalFontSize), weight: .medium))
 								.foregroundStyle(Color(colorEnum: .text))
 						}

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
@@ -441,9 +441,9 @@ private extension WeatherStationsHomeViewModel {
 		let totalEarned: Double = owndedDevices.reduce(0.0) { $0 + ($1.rewards?.totalRewards ?? 0.0) }
 		
 		let noRewardsText = LocalizableString.Home.noRewardsYet.localized
-		let totalEarnedText = LocalizableString.Profile.totalEarned.localized
+		let stationRewardsdText = LocalizableString.RewardAnalytics.stationRewards.localized
 		
-		self.totalEarnedTitle = (totalEarned == 0 && hasOwned) ? noRewardsText : totalEarnedText
+		self.totalEarnedTitle = (totalEarned == 0 && hasOwned) ? noRewardsText : stationRewardsdText
 		self.totalEarnedValueText = (totalEarned == 0 && hasOwned) ? nil : "\(totalEarned.toWXMTokenPrecisionString) \(StringConstants.wxmCurrency)" 
 	}
 

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
@@ -33,7 +33,7 @@ public final class WeatherStationsHomeViewModel: ObservableObject {
 	private var followStates: [String: UserDeviceFollowState] = [:] {
 		didSet {
 			updateFilteredDevices()
-			updateTotalEarned()
+			updateStationRewards()
 		}
 	}
 
@@ -435,7 +435,7 @@ private extension WeatherStationsHomeViewModel {
         }
     }
 
-	func updateTotalEarned() {
+	func updateStationRewards() {
 		let owndedDevices = getOwnedDevices()
 		let hasOwned = !owndedDevices.isEmpty
 		let totalEarned: Double = owndedDevices.reduce(0.0) { $0 + ($1.rewards?.totalRewards ?? 0.0) }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
@@ -55,8 +55,8 @@ public final class WeatherStationsHomeViewModel: ObservableObject {
 	@Published var uploadInProgressStationName: String?
 	@Published var uploadState: UploadProgressView.UploadState?
 	@Published var infoBanner: InfoBanner?
-	@Published var totalEarnedTitle: String?
-	@Published var totalEarnedValueText: String?
+	@Published var stationRewardsTitle: String?
+	@Published var stationRewardsValueText: String?
     @Published var shouldShowFullScreenLoader = true
     @Published var devices = [DeviceDetails]()
     @Published var scrollOffsetObject: TrackableScrollOffsetObject
@@ -443,8 +443,8 @@ private extension WeatherStationsHomeViewModel {
 		let noRewardsText = LocalizableString.Home.noRewardsYet.localized
 		let stationRewardsdText = LocalizableString.RewardAnalytics.stationRewards.localized
 		
-		self.totalEarnedTitle = (totalEarned == 0 && hasOwned) ? noRewardsText : stationRewardsdText
-		self.totalEarnedValueText = (totalEarned == 0 && hasOwned) ? nil : "\(totalEarned.toWXMTokenPrecisionString) \(StringConstants.wxmCurrency)" 
+		self.stationRewardsTitle = (totalEarned == 0 && hasOwned) ? noRewardsText : stationRewardsdText
+		self.stationRewardsValueText = (totalEarned == 0 && hasOwned) ? nil : "\(totalEarned.toWXMTokenPrecisionString) \(StringConstants.wxmCurrency)" 
 	}
 
 	func getOwnedDevices() -> [DeviceDetails] {


### PR DESCRIPTION
## **Why?**
Update title on top right of home screen 
### **How?**
Updated rendered text
### **Testing**
Ensure the UI is the expected 
### **Additional context**
fixes fe-1643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Refined the reward display on the weather stations screen to show "station rewards" instead of "total earned," providing clearer and more context-specific information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->