### PR TITLE
Station settings blocked by photo verification endpoint

### DIFF
--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoFactory.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoFactory.swift
@@ -90,6 +90,8 @@ extension DeviceInfoViewModel.Field {
 						}
 
 						return LocalizableString.DeviceInfo.photoVerificationWithPhotosDescription.localized
+					case .fetchPhotosFailed:
+						return ""
 				}
 		}
 	}

--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoView.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoView.swift
@@ -67,8 +67,7 @@ struct DeviceInfoView: View {
                     .padding(CGFloat(.defaultSidePadding))
                 }
             }
-            .spinningLoader(show: $viewModel.isLoading, hideContent: true)
-            .fail(show: $viewModel.isFailed, obj: viewModel.failObj)
+            .spinningLoader(show: $viewModel.isLoading, hideContent: true)            
         }
         .onAppear {
 			navigationObject.title = LocalizableString.DeviceInfo.title.localized

--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel+Content.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel+Content.swift
@@ -36,21 +36,33 @@ extension DeviceInfoViewModel {
 		case rewardSplit
 		case photos
 
-        static func heliumSections(for followState: UserDeviceFollowState?) -> [[Field]] {
+		static func heliumSections(for followState: UserDeviceFollowState?,
+								   photosState: PhotoVerificationStateView.State?) -> [[Field]] {
             if followState?.state == .owned {
-				return [[.name, .frequency, .reboot],
-						[.photos],
-						[.stationLocation]]
+				let isPhotosFailed: Bool = photosState == .fetchPhotosFailed
+				var sections: [[Field]] = [[.name, .frequency, .reboot]]
+				if !isPhotosFailed {
+					sections.append([.photos])
+				}
+				sections.append([.stationLocation])
+
+				return sections
             }
 
             return [[.name], [.stationLocation]]
         }
 
-        static func wifiSections(for followState: UserDeviceFollowState?) -> [[Field]] {
+        static func wifiSections(for followState: UserDeviceFollowState?,
+								 photosState: PhotoVerificationStateView.State?) -> [[Field]] {
             if followState?.state == .owned {
-                return [[.name],
-						[.photos],
-						[.stationLocation]]
+				let isPhotosFailed: Bool = photosState == .fetchPhotosFailed
+				var sections: [[Field]] = [[.name]]
+				if !isPhotosFailed {
+					sections.append([.photos])
+				}
+				sections.append([.stationLocation])
+
+				return sections
             }
             
 			return [[.name], [.stationLocation]]

--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel.swift
@@ -82,8 +82,6 @@ class DeviceInfoViewModel: ObservableObject {
 	@Published var showShareDialog: Bool = false
 	private(set) var shareDialogText: String = ""
     @Published var isLoading: Bool = true
-    @Published var isFailed: Bool = false
-    var failObj: FailSuccessStateObject?
     @Published private(set) var device: DeviceDetails
 	@Published private(set) var deviceInfo: NetworkDevicesInfoResponse? {
 		didSet {
@@ -179,12 +177,11 @@ class DeviceInfoViewModel: ObservableObject {
 				let response = try await self?.deviceInfoUseCase?.getDeviceInfo(deviceId: deviceId).toAsync()
 				self?.isLoading = false
 				if let error = response?.error {
-					self?.failObj = error.uiInfo.defaultFailObject(type: .deviceInfo) {
-						self?.isFailed = false
-						self?.isLoading = true
-						self?.refresh()
+					let uiInfo = error.uiInfo
+					let text = uiInfo.description ?? uiInfo.title
+					if let message = text.attributedMarkdown {
+						Toast.shared.show(text: message)
 					}
-					self?.isFailed = true
 				}
 				self?.deviceInfo = response?.value
 				completion?()

--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoViewModel.swift
@@ -19,9 +19,9 @@ class DeviceInfoViewModel: ObservableObject {
 	var sections: [[DeviceInfoRowView.Row]] {
 		var fields: [[Field]] = []
 		if device.isHelium {
-			fields = Field.heliumSections(for: followState)
+			fields = Field.heliumSections(for: followState, photosState: photoVerificationState)
 		} else {
-			fields = Field.wifiSections(for: followState)
+			fields = Field.wifiSections(for: followState, photosState: photoVerificationState)
 		}
 
 		let rows: [[DeviceInfoRowView.Row]] = fields.map { $0.map { field in
@@ -178,7 +178,7 @@ class DeviceInfoViewModel: ObservableObject {
 			do {
 				let response = try await self?.deviceInfoUseCase?.getDeviceInfo(deviceId: deviceId).toAsync()
 				self?.isLoading = false
-				if let error = response?.error ?? photosError {
+				if let error = response?.error {
 					self?.failObj = error.uiInfo.defaultFailObject(type: .deviceInfo) {
 						self?.isFailed = false
 						self?.isLoading = true

--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/PhotoVerificationState/PhotoVerificationStateView.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/PhotoVerificationState/PhotoVerificationStateView.swift
@@ -17,14 +17,17 @@ struct PhotoVerificationStateView: View {
 				photosView(photos: photos, isFailed: isFailed)
 			case .uploading(let progress):
 				uploadingView(progress: progress)
+			case .fetchPhotosFailed:
+				EmptyView()
 		}
     }
 }
 
 extension PhotoVerificationStateView {
-	enum State {
+	enum State: Equatable {
 		case content(photos: [URL], isFailed: Bool)
 		case uploading(progress: CGFloat)
+		case fetchPhotosFailed
 	}
 
 	@ViewBuilder

--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/PhotoVerificationState/PhotoVerificationStateViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/PhotoVerificationState/PhotoVerificationStateViewModel.swift
@@ -76,7 +76,7 @@ private extension PhotoVerificationStateViewModel {
 					allPhotos = response
 					updateState()
 				case .failure(let error):
-					updateState()
+					updateState(photosError: error)
 					return error
 			}
 		} catch {
@@ -122,7 +122,12 @@ private extension PhotoVerificationStateViewModel {
 		}
 	}
 
-	func updateState() {
+	func updateState(photosError: NetworkErrorResponse? = nil) {
+		guard photosError == nil else {
+			state = .fetchPhotosFailed
+			return
+		}
+
 		let uploadState = photoGalleryUseCase?.getUploadState(deviceId: deviceId)
 		var isFailed: Bool
 		switch uploadState {


### PR DESCRIPTION
## **Why?**
In case of the fetch photos error, the UI in settings is in failed state.
### **How?**
- Hide the photos section in case of error in the photos endpoint
- Show error toast instead of full screen failure in case of device info error
### **Testing**
- Ensure the photos section is hidden in case of photos error (check dev api)
- Ensure the UI state is not in fail state in case of device info endpoint failure. Use the mock scheme and edit the `get_device_info_...` json
### **Additional context**
fixes fe-1673


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced improved handling of photo verification errors. When photo retrieval fails, the UI now omits the related photo sections and provides a fallback display.
  - Added a visual response in the UI for photo fetching failures, enhancing user feedback during the photo verification process.

- **Refactor**
  - Streamlined the error handling during device information refresh, ensuring a more consistent and clear user experience when photo fetching is unsuccessful.
  - Simplified state management in the UI by removing unnecessary failure state indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->