### PR TITLE
Added missing content type

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/Announcement/ProPromotional/ProBannerView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/Announcement/ProPromotional/ProBannerView.swift
@@ -32,8 +32,9 @@ struct ProBannerView: View {
 			Spacer()
 			Button {
 				WXMAnalytics.shared.trackEvent(.selectContent,
-											   parameters: [.source: analyticsSource])
-				
+											   parameters: [.contentType: .proPromotionCTA,
+															.source: analyticsSource])
+
 				Router.shared.showBottomSheet(.proPromo(ViewModelsFactory.getProPromotionalViewModel()))
 			} label: {
 				Text(LocalizableString.Promotional.getPro.localized)

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
@@ -92,7 +92,8 @@ public final class WeatherStationsHomeViewModel: ObservableObject {
 					return
 				}
 
-				WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.itemId: .custom(urlString),
+				WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .proPromotionCTA,
+																			.itemId: .custom(urlString),
 																			.source: .remoteDevicesList])
 
 				let handled = self?.mainVM?.deepLinkHandler.handleUrl(url) ?? false


### PR DESCRIPTION
## **Why?**
Added missing `content_type` in Pro promotional events
### **Testing**
Ensure the events are tracked properly
### **Additional context**
fixes fe-1814


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved analytics tracking for promotional banner and announcement actions by including additional event parameters for more detailed insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->