### PR TITLE
Fixed force logout on request timeout

### DIFF
--- a/wxm-ios/DataLayer/DataLayer/Networking/Interceptors/AuthInterceptor.swift
+++ b/wxm-ios/DataLayer/DataLayer/Networking/Interceptors/AuthInterceptor.swift
@@ -29,13 +29,19 @@ class AuthInterceptor: @unchecked Sendable, RequestInterceptor {
     }
 
     func retry(_ request: Request, for _: Session, dueTo _: Error, completion: @escaping (RetryResult) -> Void) {
-        let networkTokenResponse = keychainHelperService.getNetworkTokenResponse()
-        guard let refreshToken = networkTokenResponse?.refreshToken, let statusCode = request.response?.statusCode else {
+		guard  let statusCode = request.response?.statusCode else {
+			completion(.doNotRetry)
+			return
+		}
+
+		let networkTokenResponse = keychainHelperService.getNetworkTokenResponse()
+        guard let refreshToken = networkTokenResponse?.refreshToken else {
             completion(.doNotRetry)
 			NotificationCenter.default.post(name: .AuthRefreshTokenExpired, object: nil)
-            return
+			return
         }
-        switch statusCode {
+
+		switch statusCode {
             case 200 ... 299:
                 completion(.doNotRetry)
             case 401:


### PR DESCRIPTION
## **Why?**
The problem occurred when an authenticated request was timed out
### **How?**
Differentiate the case of time out and missing stored access token in `AuthInterceptor` 
### **Testing**
Simulate bad network -> wait until an api request is failed (eg. retry screen in home) -> move network back to normal -> tap retry button -> ensure the user is still logged in
To simulate network conditions, download the "Additional Tools" from [here](https://developer.apple.com/download/all/) and install the "Network Link Conditioner" from the hardware folder.
Then enable or disable it from Mac system settings
<img width="600" alt="Screenshot 2025-03-28 at 15 23 22" src="https://github.com/user-attachments/assets/bd1c6ca1-ec5d-44ad-b22d-1ff62cb9ec7a" />

### **Additional context**
fixes fe-1763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the authentication workflow by streamlining error validation, ensuring quicker and more efficient handling of response issues.
	- Improved the robustness of token management, ultimately contributing to a more stable and responsive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->