### PR TITLE
Remove new indication

### DIFF
--- a/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoFactory.swift
+++ b/PresentationLayer/UIComponents/Screens/DeviceInfo/DeviceInfoFactory.swift
@@ -40,7 +40,7 @@ extension DeviceInfoViewModel.Field {
 			case .rewardSplit:
 				return (LocalizableString.RewardDetails.rewardSplit.localized, nil)
 			case .photos:
-				return (LocalizableString.PhotoVerification.photoVerificationIntroTitle.localized, LocalizableString.new.localized)
+				return (LocalizableString.PhotoVerification.photoVerificationIntroTitle.localized, nil)
 		}
 	}
 


### PR DESCRIPTION
## **Why?**
Remove "new" indication from device info screen
### **Testing**
Ensure the indication is removed
### **Additional context**
fixes fe-1898


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the device info screen so that the "Photos" section no longer displays a "new" badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->