### PR TITLE
Research about bluetooth mock for unit testing

### DIFF
--- a/wxm-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/wxm-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "681297f8ac832854e6e0cc0b09a265340e2f7aae666e785cb2905a97406d01c4",
+  "originHash" : "7e7d7671e73536d4a50d18f3e200b92f8a0c643e6d06429a0a44edc123d78572",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -116,6 +116,15 @@
       "state" : {
         "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
         "version" : "100.0.0"
+      }
+    },
+    {
+      "identity" : "ios-corebluetooth-mock",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock",
+      "state" : {
+        "revision" : "500b23852e7d46b63ef8e2a826c2b6f3f6ed50ef",
+        "version" : "0.18.0"
       }
     },
     {

--- a/wxm-ios/DataLayer/DataLayer.xcodeproj/project.pbxproj
+++ b/wxm-ios/DataLayer/DataLayer.xcodeproj/project.pbxproj
@@ -69,6 +69,9 @@
 		26C71CD82D26D97500D2F0F3 /* post_device_photos.json in Resources */ = {isa = PBXBuildFile; fileRef = 26C71CD72D26D95F00D2F0F3 /* post_device_photos.json */; };
 		26C71CDC2D27D89300D2F0F3 /* FileUploaderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C71CDB2D27D89300D2F0F3 /* FileUploaderService.swift */; };
 		26D47E9E2A177AFB0078723A /* SettingsRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D47E9D2A177AFB0078723A /* SettingsRepositoryImpl.swift */; };
+		26D6E2422D819B41006CAAEA /* CoreBluetoothMock in Frameworks */ = {isa = PBXBuildFile; productRef = 26D6E2412D819B41006CAAEA /* CoreBluetoothMock */; };
+		26D6E2442D819C39006CAAEA /* Aliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D6E2432D819C39006CAAEA /* Aliases.swift */; };
+		26D6E2462D81A59E006CAAEA /* MockHeliumDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D6E2452D81A59E006CAAEA /* MockHeliumDevice.swift */; };
 		26DD42AF29AF4765008E277E /* Toolkit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26DD42AE29AF4765008E277E /* Toolkit.framework */; };
 		26DD42D229AFAF26008E277E /* get_user_devices.json in Resources */ = {isa = PBXBuildFile; fileRef = 26DD42D129AFAF26008E277E /* get_user_devices.json */; };
 		26DF1F542D549A310001E936 /* FileUploadMockProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DF1F532D549A310001E936 /* FileUploadMockProtocol.swift */; };
@@ -171,6 +174,8 @@
 		26C71CD72D26D95F00D2F0F3 /* post_device_photos.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = post_device_photos.json; sourceTree = "<group>"; };
 		26C71CDB2D27D89300D2F0F3 /* FileUploaderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploaderService.swift; sourceTree = "<group>"; };
 		26D47E9D2A177AFB0078723A /* SettingsRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRepositoryImpl.swift; sourceTree = "<group>"; };
+		26D6E2432D819C39006CAAEA /* Aliases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Aliases.swift; sourceTree = "<group>"; };
+		26D6E2452D81A59E006CAAEA /* MockHeliumDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHeliumDevice.swift; sourceTree = "<group>"; };
 		26DD42AE29AF4765008E277E /* Toolkit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Toolkit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		26DD42D129AFAF26008E277E /* get_user_devices.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = get_user_devices.json; sourceTree = "<group>"; };
 		26DF1F532D549A310001E936 /* FileUploadMockProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadMockProtocol.swift; sourceTree = "<group>"; };
@@ -217,6 +222,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B51244012825516A00B66A31 /* Alamofire in Frameworks */,
+				26D6E2422D819B41006CAAEA /* CoreBluetoothMock in Frameworks */,
 				B51243F5282550B100B66A31 /* DomainLayer.framework in Frameworks */,
 				4D49D910294DE53700987DE6 /* MapboxMaps in Frameworks */,
 				267EC3BF2CD0ECE60085B50A /* Pulse in Frameworks */,
@@ -347,6 +353,7 @@
 				2646FCC529967D9500EBB61B /* BluetoothUtils.swift */,
 				26A4118B29BB2CAB00A2C10B /* BTActionsWrapper.swift */,
 				2646FCC72996949C00EBB61B /* BTPerformCommandDelegate.swift */,
+				26D6E2452D81A59E006CAAEA /* MockHeliumDevice.swift */,
 			);
 			path = Bluetooth;
 			sourceTree = "<group>";
@@ -465,6 +472,7 @@
 				26AB9F502A8010E300855912 /* Services */,
 				B5799E7628254CC100FEBB85 /* DataLayer.h */,
 				2683A4C32ADECBA800D5C205 /* countries_information.json */,
+				26D6E2432D819C39006CAAEA /* Aliases.swift */,
 			);
 			path = DataLayer;
 			sourceTree = "<group>";
@@ -513,6 +521,7 @@
 				264BDA09298ABF6B005C1F82 /* NordicDFU */,
 				267EC3BE2CD0ECE60085B50A /* Pulse */,
 				267EC3C02CD0ECE60085B50A /* PulseProxy */,
+				26D6E2412D819B41006CAAEA /* CoreBluetoothMock */,
 			);
 			productName = DataLayer;
 			productReference = B5799E7328254CC100FEBB85 /* DataLayer.framework */;
@@ -548,6 +557,7 @@
 				4D49D90E294DE53700987DE6 /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */,
 				264BDA08298ABF6B005C1F82 /* XCRemoteSwiftPackageReference "IOS-DFU-Library" */,
 				267EC3BD2CD0ECE60085B50A /* XCRemoteSwiftPackageReference "Pulse" */,
+				26D6E2402D819B41006CAAEA /* XCRemoteSwiftPackageReference "IOS-CoreBluetooth-Mock" */,
 			);
 			productRefGroup = B5799E7428254CC100FEBB85 /* Products */;
 			projectDirPath = "";
@@ -611,10 +621,12 @@
 			files = (
 				B55668922832DE96006D0B71 /* ApiClient.swift in Sources */,
 				B5E6B85628337A3E0060D050 /* AuthApiRequestBuilder.swift in Sources */,
+				26D6E2442D819C39006CAAEA /* Aliases.swift in Sources */,
 				B5E1FAD528A1360A002DFA24 /* AuthInterceptor.swift in Sources */,
 				B5E6B86B283391880060D050 /* AuthRepositoryImpl.swift in Sources */,
 				268ACD062C1B2A3500B30F83 /* DBBundle+CoreDataProperties.swift in Sources */,
 				4D5AE33028EA49C7006F2EBA /* BluetoothDevicesRepositoryImpl.swift in Sources */,
+				26D6E2462D81A59E006CAAEA /* MockHeliumDevice.swift in Sources */,
 				268ACD052C1B2A3500B30F83 /* DBBundle+CoreDataClass.swift in Sources */,
 				2646FCC4299658B200EBB61B /* BluetoothManager.swift in Sources */,
 				2646FCC629967D9500EBB61B /* BluetoothUtils.swift in Sources */,
@@ -1010,6 +1022,14 @@
 				minimumVersion = 5.1.2;
 			};
 		};
+		26D6E2402D819B41006CAAEA /* XCRemoteSwiftPackageReference "IOS-CoreBluetooth-Mock" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.18.0;
+			};
+		};
 		4D49D908294DE3B300987DE6 /* XCRemoteSwiftPackageReference "search-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mapbox/search-ios.git";
@@ -1051,6 +1071,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 267EC3BD2CD0ECE60085B50A /* XCRemoteSwiftPackageReference "Pulse" */;
 			productName = PulseProxy;
+		};
+		26D6E2412D819B41006CAAEA /* CoreBluetoothMock */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 26D6E2402D819B41006CAAEA /* XCRemoteSwiftPackageReference "IOS-CoreBluetooth-Mock" */;
+			productName = CoreBluetoothMock;
 		};
 		4D49D909294DE3B300987DE6 /* MapboxSearch */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/wxm-ios/DataLayer/DataLayer.xcodeproj/project.pbxproj
+++ b/wxm-ios/DataLayer/DataLayer.xcodeproj/project.pbxproj
@@ -295,6 +295,14 @@
 			path = FirmwareUpdate;
 			sourceTree = "<group>";
 		};
+		267AF46A2D830B2C00827E4F /* Mock */ = {
+			isa = PBXGroup;
+			children = (
+				26D6E2452D81A59E006CAAEA /* MockHeliumDevice.swift */,
+			);
+			path = Mock;
+			sourceTree = "<group>";
+		};
 		26AB9F502A8010E300855912 /* Services */ = {
 			isa = PBXGroup;
 			children = (
@@ -353,7 +361,6 @@
 				2646FCC529967D9500EBB61B /* BluetoothUtils.swift */,
 				26A4118B29BB2CAB00A2C10B /* BTActionsWrapper.swift */,
 				2646FCC72996949C00EBB61B /* BTPerformCommandDelegate.swift */,
-				26D6E2452D81A59E006CAAEA /* MockHeliumDevice.swift */,
 			);
 			path = Bluetooth;
 			sourceTree = "<group>";
@@ -465,6 +472,7 @@
 		B5799E7528254CC100FEBB85 /* DataLayer */ = {
 			isa = PBXGroup;
 			children = (
+				267AF46A2D830B2C00827E4F /* Mock */,
 				26E88B2A29E56B320023BBD5 /* Database */,
 				B56A25F128A0FFB800928141 /* Entities */,
 				B51243F12825509800B66A31 /* Networking */,
@@ -921,6 +929,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;
+				EXCLUDED_SOURCE_FILE_NAMES = "DataLayer/DataLayer/Mock/*";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -957,6 +966,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;
+				EXCLUDED_SOURCE_FILE_NAMES = "DataLayer/DataLayer/Mock/*";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/wxm-ios/DataLayer/DataLayer/Aliases.swift
+++ b/wxm-ios/DataLayer/DataLayer/Aliases.swift
@@ -1,0 +1,65 @@
+//
+//  Aliases.swift
+//  DataLayer
+//
+//  Created by Pantelis Giazitsis on 12/3/25.
+//
+
+import Foundation
+import CoreBluetoothMock
+
+// Copy this file to your project to start using CoreBluetoothMock classes
+// without having to refactor any of your code. You will just have to remove
+// the imports to CoreBluetooth to fix conflicts and initiate the manager
+// using CBCentralManagerFactory, instad of just creating a CBCentralManager.
+
+// disabled for Xcode 12.5 beta
+//typealias CBPeer                          = CBMPeer
+//typealias CBAttribute                     = CBMAttribute
+typealias CBCentralManagerFactory         = CBMCentralManagerFactory
+typealias CBUUID                          = CBMUUID
+typealias CBError                         = CBMError
+typealias CBATTError                      = CBMATTError
+typealias CBManagerState                  = CBMManagerState
+typealias CBPeripheralState               = CBMPeripheralState
+typealias CBCentralManager                = CBMCentralManager
+typealias CBCentralManagerDelegate        = CBMCentralManagerDelegate
+typealias CBPeripheral                    = CBMPeripheral
+typealias CBPeripheralDelegate            = CBMPeripheralDelegate
+typealias CBService                       = CBMService
+typealias CBCharacteristic                = CBMCharacteristic
+typealias CBCharacteristicWriteType       = CBMCharacteristicWriteType
+typealias CBCharacteristicProperties      = CBMCharacteristicProperties
+typealias CBDescriptor                    = CBMDescriptor
+typealias CBConnectionEvent               = CBMConnectionEvent
+typealias CBConnectionEventMatchingOption = CBMConnectionEventMatchingOption
+@available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)
+typealias CBL2CAPPSM                      = CBML2CAPPSM
+@available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)
+typealias CBL2CAPChannel                  = CBML2CAPChannel
+
+let CBCentralManagerScanOptionAllowDuplicatesKey       = CBMCentralManagerScanOptionAllowDuplicatesKey
+let CBCentralManagerOptionShowPowerAlertKey            = CBMCentralManagerOptionShowPowerAlertKey
+let CBCentralManagerOptionRestoreIdentifierKey         = CBMCentralManagerOptionRestoreIdentifierKey
+let CBCentralManagerScanOptionSolicitedServiceUUIDsKey = CBMCentralManagerScanOptionSolicitedServiceUUIDsKey
+let CBConnectPeripheralOptionStartDelayKey             = CBMConnectPeripheralOptionStartDelayKey
+#if !os(macOS)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+let CBConnectPeripheralOptionRequiresANCS              = CBMConnectPeripheralOptionRequiresANCS
+#endif
+let CBCentralManagerRestoredStatePeripheralsKey        = CBMCentralManagerRestoredStatePeripheralsKey
+let CBCentralManagerRestoredStateScanServicesKey       = CBMCentralManagerRestoredStateScanServicesKey
+let CBCentralManagerRestoredStateScanOptionsKey        = CBMCentralManagerRestoredStateScanOptionsKey
+
+let CBAdvertisementDataLocalNameKey                    = CBMAdvertisementDataLocalNameKey
+let CBAdvertisementDataServiceUUIDsKey                 = CBMAdvertisementDataServiceUUIDsKey
+let CBAdvertisementDataIsConnectable                   = CBMAdvertisementDataIsConnectable
+let CBAdvertisementDataTxPowerLevelKey                 = CBMAdvertisementDataTxPowerLevelKey
+let CBAdvertisementDataServiceDataKey                  = CBMAdvertisementDataServiceDataKey
+let CBAdvertisementDataManufacturerDataKey             = CBMAdvertisementDataManufacturerDataKey
+let CBAdvertisementDataOverflowServiceUUIDsKey         = CBMAdvertisementDataOverflowServiceUUIDsKey
+let CBAdvertisementDataSolicitedServiceUUIDsKey        = CBMAdvertisementDataSolicitedServiceUUIDsKey
+
+let CBConnectPeripheralOptionNotifyOnConnectionKey     = CBMConnectPeripheralOptionNotifyOnConnectionKey
+let CBConnectPeripheralOptionNotifyOnDisconnectionKey  = CBMConnectPeripheralOptionNotifyOnDisconnectionKey
+let CBConnectPeripheralOptionNotifyOnNotificationKey   = CBMConnectPeripheralOptionNotifyOnNotificationKey

--- a/wxm-ios/DataLayer/DataLayer/Aliases.swift
+++ b/wxm-ios/DataLayer/DataLayer/Aliases.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+#if MOCK
 import CoreBluetoothMock
 
 // Copy this file to your project to start using CoreBluetoothMock classes
@@ -63,3 +64,4 @@ let CBAdvertisementDataSolicitedServiceUUIDsKey        = CBMAdvertisementDataSol
 let CBConnectPeripheralOptionNotifyOnConnectionKey     = CBMConnectPeripheralOptionNotifyOnConnectionKey
 let CBConnectPeripheralOptionNotifyOnDisconnectionKey  = CBMConnectPeripheralOptionNotifyOnDisconnectionKey
 let CBConnectPeripheralOptionNotifyOnNotificationKey   = CBMConnectPeripheralOptionNotifyOnNotificationKey
+#endif

--- a/wxm-ios/DataLayer/DataLayer/Mock/MockHeliumDevice.swift
+++ b/wxm-ios/DataLayer/DataLayer/Mock/MockHeliumDevice.swift
@@ -84,8 +84,6 @@ private final class HeliumDevicePeripheralSpecDelegate: CBMPeripheralSpecDelegat
 	}
 }
 
-// MARK: - Blinky Definition
-
 let mockHelium = CBMPeripheralSpec
 	.simulatePeripheral(proximity: .immediate)
 	.advertising(

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/Bluetooth/BluetoothManager.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/Bluetooth/BluetoothManager.swift
@@ -6,7 +6,11 @@
 //
 
 import Combine
+#if MOCK
 import CoreBluetoothMock
+#else
+import CoreBluetooth
+#endif
 import DomainLayer
 import Foundation
 
@@ -49,8 +53,10 @@ class BluetoothManager: NSObject {
 	override public init() {
 		state = stateSubject.eraseToAnyPublisher()
 		devices = devicesSubject.eraseToAnyPublisher()
+#if MOCK
 		CBMCentralManagerMock.simulateInitialState(.poweredOn)
 		CBMCentralManagerMock.simulatePeripherals([mockHelium])
+#endif
 		super.init()
 	}
 	
@@ -59,8 +65,11 @@ class BluetoothManager: NSObject {
 	 */
 	public func enable() {
 		if manager == nil {
+#if MOCK
 			manager = CBCentralManagerFactory.instance(delegate: self, queue: .main, forceMock: false)
-
+#else
+			manager = CBCentralManager(delegate: self, queue: .main)
+#endif
 			manager.delegate = self
 		}
 	}

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/Bluetooth/BluetoothManager.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/Bluetooth/BluetoothManager.swift
@@ -50,7 +50,7 @@ class BluetoothManager: NSObject {
 		state = stateSubject.eraseToAnyPublisher()
 		devices = devicesSubject.eraseToAnyPublisher()
 		CBMCentralManagerMock.simulateInitialState(.poweredOn)
-		CBMCentralManagerMock.simulatePeripherals([blinky])
+		CBMCentralManagerMock.simulatePeripherals([mockHelium])
 		super.init()
 	}
 	

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/Bluetooth/MockHeliumDevice.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/Bluetooth/MockHeliumDevice.swift
@@ -1,0 +1,136 @@
+//
+//  MockHeliumDevice.swift
+//  DataLayer
+//
+//  Created by Pantelis Giazitsis on 12/3/25.
+//
+
+import Foundation
+@preconcurrency import CoreBluetoothMock
+
+// MARK: - Constants
+
+extension CBMUUID {
+	nonisolated(unsafe) static let nordicBlinkyService  = CBMUUID(string: "00034729-1212-EFDE-1523-785FEABCD123")
+	nonisolated(unsafe) static let buttonCharacteristic = CBMUUID(string: "00049616-1212-EFDE-1523-785FEABCD123") // read
+	nonisolated(unsafe) static let ledCharacteristic    = CBMUUID(string: "00034729-1212-EFDE-1523-785FEABCD123") // write
+}
+
+// MARK: - Services
+
+extension CBMCharacteristicMock {
+
+	static let buttonCharacteristic = CBMCharacteristicMock(
+		type: .buttonCharacteristic,
+		properties: [.notify, .read],
+		descriptors: CBMClientCharacteristicConfigurationDescriptorMock()
+	)
+
+	static let ledCharacteristic = CBMCharacteristicMock(
+		type: .ledCharacteristic,
+		properties: [.write, .read]
+	)
+
+}
+
+extension CBMServiceMock {
+
+	static let blinkyService = CBMServiceMock(
+		type: .nordicBlinkyService,
+		primary: true,
+		characteristics:
+			.buttonCharacteristic,
+			.ledCharacteristic
+	)
+
+}
+
+// MARK: - Blinky Implementation
+
+/// The delegate implements the behavior of the mocked device.
+private class BlinkyCBMPeripheralSpecDelegate: CBMPeripheralSpecDelegate {
+
+	// MARK: States
+
+	/// State of the LED.
+	private var ledEnabled: Bool = false
+	/// State of the Button.
+	private var buttonPressed: Bool = false
+
+	// MARK: Encoders
+
+	/// LED state encoded as Data.
+	///
+	/// - 0x01 - LED is ON.
+	/// - 0x00 - LED is OFF.
+	private var ledData: Data {
+		return ledEnabled ? Data([0x01]) : Data([0x00])
+	}
+
+	/// Button state encoded as Data.
+	///
+	/// - 0x01 - Button is pressed.
+	/// - 0x00 - Button is released.
+	private var buttonData: Data {
+		return buttonPressed ? Data([0x01]) : Data([0x00])
+	}
+
+	// MARK: Event handlers
+
+	func reset() {
+		ledEnabled = false
+		buttonPressed = false
+	}
+
+	func peripheral(_ peripheral: CBMPeripheralSpec,
+					didReceiveReadRequestFor characteristic: CBMCharacteristicMock)
+			-> Result<Data, Error> {
+		if characteristic.uuid == .ledCharacteristic {
+			return .success(ledData)
+		} else {
+			return .success(buttonData)
+		}
+	}
+
+	func peripheral(_ peripheral: CBMPeripheralSpec,
+					didReceiveWriteRequestFor characteristic: CBMCharacteristicMock,
+					data: Data) -> Result<Void, Error> {
+		if data.count > 0 {
+			ledEnabled = data[0] != 0x00
+		}
+		peripheral.simulateValueUpdate(Data(), for: characteristic)
+		return .success(())
+	}
+}
+
+// MARK: - Blinky Definition
+
+/// This device will advertise with 2 different types of packets, as nRF Blinky and an iBeacon (with a name).
+/// As iOS prunes the iBeacon manufacturer data, only the name is available.
+let blinky = CBMPeripheralSpec
+	.simulatePeripheral(proximity: .immediate)
+	.advertising(
+		advertisementData: [
+			CBAdvertisementDataIsConnectable : true as NSNumber,
+			CBAdvertisementDataLocalNameKey : "WXMDevice"
+		],
+		withInterval: 2.0,
+		delay: 5.0,
+		alsoWhenConnected: false
+	)
+	.advertising(
+		advertisementData: [
+			CBAdvertisementDataIsConnectable : false as NSNumber,
+			CBAdvertisementDataLocalNameKey : "WXMDevice",
+			//CBAdvertisementDataManufacturerDataKey:
+		],
+		withInterval: 4.0,
+		delay: 2.0,
+		alsoWhenConnected: false
+	)
+	.connectable(
+		name: "nRF Blinky",
+		services: [.blinkyService],
+		delegate: BlinkyCBMPeripheralSpecDelegate()
+	)
+	.build()


### PR DESCRIPTION
## **Why?**
Integrated [CoreBluetoothMock](https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock) library to mock the bluetooth functionality 
### **How?**
CoreBluetoothMock is a wrapper on the CoreBluetooth framework that overrides the core functionality.
We use the mock library  only for the mock scheme.
### **Testing**
The devices list in the claim helium process should be:
- Empty in simulator (bluetooth is off)
- As expected on real device
- Show only one device ("WXMDevice") in the mock scheme 
### **Additional context**
This is an integration PR. The unit tests will be implemented in the future.
fixes fe-1633
