### PR TITLE
Network growth card

### DIFF
--- a/PresentationLayer/Navigation/Router.swift
+++ b/PresentationLayer/Navigation/Router.swift
@@ -76,6 +76,8 @@ enum Route: Hashable, Equatable {
 				hasher.combine(vm)
 			case .tokenMetrics(let vm):
 				hasher.combine(vm)
+			case .netWorkGrowth(let vm):
+				hasher.combine(vm)
 			case .safariView(let url):
 				hasher.combine(url)
 		}
@@ -141,6 +143,8 @@ enum Route: Hashable, Equatable {
 				"proPromo"
 			case .tokenMetrics:
 				"tokenMetrics"
+			case .netWorkGrowth:
+				"netWorkGrowth"
 			case .safariView:
 				"safariView"
 		}
@@ -174,6 +178,7 @@ enum Route: Hashable, Equatable {
 	case photoGallery(GalleryViewModel)
 	case proPromo(ProPromotionalViewModel)
 	case tokenMetrics(NetworkStatsViewModel)
+	case netWorkGrowth(NetworkStatsViewModel)
 	case safariView(URL)
 }
 
@@ -270,6 +275,10 @@ extension Route {
 			case .tokenMetrics(let netStatsViewModel):
 				NavigationContainerView {
 					TokenMetricsView(viewModel: netStatsViewModel)
+				}
+			case .netWorkGrowth(let netStatsViewModel):
+				NavigationContainerView {
+					NetworkGrowthView(viewModel: netStatsViewModel)
 				}
 			case .safariView(let url):
 				SafariView(url: url)

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkGrowthView.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkGrowthView.swift
@@ -1,0 +1,87 @@
+//
+//  NetworkGrowthView.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 19/6/25.
+//
+
+import SwiftUI
+
+struct NetworkGrowthView: View {
+	@ObservedObject var viewModel: NetworkStatsViewModel
+	@EnvironmentObject var navigationObject: NavigationObject
+
+    var body: some View {
+		ZStack {
+			Color(colorEnum: .bg)
+				.ignoresSafeArea()
+
+			ScrollView {
+				VStack(spacing: CGFloat(.mediumSpacing)) {
+					weatherStationsView
+					lastUpdatedView
+				}
+				.padding(CGFloat(.defaultSidePadding))
+			}
+		}
+		.onAppear {
+			navigationObject.title = LocalizableString.NetStats.networkGrowth.localized
+			navigationObject.navigationBarColor = Color(colorEnum: .bg)
+		}
+    }
+}
+
+extension NetworkGrowthView {
+	@ViewBuilder
+	var weatherStationsView: some View {
+		if let stationStats = viewModel.stationStats {
+			VStack(spacing: CGFloat(.mediumSpacing)) {
+				HStack {
+					Text(LocalizableString.NetStats.weatherStations.localized)
+						.font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
+						.foregroundColor(Color(colorEnum: .text))
+					Spacer()
+				}
+				.padding(.horizontal, 24.0)
+
+				VStack(spacing: CGFloat(.mediumSpacing)) {
+					ForEach(stationStats, id: \.title) { stats in
+						stationStatsView(statistics: stats) { statistics, details in
+							viewModel.handleDetailsActionTap(statistics: statistics, details: details)
+						}
+					}
+				}
+				.padding(.horizontal, CGFloat(.smallToMediumSidePadding))
+			}
+			.WXMCardStyle(backgroundColor: Color(colorEnum: .top),
+						  insideHorizontalPadding: 0.0,
+						  insideVerticalPadding: CGFloat(.smallToMediumSidePadding))
+			.wxmShadow()
+
+		} else {
+			EmptyView()
+		}
+	}
+
+	@ViewBuilder
+	var lastUpdatedView: some View {
+		if let lastUpdated = viewModel.lastUpdatedText {
+			HStack {
+				Spacer()
+
+				Text(lastUpdated)
+					.font(.system(size: CGFloat(.normalFontSize), weight: .thin))
+					.foregroundColor(Color(colorEnum: .text))
+
+			}
+		} else {
+			EmptyView()
+		}
+	}
+}
+
+#Preview {
+	NavigationContainerView {
+		NetworkGrowthView(viewModel: ViewModelsFactory.getNetworkStatsViewModel())
+	}
+}

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkGrowthView.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkGrowthView.swift
@@ -37,7 +37,7 @@ extension NetworkGrowthView {
 		if let stationStats = viewModel.stationStats {
 			VStack(spacing: CGFloat(.mediumSpacing)) {
 				HStack {
-					Text(LocalizableString.NetStats.weatherStations.localized)
+					Text(LocalizableString.NetStats.weatherStationsBreakdown.localized)
 						.font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
 						.foregroundColor(Color(colorEnum: .text))
 					Spacer()

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStats+Content.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStats+Content.swift
@@ -84,15 +84,6 @@ extension NetworkStatsView {
 
 extension NetworkStatsView {
     @ViewBuilder
-    var dataDaysView: some View {
-        if let dataDays = viewModel.dataDays {
-            generateStatsView(stats: dataDays)
-        } else {
-            EmptyView()
-        }
-    }
-
-    @ViewBuilder
     var rewardsView: some View {
         if let rewards = viewModel.rewards {
             generateStatsView(stats: rewards)

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStats+Content.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStats+Content.swift
@@ -110,6 +110,15 @@ extension NetworkStatsView {
 		}
 	}
 
+	@ViewBuilder
+	var growthView: some View {
+		if let growth = viewModel.growth {
+			generateStatsView(stats: growth)
+		} else {
+			EmptyView()
+		}
+	}
+
     @ViewBuilder
     var buyStationView: some View {
 		PercentageGridLayoutView {

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStats+Content.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStats+Content.swift
@@ -203,35 +203,4 @@ extension NetworkStatsView {
             EmptyView()
         }
     }
-    @ViewBuilder
-    var weatherStationsView: some View {
-        if let stationStats = viewModel.stationStats {
-            VStack(spacing: CGFloat(.mediumSpacing)) {
-                HStack {
-                    Text(LocalizableString.NetStats.weatherStations.localized)
-                        .font(.system(size: CGFloat(.mediumFontSize), weight: .bold))
-                        .foregroundColor(Color(colorEnum: .text))
-                    Spacer()
-                }
-                .padding(.horizontal, 24.0)
-
-                VStack(spacing: CGFloat(.mediumSpacing)) {
-                    ForEach(stationStats, id: \.title) { stats in
-						stationStatsView(statistics: stats) { statistics, details in
-							viewModel.handleDetailsActionTap(statistics: statistics, details: details)
-						}
-                    }
-                }
-				.padding(.horizontal, CGFloat(.smallToMediumSidePadding))
-            }
-            .WXMCardStyle(backgroundColor: Color(colorEnum: .top),
-                          insideHorizontalPadding: 0.0,
-                          insideVerticalPadding: CGFloat(.smallToMediumSidePadding))
-            .wxmShadow()
-
-        } else {
-            EmptyView()
-        }
-    }
-
 }

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsView.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsView.swift
@@ -47,7 +47,6 @@ private extension NetworkStatsView {
             viewModel.refresh(completion: completion)
         } content: {
             VStack(spacing: CGFloat(.mediumSpacing)) {
-                dataDaysView
 				healthView
 				growthView
                 buyStationView

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsView.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsView.swift
@@ -49,6 +49,7 @@ private extension NetworkStatsView {
             VStack(spacing: CGFloat(.mediumSpacing)) {
                 dataDaysView
 				healthView
+				growthView
                 buyStationView
 				ProBannerView(description: LocalizableString.Promotional.wantMoreAccurateForecast.localized,
 							  analyticsSource: .localNetworkStats)

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel+Factory.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel+Factory.swift
@@ -138,6 +138,33 @@ extension NetworkStatsViewModel {
 							 analyticsItemId: .allocatedRewards)
 	}
 
+	func getGrowthStatistics(response: NetworkStatsResponse?) -> NetworkStatsView.Statistics? {
+		guard let growth = response?.growth,
+			  let timeSeries = fixedTimeSeries(timeSeries: growth.last30DaysGraph) else {
+			return nil
+		}
+		let networkSize = growth.networkSize ?? 0
+		let netSize = NetworkStatsView.AdditionalStats(title: LocalizableString.NetStats.networkSize.localized,
+													   value: networkSize.localizedFormatted,
+												   accessory: nil,
+												   analyticsItemId: nil)
+
+		let value = growth.last30Days ?? 0
+		let lastAdded = LocalizableString.NetStats.addedInLastXDays(30).localized
+		let lastAddedStations = NetworkStatsView.AdditionalStats(title: lastAdded.uppercased(),
+															  value: value.localizedFormatted,
+															  analyticsItemId: nil)
+
+		return getStatistics(from: timeSeries,
+							 title: LocalizableString.NetStats.networkGrowth.localized,
+							 chartTitle: LocalizableString.NetStats.networkScaleUp.localized,
+							 chartValueText: LocalizableString.percentage(Float(growth.networkScaleUp ?? 0)).localized,
+							 description: nil,
+							 accessory: nil,
+							 additionalStats: [netSize, lastAddedStations],
+							 analyticsItemId: .allocatedRewards)
+	}
+
 
 	func getTokenStatistics(response: NetworkStatsResponse?) -> NetworkStatsView.Statistics? {
 		guard let tokens = response?.rewards?.tokenMetrics?.token else {

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel+Factory.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel+Factory.swift
@@ -162,7 +162,12 @@ extension NetworkStatsViewModel {
 							 description: nil,
 							 accessory: nil,
 							 additionalStats: [netSize, lastAddedStations],
-							 analyticsItemId: .allocatedRewards)
+							 analyticsItemId: .allocatedRewards) { [weak self] in
+			guard let self else {
+				return
+			}
+			self.router.navigateTo(.netWorkGrowth(self))
+		}
 	}
 
 
@@ -208,16 +213,16 @@ extension NetworkStatsViewModel {
 	}
 
     func getStationStats(response: NetworkStatsResponse?) -> [NetworkStatsView.StationStatistics]? {
-		let total = (LocalizableString.total(nil).localized,
-					 response?.weatherStations?.onboarded,
-					 NetworkStatsView.Accessory(fontIcon: .infoCircle) { [weak self] in
+		let manufactured = (LocalizableString.NetStats.manufactured.localized.uppercased(),
+							response?.weatherStations?.onboarded,
+							NetworkStatsView.Accessory(fontIcon: .infoCircle) { [weak self] in
 			self?.showInfo(title: LocalizableString.NetStats.totalWeatherStationsInfoTitle.localized,
 						   description: LocalizableString.NetStats.totalWeatherStationsInfoText.localized,
 						   analyticsItemId: .total)
 		},
-					 ParameterValue.total)
+							ParameterValue.total)
 
-		let claimed = (LocalizableString.NetStats.claimed.localized,
+		let deployed = (LocalizableString.NetStats.deployed.localized.uppercased(),
 					   response?.weatherStations?.claimed,
 					   NetworkStatsView.Accessory(fontIcon: .infoCircle) { [weak self] in
 			self?.showInfo(title: LocalizableString.NetStats.claimedWeatherStationsInfoTitle.localized,
@@ -227,7 +232,7 @@ extension NetworkStatsViewModel {
 
 					   ParameterValue.claimed)
 
-		let active = (LocalizableString.NetStats.active.localized,
+		let active = (LocalizableString.NetStats.active.localized.uppercased(),
 					  response?.weatherStations?.active,
 					  NetworkStatsView.Accessory(fontIcon: .infoCircle) { [weak self] in
 			self?.showInfo(title: LocalizableString.NetStats.activeWeatherStationsInfoTitle.localized,
@@ -236,7 +241,7 @@ extension NetworkStatsViewModel {
 		},
 					  ParameterValue.active)
 
-        let sections = [total, claimed, active]
+		let sections = [manufactured, deployed, active]
 
         return sections.compactMap { title, stats, info, analyticsItemId in
             guard let stats else {

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel+Factory.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel+Factory.swift
@@ -13,7 +13,7 @@ import SwiftUI
 
 extension NetworkStatsViewModel {
     func getDataDaysStatistics(response: NetworkStatsResponse?) -> NetworkStatsView.Statistics? {
-        guard let dataDays = fixedTimeSeries(timeSeries: response?.dataDays) else {
+        guard let dataDays = response?.dataDays else {
             return nil
         }
         let total = NetworkStatsView.AdditionalStats(title: LocalizableString.total(nil).localized,
@@ -46,7 +46,7 @@ extension NetworkStatsViewModel {
 
     func getRewardsStatistics(response: NetworkStatsResponse?) -> NetworkStatsView.Statistics? {
 		guard let tokens = response?.rewards,
-			  let allocatedPerDay = fixedTimeSeries(timeSeries: tokens.last30DaysGraph) else {
+			  let allocatedPerDay = tokens.last30DaysGraph else {
             return nil
         }
 		let totalValue = tokens.total
@@ -99,7 +99,7 @@ extension NetworkStatsViewModel {
 
 	func getHealthStatistics(response: NetworkStatsResponse?) -> NetworkStatsView.Statistics? {
 		guard let health = response?.health,
-			  let timeSeries = fixedTimeSeries(timeSeries: health.health30DaysGraph) else {
+			  let timeSeries = health.health30DaysGraph else {
 			return nil
 		}
 		let qualityScore = Float(health.networkAvgQod ?? 0)
@@ -140,7 +140,7 @@ extension NetworkStatsViewModel {
 
 	func getGrowthStatistics(response: NetworkStatsResponse?) -> NetworkStatsView.Statistics? {
 		guard let growth = response?.growth,
-			  let timeSeries = fixedTimeSeries(timeSeries: growth.last30DaysGraph) else {
+			  let timeSeries = growth.last30DaysGraph else {
 			return nil
 		}
 		let networkSize = growth.networkSize ?? 0
@@ -375,21 +375,4 @@ private extension NetworkStatsViewModel {
 										   cardTapAction: cardTapAction,
 										   customView: customView)
     }
-
-	func fixedTimeSeries(timeSeries: [NetworkStatsTimeSeries]?) -> [NetworkStatsTimeSeries]? {
-		guard let timeSeries, let lastItem = timeSeries.last else {
-			return nil
-		}
-
-		var dropCount = -1
-		for item in timeSeries.reversed() {
-			if lastItem.value == item.value {
-				dropCount += 1
-			} else {
-				break
-			}
-		}
-
-		return Array(timeSeries.dropLast(dropCount))
-	}
 }

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel+Factory.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel+Factory.swift
@@ -12,38 +12,6 @@ import Toolkit
 import SwiftUI
 
 extension NetworkStatsViewModel {
-    func getDataDaysStatistics(response: NetworkStatsResponse?) -> NetworkStatsView.Statistics? {
-        guard let dataDays = response?.dataDays else {
-            return nil
-        }
-        let total = NetworkStatsView.AdditionalStats(title: LocalizableString.total(nil).localized,
-                                                     value: dataDays.last?.value?.toCompactDecimaFormat ?? "?",
-                                                     color: .text,
-                                                     accessory: nil,
-                                                     analyticsItemId: nil)
-        
-        let count = dataDays.count
-        let lastDataDayValue = dataDays.last?.value ?? 0.0
-        let preLastDataDayValue = dataDays[safe: count - 2]?.value ?? 0.0
-        let value = (lastDataDayValue - preLastDataDayValue).toCompactDecimaFormat ?? "?"
-        let preLastDay = NetworkStatsView.AdditionalStats(title: LocalizableString.NetStats.lastRun.localized,
-                                                          value: "+\(value)",
-                                                          color: .reward_score_very_high,
-                                                          accessory: nil,
-                                                          analyticsItemId: nil)
-		let accessory = NetworkStatsView.Accessory(fontIcon: .infoCircle) { [weak self] in
-			self?.showInfo(title: LocalizableString.NetStats.weatherStationDays.localized,
-						   description: LocalizableString.NetStats.dataDaysInfoText.localized,
-						   analyticsItemId: .dataDays)
-		}
-
-        return getStatistics(from: dataDays,
-                             title: LocalizableString.NetStats.weatherStationDays.localized,
-                             accessory: accessory,
-                             additionalStats: [total, preLastDay],
-                             analyticsItemId: .dataDays)
-    }
-
     func getRewardsStatistics(response: NetworkStatsResponse?) -> NetworkStatsView.Statistics? {
 		guard let tokens = response?.rewards,
 			  let allocatedPerDay = tokens.last30DaysGraph else {

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel+Factory.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel+Factory.swift
@@ -216,7 +216,7 @@ extension NetworkStatsViewModel {
 		let manufactured = (LocalizableString.NetStats.manufactured.localized.uppercased(),
 							response?.weatherStations?.onboarded,
 							NetworkStatsView.Accessory(fontIcon: .infoCircle) { [weak self] in
-			self?.showInfo(title: LocalizableString.NetStats.totalWeatherStationsInfoTitle.localized,
+			self?.showInfo(title: LocalizableString.NetStats.manufactured.localized,
 						   description: LocalizableString.NetStats.totalWeatherStationsInfoText.localized,
 						   analyticsItemId: .total)
 		},
@@ -225,7 +225,7 @@ extension NetworkStatsViewModel {
 		let deployed = (LocalizableString.NetStats.deployed.localized.uppercased(),
 					   response?.weatherStations?.claimed,
 					   NetworkStatsView.Accessory(fontIcon: .infoCircle) { [weak self] in
-			self?.showInfo(title: LocalizableString.NetStats.claimedWeatherStationsInfoTitle.localized,
+			self?.showInfo(title: LocalizableString.NetStats.deployed.localized,
 						   description: LocalizableString.NetStats.claimedWeatherStationsInfoText.localized,
 						   analyticsItemId: .claimed)
 		},

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel.swift
@@ -31,8 +31,9 @@ class NetworkStatsViewModel: ObservableObject {
 
     private var isEmpty: Bool {
         rewards == nil &&
-        stationStats == nil
-    }
+		health == nil &&
+		growth == nil
+	}
 
 	private let useCase: NetworkUseCaseApi?
     private var cancellables: Set<AnyCancellable> = []

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel.swift
@@ -18,6 +18,7 @@ class NetworkStatsViewModel: ObservableObject {
     @Published var dataDays: NetworkStatsView.Statistics?
     @Published var rewards: NetworkStatsView.Statistics?
 	@Published var health: NetworkStatsView.Statistics?
+	@Published var growth: NetworkStatsView.Statistics?
     @Published var token: NetworkStatsView.Statistics?
 	@Published var totalAllocated: NetworkStatsView.Statistics?
     @Published var stationStats: [NetworkStatsView.StationStatistics]?
@@ -118,6 +119,7 @@ private extension NetworkStatsViewModel {
         self.dataDays = getDataDaysStatistics(response: response)
         self.rewards = getRewardsStatistics(response: response)
 		self.health = getHealthStatistics(response: response)
+		self.growth = getGrowthStatistics(response: response)
         self.token = getTokenStatistics(response: response)
 		self.totalAllocated = getTotalAllocatedRewards(response: response)
         self.stationStats = getStationStats(response: response)

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel.swift
@@ -15,7 +15,6 @@ import SwiftUI
 @MainActor
 class NetworkStatsViewModel: ObservableObject {
 
-    @Published var dataDays: NetworkStatsView.Statistics?
     @Published var rewards: NetworkStatsView.Statistics?
 	@Published var health: NetworkStatsView.Statistics?
 	@Published var growth: NetworkStatsView.Statistics?
@@ -31,7 +30,6 @@ class NetworkStatsViewModel: ObservableObject {
     private(set) var info: BottomSheetInfo?
 
     private var isEmpty: Bool {
-        dataDays == nil &&
         rewards == nil &&
         stationStats == nil
     }
@@ -116,7 +114,6 @@ private extension NetworkStatsViewModel {
     }
 
     func updateStats(from response: NetworkStatsResponse?) {
-        self.dataDays = getDataDaysStatistics(response: response)
         self.rewards = getRewardsStatistics(response: response)
 		self.health = getHealthStatistics(response: response)
 		self.growth = getGrowthStatistics(response: response)
@@ -128,88 +125,5 @@ private extension NetworkStatsViewModel {
         if let lastUpdated = response?.lastUpdated {
 			lastUpdatedText = LocalizableString.lastUpdated(lastUpdated.localizedDateString()).localized
         }
-    }
-}
-
-// MARK: - Mock
-
-extension NetworkStatsViewModel {
-	static var mock: NetworkStatsViewModel {
-		let viewModel = NetworkStatsViewModel()
-		viewModel.dataDays = NetworkStatsView.Statistics(title: LocalizableString.NetStats.weatherStationDays.localized,
-														 description: nil,
-														 showExternalLinkIcon: false,
-														 externalLinkTapAction: nil,
-														 mainText: "90,2K",
-														 accessory: .init(fontIcon: .infoCircle) {
-			viewModel.showInfo(title: LocalizableString.NetStats.weatherStationDays.localized,
-							   description: "This is info",
-							   analyticsItemId: .dataDays)
-		},
-														 dateString: "Yesterday",
-														 chartModel: .mock(),
-														 xAxisTuple: nil,
-														 analyticsItemId: .dataDays,
-														 cardTapAction: nil)
-
-		let addtional: [NetworkStatsView.AdditionalStats] = [.init(title: "Total supply",
-																   value: "100,000,000",
-																   accessory: .init(fontIcon: .infoCircle,
-																					action: { }),
-																   analyticsItemId: nil),
-															 .init(title: "Daily Minted", value: "20,020", analyticsItemId: nil)]
-		viewModel.rewards = NetworkStatsView.Statistics(title: LocalizableString.NetStats.wxmRewardsTitle.localized,
-														description: nil,
-														showExternalLinkIcon: false,
-														externalLinkTapAction: nil,
-														mainText: "90,2K",
-														accessory: .init(fontIcon: .infoCircle) {
-			viewModel.showInfo(title: LocalizableString.NetStats.wxmRewardsTitle.localized,
-							   description: "This is info",
-							   analyticsItemId: .allocatedRewards)
-		},
-														dateString: "Yesterday",
-														chartModel: .mock(),
-														xAxisTuple: nil,
-														additionalStats: addtional,
-														analyticsItemId: .allocatedRewards,
-														cardTapAction: nil)
-
-		let stationStats = NetworkStatsView.StationStatistics(title: "Total",
-															  total: "7,823",
-															  details: [.init(title: "WS1000",
-																			  value: "5,642",
-																			  percentage: 0.2,
-																			  color: .crypto,
-																			  url: nil),
-																		.init(title: "WS2000",
-																			  value: "8,642",
-																			  percentage: 1.0,
-																			  color: .wxmPrimary,
-																			  url: nil)],
-															  analyticsItemId: .total)
-
-		let stationStats1 = NetworkStatsView.StationStatistics(title: "Claimed",
-															   total: "7,823",
-															   accessory: .init(fontIcon: .infoCircle) {
-			viewModel.showInfo(title: "Claimed",
-							   description: "This is info",
-							   analyticsItemId: .claimed)
-		},
-															   details: [.init(title: "WS1000",
-																			   value: "5,642",
-																			   percentage: 0.2,
-																			   color: .crypto,
-																			   url: nil),
-																		 .init(title: "WS2000",
-																			   value: "8,642",
-																			   percentage: 0.8,
-																			   color: .wxmPrimary,
-																			   url: nil)],
-															   analyticsItemId: .claimed)
-
-        viewModel.stationStats = [stationStats, stationStats1]
-
-        return viewModel
     }
 }

--- a/WeatherXMTests/DataLayer/Bluetooth/BTUtils.swift
+++ b/WeatherXMTests/DataLayer/Bluetooth/BTUtils.swift
@@ -10,7 +10,7 @@ import CoreBluetoothMock
 
 func simulateNormal() async  throws{
 	CBMCentralManagerMock.simulatePowerOff()
-	CBMCentralManagerMock.simulatePeripherals([mockHelium, mockBTDevice])
+//	CBMCentralManagerMock.simulatePeripherals([mockHelium, mockBTDevice])
 	CBMCentralManagerMock.simulatePowerOn()
 	try await Task.sleep(for: .seconds(1))
 }
@@ -22,14 +22,14 @@ func simulatePoweredOff() async throws {
 
 func simulateNoWXMDevice() async  throws{
 	CBMCentralManagerMock.simulatePowerOff()
-	CBMCentralManagerMock.simulatePeripherals([mockBTDevice])
+//	CBMCentralManagerMock.simulatePeripherals([mockBTDevice])
 	CBMCentralManagerMock.simulatePowerOn()
 	try await Task.sleep(for: .seconds(1))
 }
 
 func simulateNotConnectable() async  throws{
 	CBMCentralManagerMock.simulatePowerOff()
-	CBMCentralManagerMock.simulatePeripherals([mockNotConnectableHelium, mockBTDevice])
+//	CBMCentralManagerMock.simulatePeripherals([mockNotConnectableHelium, mockBTDevice])
 	CBMCentralManagerMock.simulatePowerOn()
 	try await Task.sleep(for: .seconds(1))
 }

--- a/WeatherXMTests/DataLayer/Bluetooth/BTUtils.swift
+++ b/WeatherXMTests/DataLayer/Bluetooth/BTUtils.swift
@@ -10,7 +10,7 @@ import CoreBluetoothMock
 
 func simulateNormal() async  throws{
 	CBMCentralManagerMock.simulatePowerOff()
-//	CBMCentralManagerMock.simulatePeripherals([mockHelium, mockBTDevice])
+	CBMCentralManagerMock.simulatePeripherals([mockHelium, mockBTDevice])
 	CBMCentralManagerMock.simulatePowerOn()
 	try await Task.sleep(for: .seconds(1))
 }
@@ -22,14 +22,14 @@ func simulatePoweredOff() async throws {
 
 func simulateNoWXMDevice() async  throws{
 	CBMCentralManagerMock.simulatePowerOff()
-//	CBMCentralManagerMock.simulatePeripherals([mockBTDevice])
+	CBMCentralManagerMock.simulatePeripherals([mockBTDevice])
 	CBMCentralManagerMock.simulatePowerOn()
 	try await Task.sleep(for: .seconds(1))
 }
 
 func simulateNotConnectable() async  throws{
 	CBMCentralManagerMock.simulatePowerOff()
-//	CBMCentralManagerMock.simulatePeripherals([mockNotConnectableHelium, mockBTDevice])
+	CBMCentralManagerMock.simulatePeripherals([mockNotConnectableHelium, mockBTDevice])
 	CBMCentralManagerMock.simulatePowerOn()
 	try await Task.sleep(for: .seconds(1))
 }

--- a/WeatherXMTests/DomainLayer/MockRepositories/MockNetworkRepositoryImpl.swift
+++ b/WeatherXMTests/DomainLayer/MockRepositories/MockNetworkRepositoryImpl.swift
@@ -19,8 +19,6 @@ class MockNetworkRepositoryImpl {
 extension MockNetworkRepositoryImpl: NetworkRepository {
 	func getNetworkStats() throws -> AnyPublisher<DataResponse<NetworkStatsResponse, NetworkErrorResponse>, Never> {
 		let statsResponse = NetworkStatsResponse(weatherStations: nil,
-												 dataDays: nil,
-												 tokens: nil,
 												 contracts: nil,
 												 rewards: nil,
 												 health: nil,

--- a/WeatherXMTests/DomainLayer/MockRepositories/MockNetworkRepositoryImpl.swift
+++ b/WeatherXMTests/DomainLayer/MockRepositories/MockNetworkRepositoryImpl.swift
@@ -22,7 +22,11 @@ extension MockNetworkRepositoryImpl: NetworkRepository {
 												 dataDays: nil,
 												 tokens: nil,
 												 contracts: nil,
+												 rewards: nil,
+												 health: nil,
+												 growth: nil,
 												 lastUpdated: nil)
+
 		let response = DataResponse<NetworkStatsResponse, NetworkErrorResponse>(request: nil,
 																				response: nil,
 																				data: nil,

--- a/WeatherXMTests/PresentationLayer/Extensions/DomainExtensions/DomainExtensionsTests.swift
+++ b/WeatherXMTests/PresentationLayer/Extensions/DomainExtensions/DomainExtensionsTests.swift
@@ -19,37 +19,17 @@ struct DomainExtensionsTests {
 
 	@Test
 	func networkStationsStatsTokensSupplyProgress() {
-		var tokens = NetworkStationsStatsTokens(totalSupply: 1000,
-												circulatingSupply: 250,
-												totalAllocated: nil,
-												allocatedPerDay: nil,
-												lastTxHashUrl: nil,
-												averageMonthly: nil)
-//		#expect(tokens.supplyProgress == 0.25)
+		var tokens = NetworkStatsToken(circulatingSupply: 250, totalSupply: 1000)
+		#expect(tokens.supplyProgress == 0.25)
 
-		tokens = NetworkStationsStatsTokens(totalSupply: nil,
-											circulatingSupply: 250,
-											totalAllocated: nil,
-											allocatedPerDay: nil,
-											lastTxHashUrl: nil,
-											averageMonthly: nil)
-//		#expect(tokens.supplyProgress == nil)
+		tokens = NetworkStatsToken(circulatingSupply: 250, totalSupply: nil)
+		#expect(tokens.supplyProgress == nil)
 
-		tokens = NetworkStationsStatsTokens(totalSupply: 1000,
-											circulatingSupply: nil,
-											totalAllocated: nil,
-											allocatedPerDay: nil,
-											lastTxHashUrl: nil,
-											averageMonthly: nil)
-//		#expect(tokens.supplyProgress == nil)
+		tokens = NetworkStatsToken(circulatingSupply: nil, totalSupply: 1000)
+		#expect(tokens.supplyProgress == nil)
 
-		tokens = NetworkStationsStatsTokens(totalSupply: 0,
-											circulatingSupply: 100,
-											totalAllocated: nil,
-											allocatedPerDay: nil,
-											lastTxHashUrl: nil,
-											averageMonthly: nil)
-//		#expect(tokens.supplyProgress?.isInfinite == true)
+		tokens = NetworkStatsToken(circulatingSupply: 100, totalSupply: 0)
+		#expect(tokens.supplyProgress?.isInfinite == true)
 	}
 
 	@Test

--- a/WeatherXMTests/PresentationLayer/Extensions/DomainExtensions/DomainExtensionsTests.swift
+++ b/WeatherXMTests/PresentationLayer/Extensions/DomainExtensions/DomainExtensionsTests.swift
@@ -25,7 +25,7 @@ struct DomainExtensionsTests {
 												allocatedPerDay: nil,
 												lastTxHashUrl: nil,
 												averageMonthly: nil)
-		#expect(tokens.supplyProgress == 0.25)
+//		#expect(tokens.supplyProgress == 0.25)
 
 		tokens = NetworkStationsStatsTokens(totalSupply: nil,
 											circulatingSupply: 250,
@@ -33,7 +33,7 @@ struct DomainExtensionsTests {
 											allocatedPerDay: nil,
 											lastTxHashUrl: nil,
 											averageMonthly: nil)
-		#expect(tokens.supplyProgress == nil)
+//		#expect(tokens.supplyProgress == nil)
 
 		tokens = NetworkStationsStatsTokens(totalSupply: 1000,
 											circulatingSupply: nil,
@@ -41,7 +41,7 @@ struct DomainExtensionsTests {
 											allocatedPerDay: nil,
 											lastTxHashUrl: nil,
 											averageMonthly: nil)
-		#expect(tokens.supplyProgress == nil)
+//		#expect(tokens.supplyProgress == nil)
 
 		tokens = NetworkStationsStatsTokens(totalSupply: 0,
 											circulatingSupply: 100,
@@ -49,7 +49,7 @@ struct DomainExtensionsTests {
 											allocatedPerDay: nil,
 											lastTxHashUrl: nil,
 											averageMonthly: nil)
-		#expect(tokens.supplyProgress?.isInfinite == true)
+//		#expect(tokens.supplyProgress?.isInfinite == true)
 	}
 
 	@Test

--- a/WeatherXMTests/PresentationLayer/MockUseCases/MockNetworkUseCase.swift
+++ b/WeatherXMTests/PresentationLayer/MockUseCases/MockNetworkUseCase.swift
@@ -16,8 +16,6 @@ final class MockNetworkUseCase: NetworkUseCaseApi {
 
 	func getNetworkStats() throws -> AnyPublisher<DataResponse<NetworkStatsResponse, NetworkErrorResponse>, Never> {
 		let statsResponse =	NetworkStatsResponse(weatherStations: nil,
-												 dataDays: nil,
-												 tokens: nil,
 												 contracts: nil,
 												 rewards: nil,
 												 health: nil,

--- a/WeatherXMTests/PresentationLayer/MockUseCases/MockNetworkUseCase.swift
+++ b/WeatherXMTests/PresentationLayer/MockUseCases/MockNetworkUseCase.swift
@@ -15,11 +15,15 @@ final class MockNetworkUseCase: NetworkUseCaseApi {
 	nonisolated(unsafe) var deletedSearchRecent: Bool = false
 
 	func getNetworkStats() throws -> AnyPublisher<DataResponse<NetworkStatsResponse, NetworkErrorResponse>, Never> {
-		let statsResponse = NetworkStatsResponse(weatherStations: nil,
+		let statsResponse =	NetworkStatsResponse(weatherStations: nil,
 												 dataDays: nil,
 												 tokens: nil,
 												 contracts: nil,
+												 rewards: nil,
+												 health: nil,
+												 growth: nil,
 												 lastUpdated: nil)
+
 		let response = DataResponse<NetworkStatsResponse, NetworkErrorResponse>(request: nil,
 																				response: nil,
 																				data: nil,

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		264E2F6129DC5AEE009580A2 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 264E2F6029DC5AEE009580A2 /* Settings.bundle */; };
 		2655F1812AD3FA8400BB19D5 /* WidgetConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2655F1802AD3FA8400BB19D5 /* WidgetConstants.swift */; };
 		2655F1822AD3FA8400BB19D5 /* WidgetConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2655F1802AD3FA8400BB19D5 /* WidgetConstants.swift */; };
+		2656A9A12E04142A002F0294 /* NetworkGrowthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2656A9A02E04142A002F0294 /* NetworkGrowthView.swift */; };
 		265985552C4E467000BDF225 /* UnitsConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265985542C4E467000BDF225 /* UnitsConverterTests.swift */; };
 		265985652C4EAD9F00BDF225 /* FoundationExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265985642C4EAD9F00BDF225 /* FoundationExtensionsTests.swift */; };
 		265D2CD829D194070044D032 /* Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265D2CD729D194070044D032 /* Common.swift */; };
@@ -880,6 +881,7 @@
 		264E2F5229DC3533009580A2 /* ThemeEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnum.swift; sourceTree = "<group>"; };
 		264E2F6029DC5AEE009580A2 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		2655F1802AD3FA8400BB19D5 /* WidgetConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetConstants.swift; sourceTree = "<group>"; };
+		2656A9A02E04142A002F0294 /* NetworkGrowthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkGrowthView.swift; sourceTree = "<group>"; };
 		265985542C4E467000BDF225 /* UnitsConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitsConverterTests.swift; sourceTree = "<group>"; };
 		265985642C4EAD9F00BDF225 /* FoundationExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationExtensionsTests.swift; sourceTree = "<group>"; };
 		265D2CD729D194070044D032 /* Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Common.swift; sourceTree = "<group>"; };
@@ -1666,6 +1668,7 @@
 				267401912A3A00D500E54E35 /* StationDetailsGridView.swift */,
 				2632E6332A3378BF00A5ADB3 /* StatisticsChart.swift */,
 				269AD4632DD3902F00B89078 /* TokenMetricsView.swift */,
+				2656A9A02E04142A002F0294 /* NetworkGrowthView.swift */,
 				269AD4732DD5C0A400B89078 /* NetworkStatsDonutView.swift */,
 			);
 			path = NetworkStatistics;
@@ -3969,6 +3972,7 @@
 				26AF276E2A0B815B0067A1B8 /* ChartsFactory.swift in Sources */,
 				268E8E0D2B07A2D50025163F /* IPadMaxWidthModifier.swift in Sources */,
 				2675481229A9181E008BCF40 /* CircleRadius.swift in Sources */,
+				2656A9A12E04142A002F0294 /* NetworkGrowthView.swift in Sources */,
 				266B01CD2B84FB59007AC689 /* NetworkDeviceRewardsSummaryResponse+.swift in Sources */,
 				268E8E0A2B07A1E30025163F /* AdaptiveGridContainerView.swift in Sources */,
 				26AA21D32BF3A45E00B91A7C /* ManualSerialNumberViewModel.swift in Sources */,

--- a/wxm-ios/DomainLayer/DomainLayer.xcodeproj/project.pbxproj
+++ b/wxm-ios/DomainLayer/DomainLayer.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		264CC75B2B986AC90060DEA4 /* NetworkDeviceRewardBoostsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264CC75A2B986AC90060DEA4 /* NetworkDeviceRewardBoostsResponse.swift */; };
 		26504E3D2A7A4753008E2B59 /* NetworkResultsConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26504E3C2A7A4753008E2B59 /* NetworkResultsConverter.swift */; };
 		2656675D2C47A12800CA49A5 /* LoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2656675C2C47A12800CA49A5 /* LoginService.swift */; };
+		2656A99F2E0407CF002F0294 /* NetworkStatsGrowth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2656A99E2E0407CF002F0294 /* NetworkStatsGrowth.swift */; };
 		2664830629C218D900748F9C /* NetworkDevicesInfoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2664830529C218D900748F9C /* NetworkDevicesInfoResponse.swift */; };
 		2664830829C21A8300748F9C /* NetworkDevicesTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2664830729C21A8300748F9C /* NetworkDevicesTypes.swift */; };
 		266B01B92B84D3A7007AC689 /* NetworkDeviceRewardsSummaryResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266B01B82B84D3A7007AC689 /* NetworkDeviceRewardsSummaryResponse.swift */; };
@@ -131,6 +132,7 @@
 		264CC75A2B986AC90060DEA4 /* NetworkDeviceRewardBoostsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDeviceRewardBoostsResponse.swift; sourceTree = "<group>"; };
 		26504E3C2A7A4753008E2B59 /* NetworkResultsConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResultsConverter.swift; sourceTree = "<group>"; };
 		2656675C2C47A12800CA49A5 /* LoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginService.swift; sourceTree = "<group>"; };
+		2656A99E2E0407CF002F0294 /* NetworkStatsGrowth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStatsGrowth.swift; sourceTree = "<group>"; };
 		2664830529C218D900748F9C /* NetworkDevicesInfoResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDevicesInfoResponse.swift; sourceTree = "<group>"; };
 		2664830729C21A8300748F9C /* NetworkDevicesTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDevicesTypes.swift; sourceTree = "<group>"; };
 		266B01B82B84D3A7007AC689 /* NetworkDeviceRewardsSummaryResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDeviceRewardsSummaryResponse.swift; sourceTree = "<group>"; };
@@ -270,6 +272,7 @@
 				2674016F2A375D3800E54E35 /* NetworkStatsResponse.swift */,
 				264420D82E016E8100BE45C5 /* NetworkStatsRewards.swift */,
 				26982E3A2E02C83900B3AAE2 /* NetworkStatsHealth.swift */,
+				2656A99E2E0407CF002F0294 /* NetworkStatsGrowth.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -663,6 +666,7 @@
 				26F83C7A2D9BEE7100E5A8B8 /* RewardsUseCaseApi.swift in Sources */,
 				264813F82D8C50EE00BCCC31 /* Announcement.swift in Sources */,
 				26F83C762D9BD11E00E5A8B8 /* MeUseCaseApi.swift in Sources */,
+				2656A99F2E0407CF002F0294 /* NetworkStatsGrowth.swift in Sources */,
 				267401702A375D3800E54E35 /* NetworkStatsResponse.swift in Sources */,
 				B5E6B86128338CAB0060D050 /* NetworkTokenResponse.swift in Sources */,
 				267401722A37687000E54E35 /* NetworkUseCase.swift in Sources */,

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Network/NetworkStatsGrowth.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Network/NetworkStatsGrowth.swift
@@ -1,0 +1,22 @@
+//
+//  NetworkStatsGrowth.swift
+//  DomainLayer
+//
+//  Created by Pantelis Giazitsis on 19/6/25.
+//
+
+import Foundation
+
+public struct NetworkStatsGrowth: Codable, Sendable {
+	public let last30Days: Int?
+	public let last30DaysGraph: [NetworkStatsTimeSeries]?
+	public let networkScaleUp: Int?
+	public let networkSize: Int?
+
+	enum CodingKeys: String, CodingKey {
+		case last30Days = "last_30days"
+		case last30DaysGraph = "last_30days_graph"
+		case networkScaleUp = "network_scale_up"
+		case networkSize = "network_size"
+	}
+}

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Network/NetworkStatsResponse.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Network/NetworkStatsResponse.swift
@@ -14,6 +14,7 @@ public struct NetworkStatsResponse: Codable, Sendable {
 	public let contracts: NetworkStatsContracts?
 	public let rewards: NetworkStatsRewards?
 	public let health: NetworkStatsHealth?
+	public let growth: NetworkStatsGrowth?
     public let lastUpdated: Date?
 
     enum CodingKeys: String, CodingKey {
@@ -23,6 +24,7 @@ public struct NetworkStatsResponse: Codable, Sendable {
 		case contracts
 		case rewards
 		case health = "net_health"
+		case growth = "net_growth"
         case lastUpdated = "last_updated"
     }
 
@@ -32,6 +34,7 @@ public struct NetworkStatsResponse: Codable, Sendable {
 				contracts: NetworkStatsContracts?,
 				rewards: NetworkStatsRewards?,
 				health: NetworkStatsHealth?,
+				growth: NetworkStatsGrowth?,
 				lastUpdated: Date?) {
 		self.weatherStations = weatherStations
 		self.dataDays = dataDays
@@ -39,6 +42,7 @@ public struct NetworkStatsResponse: Codable, Sendable {
 		self.contracts = contracts
 		self.rewards = rewards
 		self.health = health
+		self.growth = growth
 		self.lastUpdated = lastUpdated
 	}
 }

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Network/NetworkStatsResponse.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Network/NetworkStatsResponse.swift
@@ -9,8 +9,6 @@ import Foundation
 
 public struct NetworkStatsResponse: Codable, Sendable {
     public let weatherStations: NetworkWeatherStations?
-    public let dataDays: [NetworkStatsTimeSeries]?
-    public let tokens: NetworkStationsStatsTokens?
 	public let contracts: NetworkStatsContracts?
 	public let rewards: NetworkStatsRewards?
 	public let health: NetworkStatsHealth?
@@ -19,8 +17,6 @@ public struct NetworkStatsResponse: Codable, Sendable {
 
     enum CodingKeys: String, CodingKey {
         case weatherStations = "weather_stations"
-        case dataDays = "data_days"
-        case tokens
 		case contracts
 		case rewards
 		case health = "net_health"
@@ -29,7 +25,6 @@ public struct NetworkStatsResponse: Codable, Sendable {
     }
 
 	public init(weatherStations: NetworkWeatherStations?,
-				dataDays: [NetworkStatsTimeSeries]?,
 				tokens: NetworkStationsStatsTokens?,
 				contracts: NetworkStatsContracts?,
 				rewards: NetworkStatsRewards?,
@@ -37,8 +32,6 @@ public struct NetworkStatsResponse: Codable, Sendable {
 				growth: NetworkStatsGrowth?,
 				lastUpdated: Date?) {
 		self.weatherStations = weatherStations
-		self.dataDays = dataDays
-		self.tokens = tokens
 		self.contracts = contracts
 		self.rewards = rewards
 		self.health = health

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Network/NetworkStatsResponse.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Network/NetworkStatsResponse.swift
@@ -25,7 +25,6 @@ public struct NetworkStatsResponse: Codable, Sendable {
     }
 
 	public init(weatherStations: NetworkWeatherStations?,
-				tokens: NetworkStationsStatsTokens?,
 				contracts: NetworkStatsContracts?,
 				rewards: NetworkStatsRewards?,
 				health: NetworkStatsHealth?,
@@ -57,38 +56,6 @@ public struct NetworkStationsStatsDetails: Codable, Sendable {
     public let amount: Int?
     public let percentage: Float?
     public let url: String?
-}
-
-public struct NetworkStationsStatsTokens: Codable, Sendable {
-    public let totalSupply: Int?
-	public let circulatingSupply: Int?
-	public let totalAllocated: Double?
-    public let allocatedPerDay: [NetworkStatsTimeSeries]?
-	public let lastTxHashUrl: String?
-    public let averageMonthly: Double?
-
-    enum CodingKeys: String, CodingKey {
-        case totalSupply = "total_supply"
-		case circulatingSupply = "circulating_supply"
-		case totalAllocated = "total_allocated"
-		case lastTxHashUrl = "last_tx_hash_url"
-        case allocatedPerDay = "allocated_per_day"
-        case averageMonthly = "avg_monthly"
-    }
-
-	public init(totalSupply: Int?,
-				circulatingSupply: Int?,
-				totalAllocated: Double?,
-				allocatedPerDay: [NetworkStatsTimeSeries]?,
-				lastTxHashUrl: String?,
-				averageMonthly: Double?) {
-		self.totalSupply = totalSupply
-		self.circulatingSupply = circulatingSupply
-		self.totalAllocated = totalAllocated
-		self.allocatedPerDay = allocatedPerDay
-		self.lastTxHashUrl = lastTxHashUrl
-		self.averageMonthly = averageMonthly
-	}
 }
 
 public struct NetworkStatsContracts: Codable, Sendable {

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Network/NetworkStatsRewards.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Network/NetworkStatsRewards.swift
@@ -43,6 +43,11 @@ public struct NetworkStatsToken: Codable, Sendable {
 		case circulatingSupply = "circulating_supply"
 		case totalSupply = "total_supply"
 	}
+
+	public init(circulatingSupply: Int?, totalSupply: Int?) {
+		self.circulatingSupply = circulatingSupply
+		self.totalSupply = totalSupply
+	}
 }
 
 public struct NetworkStatsTotalAllocated: Codable, Sendable {

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -5621,6 +5621,17 @@
         }
       }
     },
+    "net_stats_deployed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deployed"
+          }
+        }
+      }
+    },
     "net_stats_earn_wxm" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -5683,6 +5694,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Last Run"
+          }
+        }
+      }
+    },
+    "net_stats_manufactured" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manufactured"
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -5401,6 +5401,17 @@
         }
       }
     },
+    "net_stats_added_in_last_x_days" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Added in last %d days"
+          }
+        }
+      }
+    },
     "net_stats_base_rewards" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -5709,6 +5720,17 @@
         }
       }
     },
+    "net_stats_network_growth" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Network growth"
+          }
+        }
+      }
+    },
     "net_stats_network_health" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -5727,6 +5749,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reflects the overall performance and reliability of the network. It consists of data quality, network uptime and number of healthy stations (calculated monthly) to indicate how well the network is functioning and how trustworthy the collected data is."
+          }
+        }
+      }
+    },
+    "net_stats_network_scale_up" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Network scale up"
+          }
+        }
+      }
+    },
+    "net_stats_network_size" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Network Size"
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -5561,7 +5561,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The number of weather stations already claimed by users."
+            "value" : "The number of weather stations already deployed by users."
           }
         }
       }
@@ -5902,7 +5902,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The number of weather stations manufactured and registered on the network."
+            "value" : "The number of weather stations produced."
           }
         }
       }
@@ -5962,13 +5962,13 @@
         }
       }
     },
-    "net_stats_weather_stations" : {
+    "net_stats_weather_stations_breakdown" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Weather Stations"
+            "value" : "Weather stations breakdown"
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/LocalizableString+NetStats.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+NetStats.swift
@@ -18,7 +18,7 @@ extension LocalizableString {
 		case wxmRewardsDescriptionMarkdown(String)
 		case totalSupply
 		case circulatingSupply
-		case weatherStations
+		case weatherStationsBreakdown
 		case manufactured
 		case claimed
 		case deployed
@@ -116,8 +116,8 @@ extension LocalizableString.NetStats: WXMLocalizable {
 				return "net_stats_total_supply"
 			case .circulatingSupply:
 				return "net_stats_circulating_supply"
-			case .weatherStations:
-				return "net_stats_weather_stations"
+			case .weatherStationsBreakdown:
+				return "net_stats_weather_stations_breakdown"
 			case .manufactured:
 				return "net_stats_manufactured"
 			case .claimed:

--- a/wxm-ios/Resources/Localizable/LocalizableString+NetStats.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+NetStats.swift
@@ -19,7 +19,9 @@ extension LocalizableString {
 		case totalSupply
 		case circulatingSupply
 		case weatherStations
+		case manufactured
 		case claimed
+		case deployed
 		case claimedAmount(String)
 		case reserved(String)
 		case total(String)
@@ -116,8 +118,12 @@ extension LocalizableString.NetStats: WXMLocalizable {
 				return "net_stats_circulating_supply"
 			case .weatherStations:
 				return "net_stats_weather_stations"
+			case .manufactured:
+				return "net_stats_manufactured"
 			case .claimed:
 				return "net_stats_claimed"
+			case .deployed:
+				return "net_stats_deployed"
 			case .claimedAmount:
 				return "net_stats_claimed_amount_format"
 			case .reserved:

--- a/wxm-ios/Resources/Localizable/LocalizableString+NetStats.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+NetStats.swift
@@ -39,6 +39,10 @@ extension LocalizableString {
 		case checkTheWeather
 		case networkHealth
 		case networkHealthInfoText
+		case networkGrowth
+		case networkSize
+		case addedInLastXDays(Int)
+		case networkScaleUp
 		case earnWXM
 		case enterWebThree
 		case totalAllocatedInfoText
@@ -71,7 +75,8 @@ extension LocalizableString.NetStats: WXMLocalizable {
 	var localized: String {
 		var localized = NSLocalizedString(self.key, comment: "")
 		switch self {
-			case .lastDays(let count):
+			case .lastDays(let count),
+					.addedInLastXDays(let count):
 				localized = String(format: localized, count)
 			case .buyStationCardDescription(let count):
 				localized = String(format: localized, count)
@@ -149,6 +154,14 @@ extension LocalizableString.NetStats: WXMLocalizable {
 				return "net_stats_network_health"
 			case .networkHealthInfoText:
 				return "net_stats_network_health_info_text"
+			case .networkGrowth:
+				return "net_stats_network_growth"
+			case .networkSize:
+				return "net_stats_network_size"
+			case .addedInLastXDays:
+				return "net_stats_added_in_last_x_days"
+			case .networkScaleUp:
+				return "net_stats_network_scale_up"
 			case .checkTheWeather:
 				return "net_stats_check_the_weather"
 			case .earnWXM:


### PR DESCRIPTION
## **Why?**
Network Growth card and its detail screen with the stations breakdown
### **How?**
- Implemented growth card
- `NetworthGrowthView` renders the stations breakdown
- Cleanup and remove unused stuff
### **Testing**
Ensure the card and its details screen is presented as expected 
### **Additional context**
fixes fe-1407, fe-1397


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new "Network Growth", "Network Health", and "Token Metrics" screens with detailed statistics, charts, and interactive cards.
  - Added new donut chart visualizations for rewards and token metrics.
  - Expanded statistics breakdown for weather stations, rewards, and tokens.
  - Enhanced localization with new strings for network statistics and rewards.
  - Added new asset for station images.

- **Improvements**
  - Redesigned and reorganized the network statistics interface for better clarity and navigation.
  - Updated shop link URL for improved user access.
  - Improved analytics tracking for new statistics and screens.

- **Bug Fixes**
  - Corrected and clarified several localization entries for statistics descriptions.

- **Chores**
  - Updated mock data and tests to align with new statistics structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->