### PR TITLE
Wind direction does not correspond to wind arrow

### DIFF
--- a/PresentationLayer/Constants/WeatherFields.swift
+++ b/PresentationLayer/Constants/WeatherFields.swift
@@ -174,39 +174,6 @@ extension WeatherField: @retroactive CustomStringConvertible {
 					.sun
 		}
 	}
-
-	var icon: AssetEnum {
-		switch self {
-			case .temperature:
-				return .temperatureIcon
-			case .feelsLike:
-				return .temperatureIcon
-			case .humidity:
-				return .humidityIcon
-			case .wind:
-				return .windDirIconSmall
-			case .windDirection:
-				return .windDirIconSmall
-			case .precipitation:
-				return .precipitationIcon
-			case .windGust:
-				return .windDirIconSmall
-			case .pressure:
-				return .pressureIcon
-			case .solarRadiation:
-				return .solarIcon
-			case .illuminance:
-				return .solarIcon
-			case .dewPoint:
-				return .dewPointIcon
-			case .uv:
-				return .solarIcon
-			case .precipitationProbability:
-				return .umbrellaIcon
-			case .dailyPrecipitation:
-				return .precipitationIcon
-		}
-	}
 	
 	var shouldHaveSpaceWithUnit: Bool {
 		let fieldsWithoutSpace: Set<WeatherField> = [.temperature,

--- a/PresentationLayer/Constants/WeatherFields.swift
+++ b/PresentationLayer/Constants/WeatherFields.swift
@@ -142,39 +142,43 @@ extension WeatherField: @retroactive CustomStringConvertible {
 		}
 	}
 	
-	var fontIcon: FontIcon? {
+	func fontIcon(from weather: CurrentWeather?) -> (icon: FontIcon, rotation: Double) {
+		let rotation = iconRotation(from: weather)
 		switch self {
 			case .temperature:
-					.temperatureThreeQuarters
+				return (.temperatureThreeQuarters, rotation)
 			case .feelsLike:
-					.temperatureThreeQuarters
+				return (.temperatureThreeQuarters, rotation)
 			case .humidity:
-					.humidity
+				return (.humidity, rotation)
 			case .wind:
-					.locationArrow
+				// Angle threshold because the original location-arrow doesn't point up
+				return (.locationArrow, rotation - 45.0)
 			case .windDirection:
-					.locationArrow
+				// Angle threshold because the original location-arrow doesn't point up
+				return (.locationArrow, rotation - 45.0)
 			case .precipitation:
-					.cloudShowers
+				return (.cloudShowers, rotation)
 			case .precipitationProbability:
-					.umbrella
+				return (.umbrella, rotation)
 			case .dailyPrecipitation:
-					.cloudShowers
+				return (.cloudShowers, rotation)
 			case .windGust:
-					.locationArrow
+				// Angle threshold because the original location-arrow doesn't point up
+				return (.locationArrow, rotation - 45.0)
 			case .pressure:
-					.gauge
+				return (.gauge, rotation)
 			case .solarRadiation:
-					.sun
+				return (.sun, rotation)
 			case .illuminance:
-					.sun
+				return (.sun, rotation)
 			case .dewPoint:
-					.dropletDegree
+				return (.dropletDegree, rotation)
 			case .uv:
-					.sun
+				return (.sun, rotation)
 		}
 	}
-	
+
 	var shouldHaveSpaceWithUnit: Bool {
 		let fieldsWithoutSpace: Set<WeatherField> = [.temperature,
 													 .feelsLike,
@@ -184,40 +188,41 @@ extension WeatherField: @retroactive CustomStringConvertible {
 		return !fieldsWithoutSpace.contains(self)
 	}
 	
-	func hourlyIcon() -> AssetEnum {
+	func hourlyIcon(from weather: CurrentWeather?) -> (icon: AssetEnum, rotation: Double) {
+		let rotation = iconRotation(from: weather)
 		switch self {
 			case .temperature:
-				return .temperatureIcon
+				return (.temperatureIcon, rotation)
 			case .feelsLike:
-				return .temperatureIcon
+				return (.temperatureIcon, rotation)
 			case .humidity:
-				return .humidityIconSmall
+				return (.humidityIconSmall, rotation)
 			case .wind:
-				return .windDirIconSmall
+				return (.windDirIconSmall, rotation)
 			case .windDirection:
-				return .windDirIconSmall
+				return (.windDirIconSmall, rotation)
 			case .precipitation:
-				return .rainIconSmall
+				return (.rainIconSmall, rotation)
 			case .precipitationProbability:
-				return .umbrellaIconSmall
+				return (.umbrellaIconSmall, rotation)
 			case .dailyPrecipitation:
-				return .rainIconSmall
+				return (.rainIconSmall, rotation)
 			case .windGust:
-				return .windDirIconSmall
+				return (.windDirIconSmall, rotation)
 			case .pressure:
-				return .pressureIconSmall
+				return (.pressureIconSmall, rotation)
 			case .solarRadiation:
-				return .solarIconSmall
+				return (.solarIconSmall, rotation)
 			case .illuminance:
-				return .solarIconSmall
+				return (.solarIconSmall, rotation)
 			case .dewPoint:
-				return .humidityIconSmall
+				return (.humidityIconSmall, rotation)
 			case .uv:
-				return .solarIconSmall
+				return (.solarIconSmall, rotation)
 		}
 	}
 
-	func iconRotation(from weather: CurrentWeather?) -> Double {
+	private func iconRotation(from weather: CurrentWeather?) -> Double {
 		switch self {
 			case .wind, .windGust:
 				guard let direction = weather?.windDirection else {

--- a/PresentationLayer/UIComponents/BaseComponents/WeatherOverview/WeatherOverviewView+Content.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherOverview/WeatherOverviewView+Content.swift
@@ -154,11 +154,12 @@ extension WeatherOverviewView {
 
     @ViewBuilder
     func weatherFieldView(for field: WeatherField) -> some View {
+		let fontIcon = field.fontIcon(from: weather)
 		HStack(alignment: .center, spacing: CGFloat(.smallSpacing)) {
-			Text(field.fontIcon?.rawValue ?? "")
+			Text(fontIcon.icon.rawValue)
 				.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.smallTitleFontSize)))
 				.foregroundColor(Color(colorEnum: .darkestBlue))
-				.rotationEffect(Angle(degrees: field.iconRotation(from: weather)))
+				.rotationEffect(Angle(degrees: fontIcon.rotation))
 
             VStack(alignment: .leading, spacing: 0.0) {
                 Text(field.description)

--- a/PresentationLayer/UIComponents/Screens/ForecastDetails/ForecastDetailsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ForecastDetails/ForecastDetailsViewModel.swift
@@ -58,12 +58,15 @@ private extension ForecastDetailsViewModel {
 
 		let fieldItems: [ForecastFieldCardView.Item] = WeatherField.forecastFields.compactMap { field in
 			guard let daily = currentForecast.daily,
-					let literals = field.weatherLiterals(from: daily, unitsManager: .default, includeDirection: true) else {
+					let literals = field.weatherLiterals(from: daily,
+														 unitsManager: .default,
+														 includeDirection: true) else {
 				return nil
 			}
 
-			return ForecastFieldCardView.Item(icon: field.hourlyIcon(),
-											  iconRotation: field.iconRotation(from: daily),
+			let hourlyIcon = field.hourlyIcon(from: daily)
+			return ForecastFieldCardView.Item(icon: hourlyIcon.icon,
+											  iconRotation: hourlyIcon.rotation,
 											  title: field.displayTitle,
 											  value: attributedString(literals: literals,
 																	  unitWithSpace: field.shouldHaveSpaceWithUnit),

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForeCastCardView+Content.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForeCastCardView+Content.swift
@@ -66,13 +66,14 @@ private extension StationForecastCardView {
     @ViewBuilder
     func fieldView(for field: WeatherField) -> some View {
         if let weather = forecast.daily {
+			let hourlyIcon = field.hourlyIcon(from: weather)
             HStack(spacing: 0.0) {
-                Image(asset: field.hourlyIcon())
+				Image(asset: hourlyIcon.icon)
 					.resizable()
                     .renderingMode(.template)
                     .foregroundColor(Color(colorEnum: .darkGrey))
 					.frame(width: 20.0, height: 20.0)
-					.rotationEffect(Angle(degrees: field.iconRotation(from: weather)))
+					.rotationEffect(Angle(degrees: hourlyIcon.rotation))
 
                 Text(getFieldText(weatherField: field,
                                   weather: weather,

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastMiniCardView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastMiniCardView.swift
@@ -45,11 +45,10 @@ struct StationForecastMiniCardView: View {
 				}
 
 				HStack(spacing: CGFloat(.minimumSpacing)) {
-					if let fontIcon = WeatherField.precipitationProbability.fontIcon {
-						Text(fontIcon.rawValue)
-							.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.caption)))
-							.foregroundStyle(Color(colorEnum: .darkestBlue))
-					}
+					let fontIcon = WeatherField.precipitationProbability.fontIcon(from: nil).icon
+					Text(fontIcon.rawValue)
+						.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.caption)))
+						.foregroundStyle(Color(colorEnum: .darkestBlue))
 
 					Text(item.precipitation)
 						.foregroundColor(Color(colorEnum: .darkestBlue))


### PR DESCRIPTION
## **Why?**
The problem is that the font awesome icon `location-arrow` doesn't point up, so the applied  rotation is wrong
### **How?**
Changed the way we get the weather icon and in case of `location-arrow` we add a 45 degrees threshold 
### **Testing**
Ensure the wind arrow is rotated correctly in the following screens 
- Home screen 
- Station overview tab
- Forecast tab
- Forecast details 
### **Additional context**
fixes fe-1660


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Weather icons now dynamically adjust their rotation based on current weather conditions, ensuring more accurate and engaging visual feedback across all weather screens.
  - Icons for forecast details and station views display consistently, including the precipitation probability indicator, for a more reliable weather overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->