### PR TITLE
Avoid line breaks in units

### DIFF
--- a/PresentationLayer/Utils/Weather/UnitConstants.swift
+++ b/PresentationLayer/Utils/Weather/UnitConstants.swift
@@ -6,25 +6,26 @@
 //
 
 public enum UnitConstants {
-	public static let CELCIUS = LocalizableString.Units.celsiusSymbol.localized
-    public static let FAHRENHEIT = LocalizableString.Units.fahrenheitSymbol.localized
-    public static let MILLIMETERS = LocalizableString.Units.millimetersSymbol.localized
-    public static let INCHES = LocalizableString.Units.inchesSymbol.localized
-    public static let KILOMETERS_PER_HOUR = LocalizableString.Units.kilometersPerHourSymbol.localized
-    public static let MILES_PER_HOUR = LocalizableString.Units.milesPerHourSymbol.localized
-    public static let METERS_PER_SECOND = LocalizableString.Units.metersPerSecondSymbol.localized
-    public static let KNOTS = LocalizableString.Units.knotsSymbol.localized
-    public static let BEAUFORT = LocalizableString.Units.beaufortSymbol.localized
-    public static let CARDINAL = LocalizableString.Units.cardinalSymbol.localized
-    public static let DEGREES = LocalizableString.Units.degreesSymbol.localized
-    public static let HECTOPASCAL = LocalizableString.Units.hectopascalSymbol.localized
-    public static let INCH_OF_MERCURY = LocalizableString.Units.inchOfMercurySymbol.localized
-    public static let UV = LocalizableString.Units.uvSymbol.localized
-    public static let PERCENT = "%"
-    public static let MILLIMETERS_PER_HOUR = LocalizableString.Units.millimetersPerHourSymbol.localized
-    public static let INCHES_PER_HOUR = LocalizableString.Units.inchesPerHourSymbol.localized
-    public static let WATTS_PER_SQR = LocalizableString.Units.wattsPerSquareSymbol.localized
-    public static let DBM = LocalizableString.Units.dBmSymbol.localized
+	public static let CELCIUS = LocalizableString.Units.celsiusSymbol.localized.fixedLinebreaks
+	public static let FAHRENHEIT = LocalizableString.Units.fahrenheitSymbol.localized.fixedLinebreaks
+	public static let MILLIMETERS = LocalizableString.Units.millimetersSymbol.localized.fixedLinebreaks
+	public static let INCHES = LocalizableString.Units.inchesSymbol.localized.fixedLinebreaks
+	public static let KILOMETERS_PER_HOUR = LocalizableString.Units.kilometersPerHourSymbol.localized.fixedLinebreaks
+	public static let MILES_PER_HOUR = LocalizableString.Units.milesPerHourSymbol.localized.fixedLinebreaks
+	public static let METERS_PER_SECOND = LocalizableString.Units.metersPerSecondSymbol.localized.fixedLinebreaks
+	public static let KNOTS = LocalizableString.Units.knotsSymbol.localized.fixedLinebreaks
+	public static let BEAUFORT = LocalizableString.Units.beaufortSymbol.localized.fixedLinebreaks
+	public static let CARDINAL = LocalizableString.Units.cardinalSymbol.localized.fixedLinebreaks
+	public static let DEGREES = LocalizableString.Units.degreesSymbol.localized.fixedLinebreaks
+	public static let HECTOPASCAL = LocalizableString.Units.hectopascalSymbol.localized.fixedLinebreaks
+	public static let INCH_OF_MERCURY = LocalizableString.Units.inchOfMercurySymbol.localized.fixedLinebreaks
+	public static let UV = LocalizableString.Units.uvSymbol.localized.fixedLinebreaks
+    public static let PERCENT = "%".fixedLinebreaks
+	public static let MILLIMETERS_PER_HOUR = LocalizableString.Units.millimetersPerHourSymbol.localized.fixedLinebreaks
+	public static let INCHES_PER_HOUR = LocalizableString.Units.inchesPerHourSymbol.localized.fixedLinebreaks
+	public static let WATTS_PER_SQR = LocalizableString.Units.wattsPerSquareSymbol.localized.fixedLinebreaks
+	public static let DBM = LocalizableString.Units.dBmSymbol.localized.fixedLinebreaks
+}
 
 private extension String {
 	var fixedLinebreaks: String {

--- a/PresentationLayer/Utils/Weather/UnitConstants.swift
+++ b/PresentationLayer/Utils/Weather/UnitConstants.swift
@@ -25,4 +25,9 @@ public enum UnitConstants {
     public static let INCHES_PER_HOUR = LocalizableString.Units.inchesPerHourSymbol.localized
     public static let WATTS_PER_SQR = LocalizableString.Units.wattsPerSquareSymbol.localized
     public static let DBM = LocalizableString.Units.dBmSymbol.localized
+
+private extension String {
+	var fixedLinebreaks: String {
+		replacingOccurrences(of: "/", with: "\u{FEFF}/\u{FEFF}")
+	}
 }


### PR DESCRIPTION
## **Why?**
In weather units with slash (/) such as "km/h", there cases of line breaks
### **How?**
We insert a unicode symbol inside the unit string to avoid line breaking 
### **Testing**
Ensure there is no line break in units with a slash. You can run the app on smaller devices like iPhone SE
### **Additional context**
fixes fe-1690


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined the display of measurement unit symbols to ensure proper line breaking, resulting in a cleaner and more consistent appearance for units like temperature, distance, speed, and more.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->