### PR TITLE
Upload from gallery

### DIFF
--- a/PresentationLayer/Constants/FontsEnum.swift
+++ b/PresentationLayer/Constants/FontsEnum.swift
@@ -8,82 +8,83 @@
 import SwiftUI
 
 enum FontAwesome: String {
-    case FAPro = "FontAwesome6Pro-Regular"
-    case FAProLight = "FontAwesome6Pro-Light"
-    case FAProSolid = "FontAwesome6Pro-Solid"
-    case FAProThin = "FontAwesome6Pro-Thin"
-    case FADuotone = "FontAwesome6Duotone-Solid"
-    case FASharp = "FontAwesome6Sharp-Regular"
-    case FASharpSolid = "FontAwesome6Sharp-Solid"
-    case FABrands = "FontAwesome6Brands-Regular"
+	case FAPro = "FontAwesome6Pro-Regular"
+	case FAProLight = "FontAwesome6Pro-Light"
+	case FAProSolid = "FontAwesome6Pro-Solid"
+	case FAProThin = "FontAwesome6Pro-Thin"
+	case FADuotone = "FontAwesome6Duotone-Solid"
+	case FASharp = "FontAwesome6Sharp-Regular"
+	case FASharpSolid = "FontAwesome6Sharp-Solid"
+	case FABrands = "FontAwesome6Brands-Regular"
 }
 
 extension Font {
-    static func fontAwesome(font: FontAwesome, size: CGFloat) -> Font {
-        return .custom(font.rawValue, size: size)
-    }
+	static func fontAwesome(font: FontAwesome, size: CGFloat) -> Font {
+		return .custom(font.rawValue, size: size)
+	}
 }
 
 enum FontIcon: String {
-    case locationDot = "location-dot"
-    case gear
+	case arrowLeft = "arrow-left"
+	case arrowsRotate = "arrows-rotate"
+	case badgeCheck = "badge-check"
+	case barcode
+	case barsFilter = "bars-filter"
+	case batteryLow = "battery-low"
+	case calendar
+	case cart = "cart-shopping"
+	case chartSimple = "chart-simple"
+	case check
+	case chevronDown = "chevron-down"
+	case chevronRight = "chevron-right"
+	case chevronUp = "chevron-up"
+	case circleCheck = "circle-check"
+	case circleFour = "circle-4"
+	case circleOne = "circle-1"
+	case circleSmall = "circle-small"
+	case circleThree = "circle-3"
+	case circleTwo = "circle-2"
+	case circleXmark = "circle-xmark"
+	case close
+	case cog
+	case coins
+	case cloudShowers = "cloud-showers"
+	case dropletDegree = "droplet-degree"
+	case envelope
+	case externalLink = "arrow-up-right-from-square"
+	case eye
+	case eyeSlash = "eye-slash"
+	case faceSadCry = "face-sad-cry"
+	case gauge
+	case gear
 	case gem
-    case threeDots = "ellipsis-vertical"
-    case infoCircle = "info-circle"
-    case externalLink = "arrow-up-right-from-square"
-    case home = "home"
-    case hexagon
+	case heart
+	case hexagon
 	case hexagonCheck = "hexagon-check"
 	case hexagonExclamation = "hexagon-exclamation"
 	case hexagonXmark = "hexagon-xmark"
-    case share = "share-nodes"
-    case heart
-    case lock
-    case calendar
-	case check
-	case circleCheck = "circle-check"
-	case circleXmark = "circle-xmark"
-	case xmark
-    case sliders
-	case barsFilter = "bars-filter"
-	case pointUp = "hand-back-point-up"
-	case badgeCheck = "badge-check"
-	case triangleExclamation = "triangle-exclamation"
-	case sparkles
-	case trash
-	case cog
-	case coins
-	case wallet
-	case cart = "cart-shopping"
-	case circleOne = "circle-1"
-	case circleTwo = "circle-2"
-	case circleThree = "circle-3"
-	case circleFour = "circle-4"
-	case circleSmall = "circle-small"
-	case qrcode
-	case barcode
-	case split
-	case close
-	case chevronRight = "chevron-right"
-	case chevronUp = "chevron-up"
-	case chevronDown = "chevron-down"
-	case faceSadCry = "face-sad-cry"
-	case rotateRight = "rotate-right"
-	case temperatureThreeQuarters = "temperature-three-quarters"
-	case umbrella
-	case cloudShowers = "cloud-showers"
-	case locationArrow = "location-arrow"
+	case home
 	case humidity
-	case gauge
-	case sun
-	case dropletDegree = "droplet-degree"
-	case arrowsRotate = "arrows-rotate"
-	case arrowLeft = "arrow-left"
-	case batteryLow = "battery-low"
-	case chartSimple = "chart-simple"
-	case eye
-	case eyeSlash = "eye-slash"
-	case envelope
-	case user
+	case image
+	case infoCircle = "info-circle"
+	case locationArrow = "location-arrow"
+	case locationDot = "location-dot"
+	case lock
 	case plus = "plus-large"
+	case pointUp = "hand-back-point-up"
+	case qrcode
+	case rotateRight = "rotate-right"
+	case share = "share-nodes"
+	case sliders
+	case sparkles
+	case split
+	case sun
+	case temperatureThreeQuarters = "temperature-three-quarters"
+	case threeDots = "ellipsis-vertical"
+	case trash
+	case triangleExclamation = "triangle-exclamation"
+	case umbrella
+	case user
+	case wallet
+	case xmark
 }

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
@@ -102,7 +102,7 @@ struct GalleryView: View {
 					VStack(spacing: CGFloat(.largeSpacing)) {
 						galleryScroller
 
-						HStack {
+						HStack(spacing: CGFloat(.defaultSpacing)) {
 							Button {
 								viewModel.handleDeleteButtonTap()
 							} label: {
@@ -114,6 +114,17 @@ struct GalleryView: View {
 							}
 							.buttonStyle(WXMButtonOpacityStyle())
 							.disabled(viewModel.selectedImage == nil)
+
+							Button {
+								viewModel.handleGalleryButtonTap()
+							} label: {
+								Text(FontIcon.image.rawValue)
+									.font(.fontAwesome(font: .FAProSolid, size: CGFloat(.smallTitleFontSize)))
+									.foregroundStyle(Color(colorEnum: .text))
+									.padding(CGFloat(.mediumSidePadding))
+									.background(Circle().fill(Color(colorEnum: .layer1)))
+							}
+							.buttonStyle(WXMButtonOpacityStyle())
 
 							Spacer()
 

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
@@ -170,9 +170,18 @@ struct GalleryView: View {
 }
 
 extension GalleryView {
-	enum ImageSource: String {
+	enum ImageSource {
 		case camera
 		case library
+
+		var sourceValue: String {
+			switch self {
+				case .camera:
+					return "wxm-device-photo-camera"
+				case .library:
+					return "wxm-device-photo-library"
+			}
+		}
 	}
 
 	struct GalleryImage: Identifiable, Equatable {

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
@@ -170,10 +170,16 @@ struct GalleryView: View {
 }
 
 extension GalleryView {
+	enum ImageSource: String {
+		case camera
+		case library
+	}
+
 	struct GalleryImage: Identifiable, Equatable {
 		let remoteUrl: String?
 		let uiImage: UIImage?
 		let metadata: NSDictionary?
+		let source: ImageSource?
 
 		var id: String {
 			remoteUrl ?? "\(uiImage.hashValue)"

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
@@ -151,7 +151,10 @@ class GalleryViewModel: ObservableObject {
 				do {
 					self.showLoading = true
 					try self.useCase.clearLocalImages(deviceId: self.deviceId)
-					let fileUrls = await localImages.asyncCompactMap { try? await self.useCase.saveImage($0.uiImage!, deviceId: self.deviceId, metadata: $0.metadata)}
+					let fileUrls = await localImages.asyncCompactMap { try? await self.useCase.saveImage($0.uiImage!,
+																										 deviceId: self.deviceId,
+																										 metadata: $0.metadata,
+																										 userComment: $0.source?.rawValue ?? "")}
 					try await self.useCase.startFilesUpload(deviceId: self.deviceId, files: fileUrls.compactMap { try? $0.asURL() })
 					self.showLoading = false
 					self.showUploadStarted { dismissAction?() }

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
@@ -154,7 +154,7 @@ class GalleryViewModel: ObservableObject {
 					let fileUrls = await localImages.asyncCompactMap { try? await self.useCase.saveImage($0.uiImage!,
 																										 deviceId: self.deviceId,
 																										 metadata: $0.metadata,
-																										 userComment: $0.source?.rawValue ?? "")}
+																										 userComment: $0.source?.sourceValue ?? "")}
 					try await self.useCase.startFilesUpload(deviceId: self.deviceId, files: fileUrls.compactMap { try? $0.asURL() })
 					self.showLoading = false
 					self.showUploadStarted { dismissAction?() }

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryViewModel.swift
@@ -81,7 +81,7 @@ class GalleryViewModel: ObservableObject {
 		 linkNavigation: LinkNavigation = LinkNavigationHelper()) {
 		self.deviceId = deviceId
 		self.useCase = photoGalleryUseCase
-		self.images = images.map { GalleryView.GalleryImage(remoteUrl: $0, uiImage: nil, metadata: nil) }
+		self.images = images.map { GalleryView.GalleryImage(remoteUrl: $0, uiImage: nil, metadata: nil, source: nil) }
 		self.isNewPhotoVerification = isNewPhotoVerification
 		self.linkNavigator = linkNavigation
 		selectedImage = self.images.last
@@ -233,7 +233,7 @@ private class ImagePickerDelegate: NSObject, UIImagePickerControllerDelegate, UI
 		let metadata = info[.mediaMetadata] as? NSDictionary
 		Task { @MainActor in
 			if let image = info[.originalImage] as? UIImage {
-				imageCallback?([GalleryView.GalleryImage(remoteUrl: nil, uiImage: image, metadata: metadata)])
+				imageCallback?([GalleryView.GalleryImage(remoteUrl: nil, uiImage: image, metadata: metadata, source: .camera)])
 			}
 		}
 
@@ -265,7 +265,7 @@ private class ImagePickerDelegate: NSObject, UIImagePickerControllerDelegate, UI
 				let imgSrc = CGImageSourceCreateWithData(data as CFData, options as CFDictionary)
 				let metadata = CGImageSourceCopyPropertiesAtIndex(imgSrc!, 0, options as CFDictionary)
 				if let image = UIImage(data: data) {
-					images.append(GalleryView.GalleryImage(remoteUrl: nil, uiImage: image, metadata: metadata))
+					images.append(GalleryView.GalleryImage(remoteUrl: nil, uiImage: image, metadata: metadata, source: .library))
 				}
 			}
 		}

--- a/WeatherXMTests/DataLayer/RepositoryImplementations/BluetoothDevicesRepositoryImplTests.swift
+++ b/WeatherXMTests/DataLayer/RepositoryImplementations/BluetoothDevicesRepositoryImplTests.swift
@@ -9,7 +9,7 @@ import Testing
 @testable import DataLayer
 import Toolkit
 
-@Suite(.serialized)
+@Suite(.serialized, .timeLimit(.minutes(3)))
 struct BluetoothDevicesRepositoryImplTests {
 	let manager: BluetoothManager
 	let bluetoothDevicesRepositoryImpl: BluetoothDevicesRepositoryImpl

--- a/WeatherXMTests/DataLayer/Services/PhotosRepositoryImplTests.swift
+++ b/WeatherXMTests/DataLayer/Services/PhotosRepositoryImplTests.swift
@@ -52,7 +52,8 @@ private extension PhotosRepositoryImplTests {
 	func savePhoto() async throws -> String {
 		let path = try await repositoryImpl.saveImage(image,
 													  deviceId: "124",
-													  metadata: nil)
+													  metadata: nil,
+													  userComment: "")
 		let filePath = try #require(path)
 		return filePath
 	}

--- a/WeatherXMTests/DomainLayer/MockRepositories/MockPhotosRepositoryImpl.swift
+++ b/WeatherXMTests/DomainLayer/MockRepositories/MockPhotosRepositoryImpl.swift
@@ -72,7 +72,7 @@ extension MockPhotosRepositoryImpl: PhotosRepository {
 		self.termsAccepted = termsAccepted
 	}
 	
-	func saveImage(_ image: UIImage, deviceId: String, metadata: NSDictionary?) async throws -> String? {
+	func saveImage(_ image: UIImage, deviceId: String, metadata: NSDictionary?, userComment: String) async throws -> String? {
 		""
 	}
 	

--- a/WeatherXMTests/DomainLayer/UseCases/PhotoGalleryUseCaseTests.swift
+++ b/WeatherXMTests/DomainLayer/UseCases/PhotoGalleryUseCaseTests.swift
@@ -32,11 +32,13 @@ struct PhotoGalleryUseCaseTests {
 	@Test func saveImage() async throws {
 		let fileName = try await useCase.saveImage(UIImage(),
 												   deviceId: "124",
-												   metadata: nil)
+												   metadata: nil,
+												   userComment: "")
 
 		let repositoryFileName = try await repository.saveImage(UIImage(),
 																deviceId: "124",
-																metadata: nil)
+																metadata: nil,
+																userComment: "")
 		#expect(fileName == repositoryFileName)
 	}
 

--- a/WeatherXMTests/PresentationLayer/MockUseCases/MockPhotoGalleryUseCase.swift
+++ b/WeatherXMTests/PresentationLayer/MockUseCases/MockPhotoGalleryUseCase.swift
@@ -48,7 +48,7 @@ final class MockPhotoGalleryUseCase: PhotoGalleryUseCaseApi {
 		termsAcceptedValue = termsAccepted
 	}
 
-	func saveImage(_ image: UIImage, deviceId: String, metadata: NSDictionary?) async throws -> String? {
+	func saveImage(_ image: UIImage, deviceId: String, metadata: NSDictionary?, userComment: String) async throws -> String? {
 		imageSaved = true
 		return ""
 	}

--- a/wxm-ios.xctestplan
+++ b/wxm-ios.xctestplan
@@ -4,7 +4,7 @@
       "id" : "20B9F52A-8619-4B2F-BD10-91594B79C6DA",
       "name" : "Configuration 1",
       "options" : {
-
+        "testTimeoutsEnabled" : true
       }
     }
   ],

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/PhotosRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/PhotosRepositoryImpl.swift
@@ -190,6 +190,15 @@ private extension PhotosRepositoryImpl {
 		}
 	}
 
+	func injectUserCommentInMetadata(_ metadata: NSDictionary, comment: String) -> NSDictionary? {
+		let mutableMetadata = metadata.mutableCopy() as? NSMutableDictionary
+		let exifDict = mutableMetadata?[kCGImagePropertyExifDictionary] as? NSMutableDictionary ?? NSMutableDictionary()
+		exifDict[kCGImagePropertyExifUserComment] = comment
+		mutableMetadata?[kCGImagePropertyExifDictionary] = exifDict
+
+		return mutableMetadata
+	}
+
 	func retrievePhotosUpload(for deviceId: String, names: [String]) async throws -> Result<[NetworkPostDevicePhotosResponse], NetworkErrorResponse> {
 		let builder = MeApiRequestBuilder.postPhotoNames(deviceId: deviceId, photos: names)
 		let urlRequest = try builder.asURLRequest()

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/PhotosRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/PhotosRepositoryImpl.swift
@@ -57,9 +57,10 @@ public struct PhotosRepositoryImpl: PhotosRepository {
 		fileUploader.getUploadInProgressDeviceId()
 	}
 
-	public func saveImage(_ image: UIImage, deviceId: String, metadata: NSDictionary?) async throws -> String? {
+	public func saveImage(_ image: UIImage, deviceId: String, metadata: NSDictionary?, userComment: String) async throws -> String? {
 		let fileName = self.getFolderPath(for: deviceId).appendingPathComponent("\(UUID().uuidString).jpg")
-		let fixedMetadata = await injectLocationInMetadataIfNeeded(metadata ?? .init())
+		var fixedMetadata = await injectLocationInMetadataIfNeeded(metadata ?? .init()) ?? .init()
+		fixedMetadata = injectUserCommentInMetadata(fixedMetadata, comment: userComment) ?? .init()
 		guard saveImageWithEXIF(image: image, metadata: fixedMetadata, saveFilename: fileName) else {
 			return nil
 		}

--- a/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/PhotosRepository.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/PhotosRepository.swift
@@ -22,7 +22,7 @@ public protocol PhotosRepository: Sendable {
 	var uploadStartedPublisher: AnyPublisher<String, Never> { get }
 	func getUploadInProgressDeviceId() -> String?
 	func setTermsAccepted(_ termsAccepted: Bool)
-	func saveImage(_ image: UIImage, deviceId: String, metadata: NSDictionary?) async throws -> String?
+	func saveImage(_ image: UIImage, deviceId: String, metadata: NSDictionary?, userComment: String) async throws -> String?
 	func deleteImage(_ imageUrl: String, deviceId: String) async throws
 	func getCameraPermission() -> AVAuthorizationStatus
 	func requestCameraPermission() async -> AVAuthorizationStatus

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/PhotoGalleryUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/PhotoGalleryUseCase.swift
@@ -36,8 +36,8 @@ public struct PhotoGalleryUseCase: PhotoGalleryUseCaseApi {
 		photosRepository.setTermsAccepted(termsAccepted)
 	}
 
-	public func saveImage(_ image: UIImage, deviceId: String, metadata: NSDictionary?) async throws -> String? {
-		try await photosRepository.saveImage(image, deviceId: deviceId, metadata: metadata)
+	public func saveImage(_ image: UIImage, deviceId: String, metadata: NSDictionary?, userComment: String) async throws -> String? {
+		try await photosRepository.saveImage(image, deviceId: deviceId, metadata: metadata, userComment: userComment)
 	}
 
 	public func deleteImage(_ imageUrl: String, deviceId: String) async throws {

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/PhotoGalleryUseCaseApi.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/PhotoGalleryUseCaseApi.swift
@@ -18,7 +18,7 @@ public protocol PhotoGalleryUseCaseApi: Sendable {
 
 	func getUploadInProgressDeviceId() -> String?
 	func setTermsAccepted(_ termsAccepted: Bool)
-	func saveImage(_ image: UIImage, deviceId: String, metadata: NSDictionary?) async throws -> String?
+	func saveImage(_ image: UIImage, deviceId: String, metadata: NSDictionary?, userComment: String) async throws -> String?
 	func deleteImage(_ imageUrl: String, deviceId: String) async throws
 	func getCameraPermission() -> AVAuthorizationStatus
 	func requestCameraPermission() async -> AVAuthorizationStatus

--- a/wxm-ios/Toolkit/Toolkit/Utils/UIImage+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/UIImage+.swift
@@ -56,3 +56,19 @@ public extension UIImage {
 		return newImage ?? self
 	}
 }
+
+public extension CGImagePropertyOrientation {
+	init(_ uiOrientation: UIImage.Orientation) {
+		switch uiOrientation {
+			case .up: self = .up
+			case .down: self = .down
+			case .left: self = .left
+			case .right: self = .right
+			case .upMirrored: self = .upMirrored
+			case .downMirrored: self = .downMirrored
+			case .leftMirrored: self = .leftMirrored
+			case .rightMirrored: self = .rightMirrored
+			@unknown default: self = .up
+		}
+	}
+}


### PR DESCRIPTION
## **Why?**
Upload photos from phone library
### **How?**
- Added button that presents the photo picker from library
- Inject the source of the file (`wxm-device-photo-library` or `wxm-device-photo-camera`) in `exif` metadata as `User Comment`
- Fixed the scale down process before image upload
### **Testing**
Upload photos from the camera and photo library and ensure the size and metadata are correct.
To inspect the metadata download the photo and upload it [here](https://exifinfo.org).
To get the photo urls, you can use the API monitor screen (shake the device to present it)
### **Additional context**
fixes fe-1783


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new button in the photo verification screen for seamless gallery access.
  - Now you can attach optional comments when saving images, enriching your photo metadata.

- **Refinements**
  - Updated the icon set for a more consistent and polished look, with several new icons added.
  - Improved gallery layout spacing for enhanced visual clarity.
  - Enhanced image processing to ensure proper orientation and quality, including user comments in metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->