### PR TITLE
Fixed alignment in net stats

### DIFF
--- a/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViews.swift
+++ b/PresentationLayer/UIComponents/Screens/NetworkStatistics/NetworkStatsViews.swift
@@ -151,6 +151,7 @@ extension View {
 						Text(stats.title.uppercased())
 							.font(.system(size: CGFloat(.caption)))
 							.foregroundColor(Color(colorEnum: .text))
+							.fixedSize(horizontal: false, vertical: true)
 
 						Spacer()
 
@@ -174,6 +175,8 @@ extension View {
 
 						Spacer()
 					}
+					.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+
 
 					if let progress = stats.progress {
 						ProgressView(value: progress, total: 1.0)


### PR DESCRIPTION
## **Why?**
Align the text to the bottom in the following cases
![image (5)](https://github.com/user-attachments/assets/d77d75d0-7790-45dd-b1cd-1ffb03adc7cf)

### **Testing**
Ensure the layout is the expected. Check in smaller devices, eg. iPhone SE



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text wrapping for additional statistics titles to prevent truncation.
  * Enhanced vertical alignment of statistic values for a more consistent and visually appealing layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->