### PR TITLE
Historical data rendering issue

### DIFF
--- a/PresentationLayer/UIComponents/Screens/HistoryScreen/HistoryView/HistoryView.swift
+++ b/PresentationLayer/UIComponents/Screens/HistoryScreen/HistoryView/HistoryView.swift
@@ -53,7 +53,7 @@ struct HistoryView: View {
 struct Previews_HistoryView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationContainerView {
-            HistoryView(viewModel: ViewModelsFactory.getHistoryViewModel(device: DeviceDetails.emptyDeviceDetails, date: .now))
+			HistoryView(viewModel: ViewModelsFactory.getHistoryViewModel(device: DeviceDetails.mockDevice, date: .now))
         }
     }
 }

--- a/WeatherXMTests/Toolkit/DateExtensionsTests.swift
+++ b/WeatherXMTests/Toolkit/DateExtensionsTests.swift
@@ -60,7 +60,7 @@ final class DateExtensionsTests: XCTestCase {
 	func testDailyHourlySamples() {
 		let date = Date().set(hour: 3)
 		let samples = date?.dailyHourlySamples(timeZone: .current)
-		XCTAssert(samples?.count == 21, "The samples count should be 21")
+		XCTAssert(samples?.count == 24, "The samples count should be 21")
 	}
 
 	func testgetFormattedDate() {

--- a/wxm-ios/Toolkit/Toolkit/Utils/DateExtension.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/DateExtension.swift
@@ -258,7 +258,8 @@ public extension Date {
 	/// - Parameter timeZone: The needed timezone
 	/// - Returns: An array of dates with one hour diff
     func dailyHourlySamples(timeZone: TimeZone) -> [Date] {
-		guard let start = self.startOfHour, let end = self.endOfDay(timeZone: timeZone) else {
+		guard case let start = self.startOfDay(timeZone: timeZone),
+			  let end = self.endOfDay(timeZone: timeZone) else {
 			return []
 		}
 


### PR DESCRIPTION
## **Why?**
There is an issue in historical data screen when the station's timezone is in "+HH:30" format. eg. India with UTC+05:30
### **How?**
Fixed the x axis samples generation
### **Testing**
Ensure nothing is broken in stations with "normal" timezone and the graphs are rendered  as expected in stations with "strange" timezones (eg. India).
### **Additional context**
fixes fe-1850


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the preview setup for the history view to use more representative mock data.
  - Adjusted date calculations to use the start of the day instead of the start of the hour for hourly sample generation, ensuring accuracy based on the selected time zone.
- **Tests**
  - Updated hourly sample tests to expect 24 samples, reflecting the revised date calculation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->