### PR TITLE
Feature/fe 1760 station photo verification instagram throws an error

### DIFF
--- a/PresentationLayer/UIComponents/Modifiers/WXMShareModifier.swift
+++ b/PresentationLayer/UIComponents/Modifiers/WXMShareModifier.swift
@@ -99,9 +99,11 @@ private extension WXMShareModifier {
 
 	class ShareFileItemSource: NSObject, UIActivityItemSource {
 		let image: UIImage
+		let url: URL?
 
 		init(image: UIImage) {
 			self.image = image
+			url = image.saveWithName("share_\(UUID().uuidString)", tempDirectory: true)
 		}
 
 		func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
@@ -109,7 +111,7 @@ private extension WXMShareModifier {
 		}
 		
 		func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
-			image
+			url
 		}
 
 		func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {

--- a/PresentationLayer/UIComponents/Modifiers/WXMShareModifier.swift
+++ b/PresentationLayer/UIComponents/Modifiers/WXMShareModifier.swift
@@ -44,6 +44,10 @@ private struct WXMShareModifier: ViewModifier {
 			activityController.popoverPresentationController?.permittedArrowDirections = []
 		}
 		activityController.delegate = self
+		activityController.completionWithItemsHandler = { [items] _, completed, _, _ in
+			guard completed else { return }
+			cleanup(items: items.compactMap { $0 as? ShareFileItemSource })
+		}
 		hostingWrapper.hostingController = activityController
 		UIApplication.shared.rootViewController?.present(activityController, animated: true)
 	}
@@ -60,6 +64,10 @@ extension WXMShareModifier:  WXMShareModifier.WXMActivityViewControllerDelegate 
 }
 
 private extension WXMShareModifier {
+	func cleanup(items: [ShareFileItemSource]?) {
+		items?.forEach { $0.url?.deleteFile() }
+	}
+
 	@MainActor
 	struct Store {
 		var anchorView = UIView()

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -88,10 +88,10 @@
 		264813FE2D8D7CF000BCCC31 /* ProPromotionalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264813FD2D8D7CF000BCCC31 /* ProPromotionalView.swift */; };
 		264814002D8D7D2900BCCC31 /* ProPromotionalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264813FF2D8D7D2900BCCC31 /* ProPromotionalViewModel.swift */; };
 		264814022D8D7F7100BCCC31 /* LocalizableString+Promotional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264814012D8D7F6500BCCC31 /* LocalizableString+Promotional.swift */; };
+		264814042D8DA68C00BCCC31 /* ProBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264814032D8DA68C00BCCC31 /* ProBannerView.swift */; };
 		264814212D942B2300BCCC31 /* BTUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2648141F2D942B2300BCCC31 /* BTUtils.swift */; };
 		264814222D942B2300BCCC31 /* BluetoothManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2648141D2D942B2300BCCC31 /* BluetoothManagerTests.swift */; };
 		264814232D942B2300BCCC31 /* BTActionWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2648141E2D942B2300BCCC31 /* BTActionWrapperTests.swift */; };
-		264814042D8DA68C00BCCC31 /* ProBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264814032D8DA68C00BCCC31 /* ProBannerView.swift */; };
 		264CC7472B975D450060DEA4 /* rocket_dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 264CC7462B975D450060DEA4 /* rocket_dark.json */; };
 		264CC7602B9872D40060DEA4 /* RewardBoostsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264CC75F2B9872D40060DEA4 /* RewardBoostsView.swift */; };
 		264CC7622B9872E40060DEA4 /* RewardBoostsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264CC7612B9872E40060DEA4 /* RewardBoostsViewModel.swift */; };
@@ -776,10 +776,10 @@
 		264813FD2D8D7CF000BCCC31 /* ProPromotionalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProPromotionalView.swift; sourceTree = "<group>"; };
 		264813FF2D8D7D2900BCCC31 /* ProPromotionalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProPromotionalViewModel.swift; sourceTree = "<group>"; };
 		264814012D8D7F6500BCCC31 /* LocalizableString+Promotional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalizableString+Promotional.swift"; sourceTree = "<group>"; };
+		264814032D8DA68C00BCCC31 /* ProBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProBannerView.swift; sourceTree = "<group>"; };
 		2648141D2D942B2300BCCC31 /* BluetoothManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothManagerTests.swift; sourceTree = "<group>"; };
 		2648141E2D942B2300BCCC31 /* BTActionWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTActionWrapperTests.swift; sourceTree = "<group>"; };
 		2648141F2D942B2300BCCC31 /* BTUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTUtils.swift; sourceTree = "<group>"; };
-		264814032D8DA68C00BCCC31 /* ProBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProBannerView.swift; sourceTree = "<group>"; };
 		264CC7462B975D450060DEA4 /* rocket_dark.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rocket_dark.json; sourceTree = "<group>"; };
 		264CC75F2B9872D40060DEA4 /* RewardBoostsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardBoostsView.swift; sourceTree = "<group>"; };
 		264CC7612B9872E40060DEA4 /* RewardBoostsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardBoostsViewModel.swift; sourceTree = "<group>"; };

--- a/wxm-ios/Toolkit/Toolkit/Utils/FoundationExtensions.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/FoundationExtensions.swift
@@ -176,6 +176,10 @@ public extension URL {
 		return url.queryItems?.reduce(into: [:]) { $0[$1.name] = $1.value }
 	}
 
+	func deleteFile() {
+		try? FileManager.default.removeItem(at: self)
+	}
+
 	mutating func appendQueryItem(name: String, value: String?) {
 		guard var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: true) else {
 			return

--- a/wxm-ios/Toolkit/Toolkit/Utils/FoundationExtensions.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/FoundationExtensions.swift
@@ -195,6 +195,10 @@ public extension FileManager {
 		let urls = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
 		return urls.first
 	}
+
+	static var tempDirectory: URL? {
+		FileManager.default.temporaryDirectory		
+	}
 }
 
 public extension Int {

--- a/wxm-ios/Toolkit/Toolkit/Utils/UIImage+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/UIImage+.swift
@@ -9,13 +9,13 @@ import Foundation
 import UIKit
 
 public extension UIImage {
-	func saveWithName(_ name: String) -> URL? {
-		guard let documentsDirectory = FileManager.documentsDirectory,
+	func saveWithName(_ name: String, tempDirectory: Bool = false) -> URL? {
+		guard let directory = tempDirectory ? FileManager.tempDirectory : FileManager.documentsDirectory,
 			  let data = self.pngData() else {
 			return nil
 		}
 
-		let filename = documentsDirectory.appendingPathComponent(name)
+		let filename = directory.appendingPathComponent(name).appendingPathExtension(for: .png)
 		try? data.write(to: filename)
 		
 		return filename


### PR DESCRIPTION
## **Why?**
There were issues when sharing photos with some apps (eg. Instagram). 
### **How?**
Instead of passing to `UIImage`s to the `UIActivityViewController`, we save each image in the `temp` folder and pass the file urls
### **Testing**
Ensure nothing is broken when sharing photos and if you have an Instagram account, try on it
### **Additional context**
Fixes fe-1760


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced sharing: Completed shares now trigger an automatic cleanup of temporary content, ensuring a more streamlined experience.
  - New promotional banner: A dedicated view highlights special offers.
  - Flexible image saving: Users can opt to save images in a temporary location or a standard storage area.
  - Improved file management: Upgraded utilities now support efficient file deletion and smoother temporary file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->