### PR TITLE
Manufactured stations

### DIFF
--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel+Factory.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel+Factory.swift
@@ -180,10 +180,10 @@ extension NetworkStatsViewModel {
 	}
 
     func getStationStats(response: NetworkStatsResponse?) -> [NetworkStatsView.StationStatistics]? {
-		let manufactured = (LocalizableString.NetStats.manufactured.localized.uppercased(),
+		let manufactured = (LocalizableString.NetStats.manufacturedAndProvisioned.localized.uppercased(),
 							response?.weatherStations?.onboarded,
 							NetworkStatsView.Accessory(fontIcon: .infoCircle) { [weak self] in
-			self?.showInfo(title: LocalizableString.NetStats.manufactured.localized,
+			self?.showInfo(title: LocalizableString.NetStats.manufacturedAndProvisioned.localized,
 						   description: LocalizableString.NetStats.totalWeatherStationsInfoText.localized,
 						   analyticsItemId: .totalStations)
 		},

--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel+Factory.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViewModel+Factory.swift
@@ -180,6 +180,15 @@ extension NetworkStatsViewModel {
 	}
 
     func getStationStats(response: NetworkStatsResponse?) -> [NetworkStatsView.StationStatistics]? {
+		let manufactured = (LocalizableString.NetStats.manufactured.localized.uppercased(),
+							response?.weatherStations?.onboarded,
+							NetworkStatsView.Accessory(fontIcon: .infoCircle) { [weak self] in
+			self?.showInfo(title: LocalizableString.NetStats.manufactured.localized,
+						   description: LocalizableString.NetStats.totalWeatherStationsInfoText.localized,
+						   analyticsItemId: .totalStations)
+		},
+							ParameterValue.total)
+
 		let deployed = (LocalizableString.NetStats.deployed.localized.uppercased(),
 					   response?.weatherStations?.claimed,
 					   NetworkStatsView.Accessory(fontIcon: .infoCircle) { [weak self] in
@@ -199,7 +208,7 @@ extension NetworkStatsViewModel {
 		},
 					  ParameterValue.active)
 
-		let sections = [deployed, active]
+		let sections = [manufactured, deployed, active]
 
         return sections.compactMap { title, stats, info, analyticsItemId in
             guard let stats else {

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Network/NetworkStatsResponse.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Network/NetworkStatsResponse.swift
@@ -40,6 +40,7 @@ public struct NetworkStatsResponse: Codable, Sendable {
 }
 
 public struct NetworkWeatherStations: Codable, Sendable {
+    public let onboarded: NetworkStationsStats?
     public let claimed: NetworkStationsStats?
     public let active: NetworkStationsStats?
 }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -5698,6 +5698,17 @@
         }
       }
     },
+    "net_stats_manufactured" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manufactured"
+          }
+        }
+      }
+    },
     "net_stats_manufacturer_cta_button_title" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -5881,6 +5892,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Total supply refers to the number of $WXM that have already been created and are either in circulation or locked."
+          }
+        }
+      }
+    },
+    "net_stats_total_weather_stations_info_text" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The number of weather stations produced."
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -5698,13 +5698,13 @@
         }
       }
     },
-    "net_stats_manufactured" : {
+    "net_stats_manufactured_and_provisioned" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Manufactured"
+            "value" : "Manufactured and provisioned"
           }
         }
       }
@@ -5902,7 +5902,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The number of weather stations produced."
+            "value" : "The number of weather stations manufactured and provisioned in the network."
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/LocalizableString+NetStats.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+NetStats.swift
@@ -19,6 +19,7 @@ extension LocalizableString {
 		case totalSupply
 		case circulatingSupply
 		case weatherStationsBreakdown
+		case manufactured
 		case claimed
 		case deployed
 		case claimedAmount(String)
@@ -52,6 +53,7 @@ extension LocalizableString {
 		case totalWeatherStationsInfoTitle
 		case claimedWeatherStationsInfoTitle
 		case activeWeatherStationsInfoTitle
+		case totalWeatherStationsInfoText
 		case claimedWeatherStationsInfoText
 		case activeWeatherStationsInfoText
 		case emptyTitle
@@ -116,6 +118,8 @@ extension LocalizableString.NetStats: WXMLocalizable {
 				return "net_stats_circulating_supply"
 			case .weatherStationsBreakdown:
 				return "net_stats_weather_stations_breakdown"
+			case .manufactured:
+				return "net_stats_manufactured"
 			case .claimed:
 				return "net_stats_claimed"
 			case .deployed:
@@ -182,6 +186,8 @@ extension LocalizableString.NetStats: WXMLocalizable {
 				return "net_stats_claimed_weather_stations_info_title"
 			case .activeWeatherStationsInfoTitle:
 				return "net_stats_active_weather_stations_info_title"
+			case .totalWeatherStationsInfoText:
+				return "net_stats_total_weather_stations_info_text"
 			case .claimedWeatherStationsInfoText:
 				return "net_stats_claimed_weather_stations_info_text"
 			case .activeWeatherStationsInfoText:

--- a/wxm-ios/Resources/Localizable/LocalizableString+NetStats.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+NetStats.swift
@@ -19,7 +19,7 @@ extension LocalizableString {
 		case totalSupply
 		case circulatingSupply
 		case weatherStationsBreakdown
-		case manufactured
+		case manufacturedAndProvisioned
 		case claimed
 		case deployed
 		case claimedAmount(String)
@@ -118,8 +118,8 @@ extension LocalizableString.NetStats: WXMLocalizable {
 				return "net_stats_circulating_supply"
 			case .weatherStationsBreakdown:
 				return "net_stats_weather_stations_breakdown"
-			case .manufactured:
-				return "net_stats_manufactured"
+			case .manufacturedAndProvisioned:
+				return "net_stats_manufactured_and_provisioned"
 			case .claimed:
 				return "net_stats_claimed"
 			case .deployed:


### PR DESCRIPTION
## **Why?**
Bring back the manufactured stations section in the Network Growth screen
### **Testing**
Ensure the UI is as expected 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new "Manufactured and Provisioned" section to the network station statistics, displaying the count of onboarded weather stations.
  - Included an info accessory with detailed information for this new statistics section.

- **Localization**
  - Introduced new localized strings for "Manufactured and provisioned" and its info text to support internationalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->