### PR TITLE
Fixes on analytics on info banner and announcement

### DIFF
--- a/PresentationLayer/Navigation/DeepLinkHandler.swift
+++ b/PresentationLayer/Navigation/DeepLinkHandler.swift
@@ -258,6 +258,20 @@ private extension DeepLinkHandler {
 	}
 }
 
+extension String {
+	@MainActor
+	var isProPromotionUrl: Bool {
+		guard let url = URL(string: self) else {
+			return false
+		}
+		let isWeatherXMScheme = url.scheme == Bundle.main.urlScheme
+		let isAnnouncement = url.host() == DeepLinkHandler.announcement
+		let isProPromo = Announcement(rawValue: url.lastPathComponent) == .weatherxmPro
+
+		return isWeatherXMScheme && isAnnouncement && isProPromo
+	}
+}
+
 private enum NotificationType {
 	case announcement(String)
 	case device(String)

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
@@ -259,7 +259,7 @@ public final class WeatherStationsHomeViewModel: ObservableObject {
 			return
 		}
 
-		WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .announcementButton,
+		WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .infoBannerButton,
 																	.itemId: .custom(url)])
 		Router.shared.showFullScreen(.safariView(webUrl))
 	}

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/Home/WeatherStationsHomeViewModel.swift
@@ -92,13 +92,16 @@ public final class WeatherStationsHomeViewModel: ObservableObject {
 					return
 				}
 
-				WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .proPromotionCTA,
-																			.itemId: .custom(urlString),
-																			.source: .remoteDevicesList])
+				WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .announcementCTA,
+																			.itemId: .custom(urlString)])
 
 				let handled = self?.mainVM?.deepLinkHandler.handleUrl(url) ?? false
 				if !handled, url.isHttp {
 					LinkNavigationHelper().openUrl(urlString)
+				} else if handled, urlString.isProPromotionUrl {
+					WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .proPromotionCTA,
+																				.itemId: .custom(urlString),
+																				.source: .remoteDevicesList])
 				}
 			}, closeAction: {
 				guard let announcementId = announcement?.id else {

--- a/WeatherXMTests/PresentationLayer/Navigation/DeepLinkHandlerTests.swift
+++ b/WeatherXMTests/PresentationLayer/Navigation/DeepLinkHandlerTests.swift
@@ -117,6 +117,27 @@ struct DeepLinkHandlerTests {
 		#expect(router.fullScreenRoute == nil)
 		#expect(router.path.isEmpty)
 	}
+
+	@Test
+	func isProPromotionUrl() {
+		var url = "weatherxm://announcement/weatherxm_pro"
+		#expect(url.isProPromotionUrl)
+		
+		url = "weatherxm://announcement/weatherxm_pro_test"
+		#expect(!url.isProPromotionUrl)
+
+		url = "weatherxm://announce/weatherxm_pro"
+		#expect(!url.isProPromotionUrl)
+
+		url = "weatherxm://announcement/weatherxm_pro/test"
+		#expect(!url.isProPromotionUrl)
+
+		url = ""
+		#expect(!url.isProPromotionUrl)
+
+		url = "http://announcement/weatherxm_pro/test"
+		#expect(!url.isProPromotionUrl)
+	}
 }
 
 private extension DeepLinkHandlerTests {

--- a/wxm-ios.xcodeproj/xcshareddata/xcschemes/wxm-ios.xcscheme
+++ b/wxm-ios.xcodeproj/xcshareddata/xcschemes/wxm-ios.xcscheme
@@ -104,7 +104,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-WXMAnalyticsDisabled YES"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
       <LocationScenarioReference

--- a/wxm-ios.xcodeproj/xcshareddata/xcschemes/wxm-ios.xcscheme
+++ b/wxm-ios.xcodeproj/xcshareddata/xcschemes/wxm-ios.xcscheme
@@ -104,7 +104,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-WXMAnalyticsDisabled YES"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
       <LocationScenarioReference

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
@@ -202,6 +202,8 @@ extension ParameterValue: RawRepresentable {
 				return "Privacy Policy"
 			case .announcementButton:
 				return "Announcement Button"
+			case .announcementCTA:
+				return "Announcement CTA"
 			case .infoBannerButton:
 				return "Info Banner Button"
 			case .login:

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
@@ -202,6 +202,8 @@ extension ParameterValue: RawRepresentable {
 				return "Privacy Policy"
 			case .announcementButton:
 				return "Announcement Button"
+			case .infoBannerButton:
+				return "Info Banner Button"
 			case .login:
 				return "Login"
 			case .email:

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
@@ -142,6 +142,7 @@ public enum ParameterValue {
 	case termsOfUse
 	case privacyPolicy
 	case announcementButton
+	case announcementCTA
 	case infoBannerButton
 	case heliumBLEPopupError
 	case heliumBLEPopup

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
@@ -142,6 +142,7 @@ public enum ParameterValue {
 	case termsOfUse
 	case privacyPolicy
 	case announcementButton
+	case infoBannerButton
 	case heliumBLEPopupError
 	case heliumBLEPopup
 	case searchLocation

--- a/wxm-ios/Toolkit/Toolkit/FirebaseManager/RemoteConfigManager.swift
+++ b/wxm-ios/Toolkit/Toolkit/FirebaseManager/RemoteConfigManager.swift
@@ -189,6 +189,12 @@ class MockRemoteConfigManager: RemoteConfigManagerImplementation, @unchecked Sen
 				if key == .iosAppMinimumVersion || key == .iosAppLatestVersion {
 					return "1.1.1" as? T
 				}
+
+				// For testing
+				if key == .announcementActionUrl {
+					return "weatherxm://announcement/weatherxm_pro" as? T
+				}
+
 				return "Dummy Text" as? T
 			case is Bool.Type:
 				return true as? T


### PR DESCRIPTION
## **Why?**
Replace `Announcement Button` event with `Info Banner Button`. Also add `Announcement CTA` event
### **How?**
- Declared new constants
- Added helper to detect if url is weather promo url
### **Testing**
Ensure the events are tracked.
You can use the mock scheme and edit the line 194 in `MockRemoteConfigManager` class to mock the announcement banner and ensure the events are logged properly via the console
### **Additional context**
fixes fe-1848


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detection for pro promotion announcement links within the app.

- **Bug Fixes**
  - Improved analytics tracking for announcement card and info banner button taps, ensuring accurate event categorization.

- **Tests**
  - Introduced tests to verify correct identification of pro promotion URLs.

- **Chores**
  - Updated mock data to include a pro promotion announcement URL for testing and development purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->