### PR TITLE
Pro promotion analytics events

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/Announcement/ProPromotional/ProBannerView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/Announcement/ProPromotional/ProBannerView.swift
@@ -6,9 +6,11 @@
 //
 
 import SwiftUI
+import Toolkit
 
 struct ProBannerView: View {
 	let description: String
+	let analyticsSource: ParameterValue
 
     var body: some View {
 		HStack(spacing: CGFloat(.mediumSpacing)) {
@@ -29,6 +31,9 @@ struct ProBannerView: View {
 
 			Spacer()
 			Button {
+				WXMAnalytics.shared.trackEvent(.selectContent,
+											   parameters: [.source: analyticsSource])
+				
 				Router.shared.showBottomSheet(.proPromo(ViewModelsFactory.getProPromotionalViewModel()))
 			} label: {
 				Text(LocalizableString.Promotional.getPro.localized)
@@ -44,5 +49,6 @@ struct ProBannerView: View {
 }
 
 #Preview {
-	ProBannerView(description: LocalizableString.Promotional.wantMoreAccurateForecast.localized)
+	ProBannerView(description: LocalizableString.Promotional.wantMoreAccurateForecast.localized,
+				  analyticsSource: .localForecast)
 }

--- a/PresentationLayer/UIComponents/BaseComponents/Announcement/ProPromotional/ProPromotionalViewModel.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/Announcement/ProPromotional/ProPromotionalViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Toolkit
 
 @MainActor
 class ProPromotionalViewModel: ObservableObject {
@@ -18,6 +19,9 @@ class ProPromotionalViewModel: ObservableObject {
 
 	func handleLearnMoreTapped() {
 		HelperFunctions().openUrl(DisplayedLinks.weatherXMPro.linkURL)
+
+		WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .learnMore,
+																	.itemId: .proPromotion])
 	}
 }
 

--- a/PresentationLayer/UIComponents/Screens/ExplorerStationsList/ExplorerStationsListView.swift
+++ b/PresentationLayer/UIComponents/Screens/ExplorerStationsList/ExplorerStationsListView.swift
@@ -54,7 +54,8 @@ private struct ContentView: View {
 
 				ScrollView {
 					VStack(spacing: 0.0) {
-						ProBannerView(description: LocalizableString.Promotional.getHyperlocalForecasts.localized)
+						ProBannerView(description: LocalizableString.Promotional.getHyperlocalForecasts.localized,
+									  analyticsSource: .localCell)
 							.padding(.top, CGFloat(.defaultSpacing))
 							.padding(.horizontal, CGFloat(.defaultSpacing))
 

--- a/PresentationLayer/UIComponents/Screens/ForecastDetails/Components/ForecastDetailsDailyView.swift
+++ b/PresentationLayer/UIComponents/Screens/ForecastDetails/Components/ForecastDetailsDailyView.swift
@@ -16,7 +16,8 @@ struct ForecastDetailsDailyView: View {
 		VStack(spacing: CGFloat(.largeSpacing)) {
 			dailyConditions
 
-			ProBannerView(description: LocalizableString.Promotional.wantMoreAccurateForecast.localized)
+			ProBannerView(description: LocalizableString.Promotional.wantMoreAccurateForecast.localized,
+						  analyticsSource: .localForecastDetails)
 
 			hourlyForecast
 

--- a/PresentationLayer/UIComponents/Screens/HistoryScreen/HistoryView/HistoryView.swift
+++ b/PresentationLayer/UIComponents/Screens/HistoryScreen/HistoryView/HistoryView.swift
@@ -20,7 +20,8 @@ struct HistoryView: View {
 			} content: {
 				Group {
 					VStack(spacing: CGFloat(.largeSpacing)) {
-						ProBannerView(description: LocalizableString.Promotional.unlockFullWeather.localized)
+						ProBannerView(description: LocalizableString.Promotional.unlockFullWeather.localized,
+									  analyticsSource: .localHistory)
 
 						if let historyData = viewModel.currentHistoryData, !historyData.isEmpty() {
 							ChartsContainer(historyData: historyData,

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsView.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsView.swift
@@ -51,7 +51,8 @@ private extension NetworkStatsView {
                 rewardsView
                 buyStationView
                 tokenView
-				ProBannerView(description: LocalizableString.Promotional.wantMoreAccurateForecast.localized)
+				ProBannerView(description: LocalizableString.Promotional.wantMoreAccurateForecast.localized,
+							  analyticsSource: .localNetworkStats)
                 weatherStationsView
                 manufacturerView
                 lastUpdatedView

--- a/PresentationLayer/UIComponents/Screens/Profile/ProfileView.swift
+++ b/PresentationLayer/UIComponents/Screens/Profile/ProfileView.swift
@@ -77,7 +77,8 @@ private struct ContentView: View {
 				}
 			}
 
-			ProBannerView(description: LocalizableString.Promotional.takeYourWeatherInsights.localized)
+			ProBannerView(description: LocalizableString.Promotional.takeYourWeatherInsights.localized,
+						  analyticsSource: .localProfile)
 		}
 		.padding(CGFloat(.defaultSidePadding))
 		.animation(.easeIn, value: viewModel.surveyConfiguration != nil)

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
@@ -89,7 +89,7 @@ public final class WeatherStationsHomeViewModel: ObservableObject {
 
 				WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.itemId: .announcementActionUrl,
 																			.source: .remoteDevicesList])
-				
+
 				let handled = self?.mainVM?.deepLinkHandler.handleUrl(url) ?? false
 				if !handled, url.isHttp {
 					HelperFunctions().openUrl(urlString)

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
@@ -87,6 +87,9 @@ public final class WeatherStationsHomeViewModel: ObservableObject {
 					return
 				}
 
+				WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.itemId: .announcementActionUrl,
+																			.source: .remoteDevicesList])
+				
 				let handled = self?.mainVM?.deepLinkHandler.handleUrl(url) ?? false
 				if !handled, url.isHttp {
 					HelperFunctions().openUrl(urlString)

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
@@ -87,7 +87,7 @@ public final class WeatherStationsHomeViewModel: ObservableObject {
 					return
 				}
 
-				WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.itemId: .announcementActionUrl,
+				WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.itemId: .custom(urlString),
 																			.source: .remoteDevicesList])
 
 				let handled = self?.mainVM?.deepLinkHandler.handleUrl(url) ?? false

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Forecast/StationForecastView.swift
@@ -26,7 +26,8 @@ struct StationForecastView: View {
 
 						hourlyView
 
-						ProBannerView(description: LocalizableString.Promotional.fineTuneForecast.localized)
+						ProBannerView(description: LocalizableString.Promotional.fineTuneForecast.localized,
+									  analyticsSource: .localForecast)
 							.padding(.horizontal)
 
 						VStack(spacing: CGFloat(.mediumSpacing)) {

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -88,10 +88,10 @@
 		264813FE2D8D7CF000BCCC31 /* ProPromotionalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264813FD2D8D7CF000BCCC31 /* ProPromotionalView.swift */; };
 		264814002D8D7D2900BCCC31 /* ProPromotionalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264813FF2D8D7D2900BCCC31 /* ProPromotionalViewModel.swift */; };
 		264814022D8D7F7100BCCC31 /* LocalizableString+Promotional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264814012D8D7F6500BCCC31 /* LocalizableString+Promotional.swift */; };
+		264814042D8DA68C00BCCC31 /* ProBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264814032D8DA68C00BCCC31 /* ProBannerView.swift */; };
 		264814212D942B2300BCCC31 /* BTUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2648141F2D942B2300BCCC31 /* BTUtils.swift */; };
 		264814222D942B2300BCCC31 /* BluetoothManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2648141D2D942B2300BCCC31 /* BluetoothManagerTests.swift */; };
 		264814232D942B2300BCCC31 /* BTActionWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2648141E2D942B2300BCCC31 /* BTActionWrapperTests.swift */; };
-		264814042D8DA68C00BCCC31 /* ProBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264814032D8DA68C00BCCC31 /* ProBannerView.swift */; };
 		264CC7472B975D450060DEA4 /* rocket_dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 264CC7462B975D450060DEA4 /* rocket_dark.json */; };
 		264CC7602B9872D40060DEA4 /* RewardBoostsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264CC75F2B9872D40060DEA4 /* RewardBoostsView.swift */; };
 		264CC7622B9872E40060DEA4 /* RewardBoostsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264CC7612B9872E40060DEA4 /* RewardBoostsViewModel.swift */; };
@@ -776,10 +776,10 @@
 		264813FD2D8D7CF000BCCC31 /* ProPromotionalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProPromotionalView.swift; sourceTree = "<group>"; };
 		264813FF2D8D7D2900BCCC31 /* ProPromotionalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProPromotionalViewModel.swift; sourceTree = "<group>"; };
 		264814012D8D7F6500BCCC31 /* LocalizableString+Promotional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalizableString+Promotional.swift"; sourceTree = "<group>"; };
+		264814032D8DA68C00BCCC31 /* ProBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProBannerView.swift; sourceTree = "<group>"; };
 		2648141D2D942B2300BCCC31 /* BluetoothManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothManagerTests.swift; sourceTree = "<group>"; };
 		2648141E2D942B2300BCCC31 /* BTActionWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTActionWrapperTests.swift; sourceTree = "<group>"; };
 		2648141F2D942B2300BCCC31 /* BTUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTUtils.swift; sourceTree = "<group>"; };
-		264814032D8DA68C00BCCC31 /* ProBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProBannerView.swift; sourceTree = "<group>"; };
 		264CC7462B975D450060DEA4 /* rocket_dark.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rocket_dark.json; sourceTree = "<group>"; };
 		264CC75F2B9872D40060DEA4 /* RewardBoostsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardBoostsView.swift; sourceTree = "<group>"; };
 		264CC7612B9872E40060DEA4 /* RewardBoostsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardBoostsViewModel.swift; sourceTree = "<group>"; };

--- a/wxm-ios.xcodeproj/xcshareddata/xcschemes/wxm-ios.xcscheme
+++ b/wxm-ios.xcodeproj/xcshareddata/xcschemes/wxm-ios.xcscheme
@@ -104,7 +104,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-WXMAnalyticsDisabled YES"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
       <LocationScenarioReference

--- a/wxm-ios.xcodeproj/xcshareddata/xcschemes/wxm-ios.xcscheme
+++ b/wxm-ios.xcodeproj/xcshareddata/xcschemes/wxm-ios.xcscheme
@@ -104,7 +104,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-WXMAnalyticsDisabled YES"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
       <LocationScenarioReference

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
@@ -457,6 +457,26 @@ extension ParameterValue: RawRepresentable {
 				return "started"
 			case .completed:
 				return "completed"
+			case .proPromotionCTA:
+				return "Pro Promotion CTA"
+			case .announcementActionUrl:
+				return "announcement_action_url"
+			case .remoteDevicesList:
+				return "remote_devices_list"
+			case .localForecast:
+				return "local_forecast"
+			case .localForecastDetails:
+				return "local_forecast_details"
+			case .localHistory:
+				return "local_history"
+			case .localCell:
+				return "local_cell"
+			case .localProfile:
+				return "local_profile"
+			case .localNetworkStats:
+				return "local_network_stats"
+			case .bottomSheet:
+				return "bottom_sheet"
 		}
 	}
 }

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
@@ -459,8 +459,6 @@ extension ParameterValue: RawRepresentable {
 				return "completed"
 			case .proPromotionCTA:
 				return "Pro Promotion CTA"
-			case .announcementActionUrl:
-				return "announcement_action_url"
 			case .remoteDevicesList:
 				return "remote_devices_list"
 			case .localForecast:

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
@@ -475,8 +475,8 @@ extension ParameterValue: RawRepresentable {
 				return "local_profile"
 			case .localNetworkStats:
 				return "local_network_stats"
-			case .bottomSheet:
-				return "bottom_sheet"
+			case .proPromotion:
+				return "pro_promotion"
 		}
 	}
 }

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
@@ -311,7 +311,6 @@ public enum ParameterValue {
 	case started
 	case completed
 	case proPromotionCTA
-	case announcementActionUrl
 	case remoteDevicesList
 	case localForecast
 	case localForecastDetails

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
@@ -310,5 +310,15 @@ public enum ParameterValue {
 	case goToPhotoVerification
 	case started
 	case completed
+	case proPromotionCTA
+	case announcementActionUrl
+	case remoteDevicesList
+	case localForecast
+	case localForecastDetails
+	case localHistory
+	case localCell
+	case localProfile
+	case localNetworkStats
+	case bottomSheet
 	case custom(String)
 }

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
@@ -319,6 +319,6 @@ public enum ParameterValue {
 	case localCell
 	case localProfile
 	case localNetworkStats
-	case bottomSheet
+	case proPromotion
 	case custom(String)
 }


### PR DESCRIPTION
## **Why?**
The necessary events to track for the feature
### **Testing**
Ensure the events are tracked properly.
Don't forget to uncheck the `WXMAnalyticsDisabled` launch argument 
### **Additional context**
fixes fe-1723


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced promotional components with improved analytics tracking of user interactions across various screens.
  - Promotional elements now support configurable tracking sources, enabling more detailed engagement reporting.

- **Chores**
  - Expanded the analytics framework to include new tracking parameters, offering finer granularity in usage insights:
    - Added new analytics cases: `.proPromotionCTA`, `.remoteDevicesList`, `.localForecast`, `.localForecastDetails`, `.localHistory`, `.localCell`, `.localProfile`, `.localNetworkStats`, and `.proPromotion`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->