### PR TITLE
Add parameter to add station photo

### DIFF
--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
@@ -61,7 +61,8 @@ class GalleryViewModel: ObservableObject {
 			self?.images.append(imageUrl)
 			self?.selectedImage = self?.images.last
 
-			WXMAnalytics.shared.trackEvent(.userAction, parameters: [.actionName: .addStationPhoto])
+			WXMAnalytics.shared.trackEvent(.userAction, parameters: [.actionName: .addStationPhoto,
+																	 .action: .completed])
 		}
 		return picker
 	}()
@@ -80,6 +81,9 @@ class GalleryViewModel: ObservableObject {
 	}
 
 	func handlePlusButtonTap() {
+		WXMAnalytics.shared.trackEvent(.userAction, parameters: [.actionName: .addStationPhoto,
+																 .action: .started])
+
 		guard images.count < maxPhotosCount else {
 			if let text = LocalizableString.PhotoVerification.maxLimitPhotosInfo(maxPhotosCount).localized.attributedMarkdown {
 				Toast.shared.show(text: text, type: .info, visibleDuration: 5.0)

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
@@ -463,6 +463,10 @@ extension ParameterValue: RawRepresentable {
 				return "Uploading Photos Success"
 			case .goToPhotoVerification:
 				return "Go To Photo Verification"
+			case .started:
+				return "started"
+			case .completed:
+				return "completed"
 		}
 	}
 }

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
@@ -311,5 +311,7 @@ public enum ParameterValue {
 	case startUploadingPhotos
 	case uploadingPhotosSuccess
 	case goToPhotoVerification
+	case started
+	case completed
 	case custom(String)
 }


### PR DESCRIPTION
## **Why?**
Added `action` parameter in `Add Station Photo` event
### **How?**
Track `stated` action on add button tap and `completed` once a photo is added in the gallery 
### **Testing**
Ensure the events are tracked as expected
### **Additional context**
fixes fe-1709


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the tracking of photo addition actions by capturing both the initiation and completion stages. This improvement provides more detailed insights into the photo upload process, contributing to a smoother verification experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->