### PR TITLE
No active station chip

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/PillsView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/PillsView.swift
@@ -99,8 +99,3 @@ struct PillsView_Previews: PreviewProvider {
 		.padding()
 	}
 }
-
-extension Alignment {
-	static let myAlignment = Alignment(horizontal: .leading,
-									   vertical: .top)
-}

--- a/PresentationLayer/UIComponents/BaseComponents/PillsView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/PillsView.swift
@@ -1,0 +1,106 @@
+//
+//  PillsView.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 30/4/25.
+//
+
+import SwiftUI
+import Toolkit
+
+struct PillsView<Item: Hashable, PillContent: View>: View {
+	var items: [Item]
+	var containerWidth: CGFloat
+	var pillContent: (Item) -> PillContent
+
+	private let pillsSpacing = CGFloat(.smallSpacing)
+
+	@State private var sizes: [SizeWrapper]
+
+	init(items: [Item], containerWidth: CGFloat, pillContent: @escaping (Item) -> PillContent) {
+		self.items = items
+		self.containerWidth = containerWidth
+		self.pillContent = pillContent
+		sizes = items.map { _ in SizeWrapper() }
+	}
+
+	var body: some View {
+		generatePills(width: containerWidth)
+	}
+}
+
+private extension PillsView {
+
+	@ViewBuilder
+	func generatePills(width: CGFloat) -> some View {
+		let rows = getRows(containerWidth: width)
+		VStack(alignment: .leading, spacing: pillsSpacing) {
+			ForEach(rows, id: \.self) { row in
+				HStack(spacing: pillsSpacing) {
+					ForEach(row, id: \.self) { item in
+						let index = items.firstIndex(of: item)
+
+						pillContent(item)
+							.fixedSize()
+							.sizeObserver(size: $sizes[index!].size)
+					}
+
+					Spacer(minLength: 0.0)
+				}
+			}
+		}
+	}
+
+	@ViewBuilder
+	func pill(_ item: Item, size: Binding<CGSize>) -> some View {
+		pillContent(item)
+	}
+
+	func getRows(containerWidth: CGFloat) -> [[Item]] {
+		var rows: [[Item]] = [[]]
+		var width = containerWidth
+
+		items.forEach { item in
+			let itemWidth = getWidth(of: item)
+			width -= itemWidth
+
+			let shouldChangeLine = width < 0
+			if shouldChangeLine {
+				rows.append([item])
+				width = containerWidth - itemWidth
+			} else {
+				let lastIndex = rows.count - 1
+				rows[lastIndex].append(item)
+			}
+		}
+
+		return rows
+	}
+
+	func getWidth(of item: Item) -> CGFloat {
+		let index = items.firstIndex(of: item)
+		return sizes[index!].size.width
+	}
+}
+
+struct PillsView_Previews: PreviewProvider {
+	static var previews: some View {
+		GeometryReader { proxy in
+			PillsView(items: ["Ninetendo",
+							  "XBox",
+							  "PlayStation 23456",
+							  "PlayStation 3"],
+					  containerWidth: proxy.size.width) { item in
+				Text(item)
+					.lineLimit(1)
+					.WXMCardStyle(backgroundColor: Color(colorEnum: .bg))
+			}
+		}
+		.padding()
+	}
+}
+
+extension Alignment {
+	static let myAlignment = Alignment(horizontal: .leading,
+									   vertical: .top)
+}

--- a/PresentationLayer/UIComponents/Screens/ExplorerStationsList/ExplorerStationsListView.swift
+++ b/PresentationLayer/UIComponents/Screens/ExplorerStationsList/ExplorerStationsListView.swift
@@ -39,7 +39,7 @@ struct ExplorerStationsListView: View {
 
 extension ExplorerStationsListView {
 	enum Pill: Hashable {
-		case activeStations(String)
+		case activeStations(String, ColorEnum)
 		case stationsCount(String)
 	}
 }
@@ -154,12 +154,12 @@ private extension ContentView {
 	@ViewBuilder
 	func viewFor(pill: ExplorerStationsListView.Pill) -> some View {
 		switch pill {
-			case .activeStations(let text):
+			case .activeStations(let text, let color):
 				Text(text)
 					.font(.system(size: CGFloat(.normalFontSize), weight: .medium))
 					.foregroundColor(Color(colorEnum: .text))
 					.lineLimit(1)
-					.WXMCardStyle(backgroundColor: Color(colorEnum: .successTint),
+					.WXMCardStyle(backgroundColor: Color(colorEnum: color),
 								  insideHorizontalPadding: CGFloat(.smallToMediumSidePadding),
 								  insideVerticalPadding: CGFloat(.smallSidePadding),
 								  cornerRadius: CGFloat(.buttonCornerRadius))

--- a/PresentationLayer/UIComponents/Screens/ExplorerStationsList/ExplorerStationsListView.swift
+++ b/PresentationLayer/UIComponents/Screens/ExplorerStationsList/ExplorerStationsListView.swift
@@ -37,10 +37,18 @@ struct ExplorerStationsListView: View {
 	}
 }
 
+extension ExplorerStationsListView {
+	enum Pill: Hashable {
+		case activeStations(String)
+		case stationsCount(String)
+	}
+}
+
 private struct ContentView: View {
     @StateObject var viewModel: ExplorerStationsListViewModel
     @EnvironmentObject var navigationObject: NavigationObject
-    
+	@State private var titleViewSize: CGSize = .zero
+
     var body: some View {
         ZStack {
             Color(colorEnum: .layer2)
@@ -112,33 +120,52 @@ private struct ContentView: View {
 
 private extension ContentView {
 	@ViewBuilder var titleView: some View {
-		VStack(spacing: CGFloat(.mediumSpacing)) {
-			if let address = viewModel.address {
-				HStack {
-					Text(address)
-						.foregroundColor(Color(.text))
-						.font(.system(size: CGFloat(.largeTitleFontSize), weight: .bold))
+		ZStack {
+			// Dummy view to calculate the `containerWidth` to pass to `pillsView`
+			Color(colorEnum: .top)
+				.frame(height: 1.0)
+				.sizeObserver(size: $titleViewSize)
 
-					Spacer()
-				}
-			}
+			VStack(spacing: CGFloat(.mediumSpacing)) {
+				if let address = viewModel.address {
+					HStack {
+						Text(address)
+							.foregroundColor(Color(.text))
+							.font(.system(size: CGFloat(.largeTitleFontSize), weight: .bold))
 
-			HStack(spacing: CGFloat(.minimumSpacing)) {
-				if let activeStationsString = viewModel.activeStationsString {
-					HStack(spacing: CGFloat(.smallSpacing)) {
-						Text(activeStationsString)
-							.font(.system(size: CGFloat(.normalFontSize), weight: .medium))
-							.foregroundColor(Color(colorEnum: .text))
-							.lineLimit(1)
+						Spacer()
 					}
+				}
+
+				PillsView(items: viewModel.pills,
+						  containerWidth: titleViewSize.width) { pill in
+					viewFor(pill: pill)
+				}
+				.id(viewModel.pills)
+			}
+		}
+		.padding(.horizontal, CGFloat(.defaultSidePadding))
+		.padding(.bottom, CGFloat(.mediumSidePadding))
+		.background(Color(colorEnum: .top))
+		.cornerRadius(CGFloat(.cardCornerRadius),
+					  corners: [.bottomLeft, .bottomRight])
+	}
+
+	@ViewBuilder
+	func viewFor(pill: ExplorerStationsListView.Pill) -> some View {
+		switch pill {
+			case .activeStations(let text):
+				Text(text)
+					.font(.system(size: CGFloat(.normalFontSize), weight: .medium))
+					.foregroundColor(Color(colorEnum: .text))
+					.lineLimit(1)
 					.WXMCardStyle(backgroundColor: Color(colorEnum: .successTint),
 								  insideHorizontalPadding: CGFloat(.smallToMediumSidePadding),
 								  insideVerticalPadding: CGFloat(.smallSidePadding),
 								  cornerRadius: CGFloat(.buttonCornerRadius))
-				}
-
+			case .stationsCount(let text):
 				HStack(spacing: CGFloat(.smallSpacing)) {
-					Text(viewModel.stationsCountString)
+					Text(text)
 						.font(.system(size: CGFloat(.normalFontSize), weight: .medium))
 						.foregroundColor(Color(colorEnum: .text))
 						.lineLimit(1)
@@ -150,21 +177,12 @@ private extension ContentView {
 							.font(.fontAwesome(font: .FAPro, size: CGFloat(.mediumFontSize)))
 							.foregroundColor(Color(colorEnum: .text))
 					}
-
 				}
 				.WXMCardStyle(backgroundColor: Color(colorEnum: .blueTint),
 							  insideHorizontalPadding: CGFloat(.smallToMediumSidePadding),
 							  insideVerticalPadding: CGFloat(.smallSidePadding),
 							  cornerRadius: CGFloat(.buttonCornerRadius))
-
-				Spacer()
-			}
 		}
-		.padding(.horizontal, CGFloat(.defaultSidePadding))
-		.padding(.bottom, CGFloat(.mediumSidePadding))
-		.background(Color(colorEnum: .top))
-		.cornerRadius(CGFloat(.cardCornerRadius),
-					  corners: [.bottomLeft, .bottomRight])
 	}
 }
 

--- a/PresentationLayer/UIComponents/Screens/ExplorerStationsList/ExplorerStationsListViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ExplorerStationsList/ExplorerStationsListViewModel.swift
@@ -36,7 +36,9 @@ class ExplorerStationsListViewModel: ObservableObject {
 		var pills: [ExplorerStationsListView.Pill] = []
 
 		if let activeStationsString {
-			pills.append(.activeStations(activeStationsString))
+			pills.append(.activeStations(activeStationsString, .successTint))
+		} else {
+			pills.append(.activeStations(LocalizableString.noActiveStations.localized, .errorTint))
 		}
 
 		let count = devices.count

--- a/PresentationLayer/UIComponents/Screens/ExplorerStationsList/ExplorerStationsListViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ExplorerStationsList/ExplorerStationsListViewModel.swift
@@ -24,7 +24,7 @@ class ExplorerStationsListViewModel: ObservableObject {
 	private(set) var info: BottomSheetInfo?
 	var deviceListFailObject: FailSuccessStateObject?
 	var alertConfiguration: WXMAlertConfiguration?
-	var activeStationsString: String? {
+	private var activeStationsString: String? {
 		let count = devices.filter { $0.isActive }.count
 		guard count > 0 else {
 			return nil
@@ -32,10 +32,18 @@ class ExplorerStationsListViewModel: ObservableObject {
 		
 		return count == 1 ? LocalizableString.activeStation(count).localized : LocalizableString.activeStations(count).localized
 	}
-	var stationsCountString: String {
+	var pills: [ExplorerStationsListView.Pill] {
+		var pills: [ExplorerStationsListView.Pill] = []
+
+		if let activeStationsString {
+			pills.append(.activeStations(activeStationsString))
+		}
+
 		let count = devices.count
-		
-		return LocalizableString.presentStations(count).localized
+
+		pills.append(.stationsCount(LocalizableString.presentStations(count).localized))
+
+		return pills
 	}
 	var cellShareUrl: String {
 		DisplayedLinks.shareCells.linkURL + cellIndex

--- a/WeatherXMTests/PresentationLayer/ViewModels/ExplorerStationsListViewModelTests.swift
+++ b/WeatherXMTests/PresentationLayer/ViewModels/ExplorerStationsListViewModelTests.swift
@@ -28,4 +28,16 @@ struct ExplorerStationsListViewModelTests {
 		viewModel.handleCellCapacityInfoTap()
 		#expect(viewModel.showInfo)
     }
+
+	@Test func pills() async throws {
+		#expect(viewModel.pills.count == 2)
+		let firstPill = try #require(viewModel.pills.first)
+		switch firstPill {
+			case .activeStations(let title, let color):
+				#expect(title == LocalizableString.noActiveStations.localized)
+				#expect(color == .errorTint)
+			default:
+				Issue.record()
+		}
+	}
 }

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -370,6 +370,7 @@
 		268BAD562DC0FD9A00748439 /* BoostCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268BAD552DC0FD9A00748439 /* BoostCodeTests.swift */; };
 		268BAD582DC0FFFB00748439 /* NetworkDeviceRewardsResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268BAD572DC0FFFB00748439 /* NetworkDeviceRewardsResponseTests.swift */; };
 		268BAD5A2DC1023E00748439 /* DomainExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268BAD592DC1023E00748439 /* DomainExtensionsTests.swift */; };
+		268BAD682DC2578100748439 /* PillsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268BAD672DC2578100748439 /* PillsView.swift */; };
 		268D07932B2B1B70002BD77E /* SelectStationLocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268D07922B2B1B70002BD77E /* SelectStationLocationView.swift */; };
 		268D07952B2B1B85002BD77E /* SelectStationLocationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268D07942B2B1B85002BD77E /* SelectStationLocationViewModel.swift */; };
 		268D07972B2B1E81002BD77E /* LocalizableString+SelectStationLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268D07962B2B1E81002BD77E /* LocalizableString+SelectStationLocation.swift */; };
@@ -1110,6 +1111,7 @@
 		268BAD552DC0FD9A00748439 /* BoostCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoostCodeTests.swift; sourceTree = "<group>"; };
 		268BAD572DC0FFFB00748439 /* NetworkDeviceRewardsResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDeviceRewardsResponseTests.swift; sourceTree = "<group>"; };
 		268BAD592DC1023E00748439 /* DomainExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainExtensionsTests.swift; sourceTree = "<group>"; };
+		268BAD672DC2578100748439 /* PillsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillsView.swift; sourceTree = "<group>"; };
 		268D07922B2B1B70002BD77E /* SelectStationLocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectStationLocationView.swift; sourceTree = "<group>"; };
 		268D07942B2B1B85002BD77E /* SelectStationLocationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectStationLocationViewModel.swift; sourceTree = "<group>"; };
 		268D07962B2B1E81002BD77E /* LocalizableString+SelectStationLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalizableString+SelectStationLocation.swift"; sourceTree = "<group>"; };
@@ -2198,6 +2200,7 @@
 				26D5013B29B2152F00BC2951 /* CustomSegmentView.swift */,
 				26A4118129BA1A9900A2C10B /* DeviceUpdatesLoadingView.swift */,
 				261CD81729CB2D5A00C0CECE /* PercentageGridLayoutView.swift */,
+				268BAD672DC2578100748439 /* PillsView.swift */,
 				2675474C29A9181E008BCF40 /* ProgressBarStyle.swift */,
 				2675474729A9181E008BCF40 /* StaticButtonStyle.swift */,
 				26D5013729B209F500BC2951 /* StationLastActiveView.swift */,
@@ -3986,6 +3989,7 @@
 				26348DFA2A42FB1F000846C6 /* ExplorerSearchViewModel.swift in Sources */,
 				267547D629A9181E008BCF40 /* ExplorerStationsListView.swift in Sources */,
 				26348E292A459A45000846C6 /* ExplorerStationsListViewModel.swift in Sources */,
+				268BAD682DC2578100748439 /* PillsView.swift in Sources */,
 				2675481D29A9181E008BCF40 /* ExplorerView.swift in Sources */,
 				264CC7692B98AA6E0060DEA4 /* NetworkDeviceRewardBoostsResponse+.swift in Sources */,
 				26AA21E42BF4F60300B91A7C /* ClaimDeviceLocationView.swift in Sources */,

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -5632,6 +5632,17 @@
         }
       }
     },
+    "no_active_stations" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No active stations"
+          }
+        }
+      }
+    },
     "no_email" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/LocalizableConstants.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableConstants.swift
@@ -183,6 +183,7 @@ enum LocalizableString: WXMLocalizable {
 	case noTransactionTitle
 	case noTransactionDesc
 	case mailLeaveMessageNote
+	case noActiveStations
 	case activeStations(Int?)
 	case activeStation(Int?)
 	case presentStations(Int?)
@@ -574,6 +575,8 @@ extension LocalizableString {
 				return "no_transaction_desc"
 			case .mailLeaveMessageNote:
 				return "mail_leave_message_note"
+			case .noActiveStations:
+				return "no_active_stations"
 			case .activeStations:
 				return "active_stations_format"
 			case .activeStation:


### PR DESCRIPTION
## **Why?**
No active stations chip in cell details screen
### **How?**
- Implemented `PillsView` to support pills layout in the header of cell details
- Show "No active stations" chip when there are no active stations in the presented cell
### **Testing**
Go to a cell with no active stations and ensure the chip is visible
### **Additional context**
fixes fe-1750


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dynamic pill view layout for displaying information as horizontally arranged "pills" that wrap across rows based on available space.
  - Pills now show both active station status and total station count in a more modular and visually organized way.
- **Localization**
  - Added a new localized string for "No active stations".
- **Bug Fixes**
  - Improved handling and display of cases with no active stations.
- **Tests**
  - Added tests to verify correct pill rendering and display logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->