### PR TITLE
Track more info on keychain error

### DIFF
--- a/WeatherXMTests/DataLayer/Services/KeychainHelperServiceTests.swift
+++ b/WeatherXMTests/DataLayer/Services/KeychainHelperServiceTests.swift
@@ -12,10 +12,13 @@ import Toolkit
 
 @Suite(.serialized)
 struct KeychainHelperServiceTests {
-	let service = KeychainHelperService()
+	let logger: MockLogger
+	let service: KeychainHelperService
 	let cancellableWrapper: CancellableWrapper
 
 	init() async throws {
+		logger = .init()
+		service = .init(logger: logger)
 		cancellableWrapper  = .init()
 		service.deleteNetworkTokenResponseFromKeychain()
 		service.deleteEmailAndPassword()
@@ -69,8 +72,13 @@ struct KeychainHelperServiceTests {
 		}
 	}
 
-	@Test func storeEmail() {
+	@Test func storeEmail() throws {
+		#expect(logger.nsError == nil)
 		#expect(service.getUsersAccountInfo() == nil)
+		let nsError = try #require(logger.nsError)
+		#expect(nsError.domain == "keychain")
+		#expect(nsError.code == -1)
+		#expect(nsError.userInfo["service"] as? String == KeychainConstants.saveAccountInfo.service)
 		service.saveEmailAndPasswordToKeychain(email: "email", password: "password")
 		let accountInfo = service.getUsersAccountInfo()
 		#expect(accountInfo?.email == "email")

--- a/WeatherXMTests/DataLayer/Services/MockLogger.swift
+++ b/WeatherXMTests/DataLayer/Services/MockLogger.swift
@@ -1,0 +1,23 @@
+//
+//  MockLogger.swift
+//  WeatherXMTests
+//
+//  Created by Pantelis Giazitsis on 13/6/25.
+//
+
+import Foundation
+import Toolkit
+
+class MockLogger: LoggerApi {
+	private(set) var networkError: (any NetworkError)? = nil
+	private(set) var nsError: NSError? = nil
+
+
+	func logNetworkError(_ networkError: any NetworkError) {
+		self.networkError = networkError
+	}
+
+	func logError(_ nsError: NSError) {
+		self.nsError = nsError
+	}
+}

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -343,6 +343,7 @@
 		267811502D4BB21700D22B67 /* UserInfoServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2678114F2D4BB21700D22B67 /* UserInfoServiceTests.swift */; };
 		267811522D4BB61800D22B67 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 267811512D4BB61800D22B67 /* Alamofire */; };
 		267811582D4CD84E00D22B67 /* UserDevicesServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267811572D4CD84E00D22B67 /* UserDevicesServiceTests.swift */; };
+		2678C45D2DFC3EF300523DF8 /* MockLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2678C45C2DFC3EF300523DF8 /* MockLogger.swift */; };
 		2678ED8F2AFD1B1400940D59 /* RewardsTimelinePagination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2678ED8E2AFD1B1400940D59 /* RewardsTimelinePagination.swift */; };
 		267A37832AEBB4C900469126 /* StationRewardsTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267A37822AEBB4C900469126 /* StationRewardsTimelineView.swift */; };
 		267A378A2AEBFF2F00469126 /* DeviceRewardsOverview+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267A37892AEBFF2F00469126 /* DeviceRewardsOverview+.swift */; };
@@ -1087,6 +1088,7 @@
 		267811092D49279300D22B67 /* FiltersServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersServiceTest.swift; sourceTree = "<group>"; };
 		2678114F2D4BB21700D22B67 /* UserInfoServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoServiceTests.swift; sourceTree = "<group>"; };
 		267811572D4CD84E00D22B67 /* UserDevicesServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDevicesServiceTests.swift; sourceTree = "<group>"; };
+		2678C45C2DFC3EF300523DF8 /* MockLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLogger.swift; sourceTree = "<group>"; };
 		2678ED8E2AFD1B1400940D59 /* RewardsTimelinePagination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardsTimelinePagination.swift; sourceTree = "<group>"; };
 		267A37822AEBB4C900469126 /* StationRewardsTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationRewardsTimelineView.swift; sourceTree = "<group>"; };
 		267A37892AEBFF2F00469126 /* DeviceRewardsOverview+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeviceRewardsOverview+.swift"; sourceTree = "<group>"; };
@@ -2455,6 +2457,7 @@
 				26DF1F512D535EB10001E936 /* KeychainHelperServiceTests.swift */,
 				26DF1F552D54AC360001E936 /* FileUploaderServiceTests.swift */,
 				26DF1F632D56328B0001E936 /* PhotosRepositoryImplTests.swift */,
+				2678C45C2DFC3EF300523DF8 /* MockLogger.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -3720,6 +3723,7 @@
 				26F83CA12D9D357200E5A8B8 /* HistoryContainerViewModelTests.swift in Sources */,
 				26F83CE32D9FDBD100E5A8B8 /* ForecastDetailsViewModelTests.swift in Sources */,
 				26710E982D7F2B2C00878298 /* DeviceLocationUseCaseTests.swift in Sources */,
+				2678C45D2DFC3EF300523DF8 /* MockLogger.swift in Sources */,
 				26F83CA52D9D3E4200E5A8B8 /* HistoryViewModelTests.swift in Sources */,
 				268BAD4E2DC0DEAA00748439 /* NetworkDevicesInfoResponseTests.swift in Sources */,
 				26F83CEB2D9FFAF900E5A8B8 /* RewardAnalyticsViewModelTests.swift in Sources */,

--- a/wxm-ios/DataLayer/KeychainHelperService/KeychainHelperService.swift
+++ b/wxm-ios/DataLayer/KeychainHelperService/KeychainHelperService.swift
@@ -12,14 +12,16 @@ import Toolkit
 public final class KeychainHelperService {
 
 	private let accessGroup: String
+	private let logger: LoggerApi
 
-	public init() {
+	public init(logger: LoggerApi = Logger.shared) {
 		guard let teamId: String = Bundle.main.getConfiguration(for: .teamId),
 				let appGroup: String = Bundle.main.getConfiguration(for: .appGroup) else {
 			fatalError("Should provide teamId in configuration file")
 		}
 		
 		accessGroup = "\(teamId).\(appGroup)"
+		self.logger = logger
 	}
 
     func save<T>(_ item: T, service: String, account: String) where T: Codable {
@@ -82,7 +84,7 @@ public final class KeychainHelperService {
 			let error = NSError(domain: "keychain", code: -1, userInfo: ["service": service,
 																		 "message": message ?? "",
 																		 "osStatus": status])
-			Logger.shared.logError(error)
+			logger.logError(error)
 		}
         
 		return (result as? Data)

--- a/wxm-ios/DataLayer/KeychainHelperService/KeychainHelperService.swift
+++ b/wxm-ios/DataLayer/KeychainHelperService/KeychainHelperService.swift
@@ -79,7 +79,9 @@ public final class KeychainHelperService {
 		// Debug
 		if status != errSecSuccess {
 			let message = SecCopyErrorMessageString(status, nil) as? String
-			let error = NSError(domain: "keychain", code: -1, userInfo: ["message": message ?? "", "osStatus": status])
+			let error = NSError(domain: "keychain", code: -1, userInfo: ["service": service,
+																		 "message": message ?? "",
+																		 "osStatus": status])
 			Logger.shared.logError(error)
 		}
         

--- a/wxm-ios/Toolkit/Toolkit/Logger/Logger.swift
+++ b/wxm-ios/Toolkit/Toolkit/Logger/Logger.swift
@@ -8,7 +8,12 @@
 import Foundation
 import FirebaseCrashlytics
 
-public class Logger: @unchecked Sendable {
+public protocol LoggerApi {
+	func logNetworkError(_ networkError: any NetworkError)
+	func logError(_ nsError: NSError)
+}
+
+public class Logger: @unchecked Sendable, LoggerApi {
 	public static let shared = Logger()
 
 	private init() {}


### PR DESCRIPTION
## **Why?**
Need more info to log on a keychain error
### **How?**
- Added service name value in error logging in `KeychainHelperService`.
- Inject logger to `KeychainHelperService` for testing purposes 
- Updated the tests to ensure everything works as expected 
### **Testing**
Check codewise. It's not so trivial to test it via the firebase console
### **Additional context**
fixes fe-1865
