### PR TITLE
View content claiming result missing

### DIFF
--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceProgressView.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceProgressView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Toolkit
 
 struct ClaimDeviceProgressView: View {
 	@Binding var state: State
@@ -24,8 +25,14 @@ struct ClaimDeviceProgressView: View {
 												 progress: .constant(obj.progress))
 					case .success(let object):
 						SuccessView(obj: object)
+							.onAppear {
+								WXMAnalytics.shared.trackEvent(.viewContent, parameters: [.success: .custom("1")])
+							}
 					case .fail(let object):
 						FailView(obj: object)
+							.onAppear {
+								WXMAnalytics.shared.trackEvent(.viewContent, parameters: [.success: .custom("0")])
+							}
 				}
 			}
 			.padding()

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
@@ -72,7 +72,7 @@ extension ParameterValue: RawRepresentable {
 			case .claiming:
 				return "Claiming"
 			case .claimingResult:
-				return "Claiming Results"
+				return "Claiming Result"
 			case .searchLocation:
 				return "Search Location"
 			case .claimingAddressSearch:


### PR DESCRIPTION
## **Why?**
Missing `view_content` events  from claiming results screen
### **How?**
- Fixed typo `Claiming Results` -> `Claiming Result`
- Track events from `ClaimDeviceProgressView`
### **Testing**
Ensure the events are tracked properly
### **Additional context**
fixes fe-1688


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the device claim process with improved outcome tracking that clearly distinguishes between successful and failed operations, leading to better service responsiveness and more reliable feedback.
  
- **Chores**
  - Updated status messaging labels for improved consistency and clarity, ensuring users enjoy a smoother and more intuitive claim experience, and resulting in an overall boost in responsiveness and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->