### PR TITLE
Analytics labels for audience implementation

### DIFF
--- a/wxm-ios/DataLayer/UserDevicesService.swift
+++ b/wxm-ios/DataLayer/UserDevicesService.swift
@@ -271,11 +271,16 @@ private extension UserDevicesService {
 	}
 
 	func updateOwnedStationsAnalyticsProperty() {
-		guard let ownedDevicesCount = getCachedDevices()?.filter({ $0.relation == .owned }).count else {
+		guard let devices = getCachedDevices() else {
 			WXMAnalytics.shared.removeUserProperty(key: .stationsOwn)
+			WXMAnalytics.shared.removeUserProperty(key: .stationsFavorite)
 			return
 		}
 
-		WXMAnalytics.shared.setUserProperty(key: .stationsOwn, value: .custom("\(ownedDevicesCount)"))
+		let ownedDevices = devices.filter({ $0.relation == .owned })
+		let favoriteDevices = devices.filter({ $0.relation == .followed })
+
+		WXMAnalytics.shared.setUserProperty(key: .stationsOwn, value: .custom("\(ownedDevices.count)"))
+		WXMAnalytics.shared.setUserProperty(key: .stationsFavorite, value: .custom("\(favoriteDevices.count)"))
 	}
 }

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Devices/NetworkDevicesTypes.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Devices/NetworkDevicesTypes.swift
@@ -50,7 +50,7 @@ public struct StationBundle: Codable, Sendable {
 		case hwClass = "hw_class"
 	}
 
-	public enum Code: String, Codable, Sendable {
+	public enum Code: String, Codable, Sendable, CaseIterable {
 		case m5
 		case h1
 		case h2

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
@@ -44,6 +44,7 @@ extension Parameter: RawRepresentable, Hashable, CustomStringConvertible {
 			case "SOURCE": self = .source
 			case "STATE": self = .state
 			case "STATIONS_OWN": self = .stationsOwn
+			case "STATIONS_FAVORITE": self = .stationsFavorite
 			case "STATUS": self = .status
 			case "STEP": self = .step
 			case "SUCCESS": self = .success
@@ -87,6 +88,8 @@ extension Parameter: RawRepresentable, Hashable, CustomStringConvertible {
 			case .source: return "SOURCE"
 			case .state: return "STATE"
 			case .stationsOwn: return "STATIONS_OWN"
+			case .stationOwn(let stationType): return "STATIONS_OWN_\(stationType.uppercased())"
+			case .stationsFavorite: return "STATIONS_FAVORITE"
 			case .status: return "STATUS"
 			case .step: return "STEP"
 			case .success: return "SUCCESS"
@@ -97,7 +100,6 @@ extension Parameter: RawRepresentable, Hashable, CustomStringConvertible {
 			case .windDirection: return "UNIT_WIND_DIRECTION"
 			case .precipitation: return "UNIT_PRECIPITATION"
 			case .pressure: return "UNIT_PRESSURE"
-			case .stationOwn(let stationType): return "STATIONS_OWN_\(stationType.uppercased())"
 		}
 	}
 
@@ -105,7 +107,7 @@ extension Parameter: RawRepresentable, Hashable, CustomStringConvertible {
 		switch self {
 			case .action, .actionName, .contentName, .promptName, .promptType,
 					.step, .state, .date, .theme, .temperature, .wind, .windDirection, .precipitation, .pressure,
-					.sortBy, .filter, .groupBy, .status, .appId, .hasWallet, .stationsOwn, .stationOwn(_), .userState, .deviceState:
+					.sortBy, .filter, .groupBy, .status, .appId, .hasWallet, .stationsOwn, .stationOwn(_), .stationsFavorite, .userState, .deviceState:
 				return rawValue
 			case .contentType:
 				return AnalyticsParameterContentType

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
@@ -58,7 +58,7 @@ extension Parameter: RawRepresentable, Hashable, CustomStringConvertible {
 			default:
 				if rawValue.starts(with: "STATIONS_OWN_") {
 					let stationType = rawValue.replacingOccurrences(of: "STATIONS_OWN_", with: "").lowercased()
-					self = .stationOwn(stationType: stationType)
+					self = .stationsOwnCount(stationType: stationType)
 				} else {
 					return nil
 				}
@@ -88,7 +88,7 @@ extension Parameter: RawRepresentable, Hashable, CustomStringConvertible {
 			case .source: return "SOURCE"
 			case .state: return "STATE"
 			case .stationsOwn: return "STATIONS_OWN"
-			case .stationOwn(let stationType): return "STATIONS_OWN_\(stationType.uppercased())"
+			case .stationsOwnCount(let stationType): return "STATIONS_OWN_\(stationType.uppercased())"
 			case .stationsFavorite: return "STATIONS_FAVORITE"
 			case .status: return "STATUS"
 			case .step: return "STEP"
@@ -107,7 +107,7 @@ extension Parameter: RawRepresentable, Hashable, CustomStringConvertible {
 		switch self {
 			case .action, .actionName, .contentName, .promptName, .promptType,
 					.step, .state, .date, .theme, .temperature, .wind, .windDirection, .precipitation, .pressure,
-					.sortBy, .filter, .groupBy, .status, .appId, .hasWallet, .stationsOwn, .stationOwn(_), .stationsFavorite, .userState, .deviceState:
+					.sortBy, .filter, .groupBy, .status, .appId, .hasWallet, .stationsOwn, .stationsOwnCount(_), .stationsFavorite, .userState, .deviceState:
 				return rawValue
 			case .contentType:
 				return AnalyticsParameterContentType

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
@@ -19,12 +19,93 @@ extension Event: CustomStringConvertible {
 	}
 }
 
-extension Parameter: CustomStringConvertible {
+extension Parameter: RawRepresentable, Hashable, CustomStringConvertible {
+
+	public init?(rawValue: String) {
+		switch rawValue {
+			case "ACTION": self = .action
+			case "ACTION_NAME": self = .actionName
+			case "APP_ID": self = .appId
+			case "CONTENT_NAME": self = .contentName
+			case "CONTENT_TYPE": self = .contentType
+			case "DATE": self = .date
+			case "DEVICE_STATE": self = .deviceState
+			case "FILTER": self = .filter
+			case "GROUP_BY": self = .groupBy
+			case "HAS_WALLET": self = .hasWallet
+			case "INDEX": self = .index
+			case "ITEM_ID": self = .itemId
+			case "ITEM_LIST_ID": self = .itemListId
+			case "LOCATION": self = .location
+			case "METHOD": self = .method
+			case "PROMPT_NAME": self = .promptName
+			case "PROMPT_TYPE": self = .promptType
+			case "SORT_BY": self = .sortBy
+			case "SOURCE": self = .source
+			case "STATE": self = .state
+			case "STATIONS_OWN": self = .stationsOwn
+			case "STATUS": self = .status
+			case "STEP": self = .step
+			case "SUCCESS": self = .success
+			case "UNIT_TEMPERATURE": self = .temperature
+			case "THEME": self = .theme
+			case "USER_STATE": self = .userState
+			case "UNIT_WIND": self = .wind
+			case "UNIT_WIND_DIRECTION": self = .windDirection
+			case "UNIT_PRECIPITATION": self = .precipitation
+			case "UNIT_PRESSURE": self = .pressure
+			default:
+				if rawValue.starts(with: "STATIONS_OWN_") {
+					let stationType = rawValue.replacingOccurrences(of: "STATIONS_OWN_", with: "").lowercased()
+					self = .stationOwn(stationType: stationType)
+				} else {
+					return nil
+				}
+		}
+	}
+
+	public var rawValue: String {
+		switch self {
+			case .action: return "ACTION"
+			case .actionName: return "ACTION_NAME"
+			case .appId: return "APP_ID"
+			case .contentName: return "CONTENT_NAME"
+			case .contentType: return "CONTENT_TYPE"
+			case .date: return "DATE"
+			case .deviceState: return "DEVICE_STATE"
+			case .filter: return "FILTER"
+			case .groupBy: return "GROUP_BY"
+			case .hasWallet: return "HAS_WALLET"
+			case .index: return "INDEX"
+			case .itemId: return "ITEM_ID"
+			case .itemListId: return "ITEM_LIST_ID"
+			case .location: return "LOCATION"
+			case .method: return "METHOD"
+			case .promptName: return "PROMPT_NAME"
+			case .promptType: return "PROMPT_TYPE"
+			case .sortBy: return "SORT_BY"
+			case .source: return "SOURCE"
+			case .state: return "STATE"
+			case .stationsOwn: return "STATIONS_OWN"
+			case .status: return "STATUS"
+			case .step: return "STEP"
+			case .success: return "SUCCESS"
+			case .temperature: return "UNIT_TEMPERATURE"
+			case .theme: return "THEME"
+			case .userState: return "USER_STATE"
+			case .wind: return "UNIT_WIND"
+			case .windDirection: return "UNIT_WIND_DIRECTION"
+			case .precipitation: return "UNIT_PRECIPITATION"
+			case .pressure: return "UNIT_PRESSURE"
+			case .stationOwn(let stationType): return "STATIONS_OWN_\(stationType.uppercased())"
+		}
+	}
+
 	public var description: String {
 		switch self {
 			case .action, .actionName, .contentName, .promptName, .promptType,
 					.step, .state, .date, .theme, .temperature, .wind, .windDirection, .precipitation, .pressure,
-					.sortBy, .filter, .groupBy, .status, .appId, .hasWallet, .stationsOwn, .userState, .deviceState:
+					.sortBy, .filter, .groupBy, .status, .appId, .hasWallet, .stationsOwn, .stationOwn(_), .userState, .deviceState:
 				return rawValue
 			case .contentType:
 				return AnalyticsParameterContentType

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
@@ -97,7 +97,7 @@ public enum Parameter {
 	case source
 	case state
 	case stationsOwn
-	case stationOwn(stationType: String)
+	case stationsOwnCount(stationType: String)
 	case stationsFavorite
 	case status
 	case step

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
@@ -75,38 +75,39 @@ public enum Event: String {
 	case selectContent = "SELECT_CONTENT"
 }
 
-public enum Parameter: String {
-	case action = "ACTION"
-	case actionName = "ACTION_NAME"
-	case appId = "APP_ID"
-	case contentName = "CONTENT_NAME"
-	case contentType = "CONTENT_TYPE"
-	case date = "DATE"
-	case deviceState = "DEVICE_STATE"
-	case filter = "FILTER"
-	case groupBy = "GROUP_BY"
-	case hasWallet = "HAS_WALLET"
-	case index = "INDEX"
-	case itemId = "ITEM_ID"
-	case itemListId = "ITEM_LIST_ID"
-	case location = "LOCATION"
-	case method = "METHOD"
-	case promptName = "PROMPT_NAME"
-	case promptType = "PROMPT_TYPE"
-	case sortBy = "SORT_BY"
-	case source = "SOURCE"
-	case state = "STATE"
-	case stationsOwn = "STATIONS_OWN"
-	case status = "STATUS"
-	case step = "STEP"
-	case success = "SUCCESS"
-	case temperature = "UNIT_TEMPERATURE"
-	case theme = "THEME"
-	case userState = "USER_STATE"
-	case wind = "UNIT_WIND"
-	case windDirection = "UNIT_WIND_DIRECTION"
-	case precipitation = "UNIT_PRECIPITATION"
-	case pressure = "UNIT_PRESSURE"
+public enum Parameter {
+	case action
+	case actionName
+	case appId
+	case contentName
+	case contentType
+	case date
+	case deviceState
+	case filter
+	case groupBy
+	case hasWallet
+	case index
+	case itemId
+	case itemListId
+	case location
+	case method
+	case promptName
+	case promptType
+	case sortBy
+	case source
+	case state
+	case stationsOwn
+	case stationOwn(stationType: String)
+	case status
+	case step
+	case success
+	case temperature
+	case theme
+	case userState
+	case wind
+	case windDirection
+	case precipitation
+	case pressure
 }
 
 public enum ParameterValue {

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
@@ -98,6 +98,7 @@ public enum Parameter {
 	case state
 	case stationsOwn
 	case stationOwn(stationType: String)
+	case stationsFavorite
 	case status
 	case step
 	case success

--- a/wxm-ios/Toolkit/Toolkit/Analytics/WXMAnalytics.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/WXMAnalytics.swift
@@ -44,6 +44,7 @@ public extension WXMAnalytics {
     }
 
     func setUserProperty(key: Parameter, value: ParameterValue) {
+		print("WXMAnalytics user property: \(key.rawValue), \(value)") // TEMP for testing
 		providers.forEach { $0.setUserProperty(key: key, value: value) }
     }
 


### PR DESCRIPTION
## **Why?**
Add user properties to identify users with different stations
### **How?**
Update station related user properties in `UserDevicesService`
### **Testing**
Disable the `-WXMAnalyticsDisabled` launch argument and filter logs with `FirebaseAnalytics`.
Ensure the properties are stored properly on login and logout. 
Check the logs to see that everything works as expected 
### **Screenshots (if applicable)**
![Screenshot 2025-04-25 at 10 51 21](https://github.com/user-attachments/assets/d1744095-0c79-4d66-80b6-ddae3e93c150)

![Screenshot 2025-04-25 at 10 56 11](https://github.com/user-attachments/assets/d94550c0-91ca-45e1-9db8-f21952b83b72)

### **Additional context**
fixes fe-1822
According to [this](https://github.com/firebase/firebase-ios-sdk/issues/4856), Firebase debug view is buggy with user properties and still shows the removed user properties. So you can check the debug view, having this in mind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded analytics tracking to include counts of owned devices, favorite devices, and owned devices by station type.
	- Added new analytics parameters for favorite stations and owned station counts by type.

- **Improvements**
	- Enhanced analytics parameter handling with improved string conversion and hashing support.
	- Improved flexibility for analytics properties with dynamic parameter support.

- **Other**
	- Added debug output for analytics user property changes to aid in troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->