### PR TITLE
Feature prompt and notifications option in 3 dots menu

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/WXMAlert/WXMAlertView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WXMAlert/WXMAlertView.swift
@@ -123,7 +123,7 @@ private extension WXMAlertView {
                     } label: {
                         Text(button.title)
                     }
-                    .buttonStyle(WXMButtonStyle())
+					.buttonStyle(WXMButtonStyle.transparent)
                 }
 
                 ForEach(configuration.primaryButtons) { button in

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsContainerView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsContainerView.swift
@@ -181,6 +181,13 @@ private struct StationDetailsView: View {
                 }
             }
         }
+		.wxmAlert(show: $viewModel.showNotificationsAlert) {
+			WXMAlertView(show: $viewModel.showNotificationsAlert,
+						 configuration: viewModel.notificationsAlertConfiguration!) {
+				EmptyView()
+			}
+		}
+
         .onAppear {
             navigationObject.navigationBarColor = Color(colorEnum: .top)
 			navigationObject.titleFont = .system(size: CGFloat(.smallTitleFontSize), weight: .bold)

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsContainerView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsContainerView.swift
@@ -61,6 +61,17 @@ struct StationDetailsContainerView: View {
 									.foregroundColor(Color(colorEnum: .text))
 							}
 						}
+
+						if viewModel.followState?.relation == .owned {
+							Button { [weak viewModel] in
+								showSettingsPopOver = false
+								viewModel?.notificationsButtonTapped()
+							} label: {
+								Text(LocalizableString.StationDetails.notifications.localized)
+									.font(.system(size: CGFloat(.mediumFontSize)))
+									.foregroundColor(Color(colorEnum: .text))
+							}
+						}
 					}
 					.padding()
 					.background(Color(colorEnum: .top).scaleEffect(2.0).ignoresSafeArea())

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
@@ -42,6 +42,7 @@ class StationDetailsViewModel: ObservableObject {
     private(set) lazy var forecastVM = ViewModelsFactory.getStationForecastViewModel(delegate: self)
     private(set) lazy var rewardsVM = ViewModelsFactory.getStationRewardsViewModel(deviceId: deviceId, delegate: self)
     private(set) var loginAlertConfiguration: WXMAlertConfiguration?
+	private(set) var notificationsAlertConfiguration: WXMAlertConfiguration?
 
     private var initialHeaderOffset: CGFloat = 0.0
 	@Published private(set) var device: DeviceDetails? {
@@ -59,6 +60,7 @@ class StationDetailsViewModel: ObservableObject {
 	}
     @Published var shouldHideHeaderToggle: Bool = false
     @Published var showLoginAlert: Bool = false
+	@Published var showNotificationsAlert: Bool = false
 	@Published var showShareDialog: Bool = false
 	private(set) var shareDialogText: String?
     private(set) var isHeaderHidden: Bool = false
@@ -94,6 +96,7 @@ class StationDetailsViewModel: ObservableObject {
 
 	func viewAppeared() {
 		trackExplorerDeviceEventIfNeeded(isInitialized: isFollowStateInitialized)
+		showStationNotificationsAlertIfNeeded()
 	}
 
     func settingsButtonTapped() {
@@ -313,6 +316,19 @@ private extension StationDetailsViewModel {
 			return
 		}
 		Router.shared.navigateTo(.viewMoreAlerts(.init(device: device, mainVM: .shared, followState: followState)))
+	}
+
+	func showStationNotificationsAlertIfNeeded() {
+		let conf = WXMAlertConfiguration(title: LocalizableString.StationDetails.notificationsAlertTitle.localized,
+										 text: LocalizableString.StationDetails.notificationsAlertMessage.localized.attributedMarkdown ?? "",
+										 canDismiss: false,
+										 buttonsLayout: .horizontal,
+										 secondaryButtons: [.init(title: LocalizableString.StationDetails.notificationsAlertCancelButtonTitle.localized,
+																  action: { self.showNotificationsAlert = false })],
+										 primaryButtons: [.init(title: LocalizableString.StationDetails.notificationsAlertButtonTitle.localized,
+																action: { self.showNotificationsAlert = false })])
+		notificationsAlertConfiguration = conf
+		showNotificationsAlert = true
 	}
 }
 

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
@@ -101,6 +101,10 @@ class StationDetailsViewModel: ObservableObject {
 		Router.shared.navigateTo(.deviceInfo(viewModel))
     }
 
+	func notificationsButtonTapped() {
+		// Route to notifications screen
+	}
+
 	func warningTapped() {
 		var parameters: [Parameter: ParameterValue] = [.contentName: .stationDetailsChip,
 													   .contentType: .warnings]

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
@@ -56,6 +56,7 @@ class StationDetailsViewModel: ObservableObject {
 	@Published private(set) var followState: UserDeviceFollowState? {
 		didSet {
 			isFollowStateInitialized = true
+			showStationNotificationsAlertIfNeeded()
 		}
 	}
     @Published var shouldHideHeaderToggle: Bool = false
@@ -96,7 +97,6 @@ class StationDetailsViewModel: ObservableObject {
 
 	func viewAppeared() {
 		trackExplorerDeviceEventIfNeeded(isInitialized: isFollowStateInitialized)
-		showStationNotificationsAlertIfNeeded()
 	}
 
     func settingsButtonTapped() {
@@ -319,6 +319,11 @@ private extension StationDetailsViewModel {
 	}
 
 	func showStationNotificationsAlertIfNeeded() {
+		guard followState?.relation == .owned,
+		useCase?.hasNotificationsPromptBeenShown == false else {
+			return
+		}
+
 		let conf = WXMAlertConfiguration(title: LocalizableString.StationDetails.notificationsAlertTitle.localized,
 										 text: LocalizableString.StationDetails.notificationsAlertMessage.localized.attributedMarkdown ?? "",
 										 canDismiss: false,
@@ -329,6 +334,7 @@ private extension StationDetailsViewModel {
 																action: { self.showNotificationsAlert = false })])
 		notificationsAlertConfiguration = conf
 		showNotificationsAlert = true
+		useCase?.notificationsPromptShown()
 	}
 }
 

--- a/WeatherXMTests/DomainLayer/UseCases/DeviceDetailsUseCaseTests.swift
+++ b/WeatherXMTests/DomainLayer/UseCases/DeviceDetailsUseCaseTests.swift
@@ -12,6 +12,7 @@ struct DeviceDetailsUseCaseTests {
 	let meRepository: MockMeRepositoryImpl = .init()
 	let explorerRepository: MockExplorerRepositoryImpl = .init()
 	let keychainRepository: MockKeychainRepositoryImpl = .init()
+	let userDefaultsRepository: MockUserDefaultsRepositoryImpl = .init()
 	let geocoder: MockGeocoder = .init()
 	let useCase: DeviceDetailsUseCase
 
@@ -19,6 +20,7 @@ struct DeviceDetailsUseCaseTests {
 		self.useCase = .init(meRepository: meRepository,
 							 explorerRepository: explorerRepository,
 							 keychainRepository: keychainRepository,
+							 userDefaultsRepository: userDefaultsRepository,
 							 geocoder: geocoder)
 
 	}
@@ -53,5 +55,11 @@ struct DeviceDetailsUseCaseTests {
 	@Test func resolveAddress() async throws {
 		let res = try await useCase.resolveAddress(location: .init())
 		#expect(res == "Resolved address")
+	}
+
+	@Test func notificationShown() {
+		#expect(userDefaultsRepository.getValue(for: UserDefaults.GenericKey.stationNotificationsPromptSeen.rawValue) == nil)
+		useCase.notificationsPromptShown()
+		#expect(userDefaultsRepository.getValue(for: UserDefaults.GenericKey.stationNotificationsPromptSeen.rawValue) == true)
 	}
 }

--- a/WeatherXMTests/PresentationLayer/MockUseCases/MockDeviceDetailsUseCase.swift
+++ b/WeatherXMTests/PresentationLayer/MockUseCases/MockDeviceDetailsUseCase.swift
@@ -11,6 +11,14 @@ import DomainLayer
 import CoreLocation
 
 struct MockDeviceDetailsUseCase: DeviceDetailsUseCaseApi {
+	var hasNotificationsPromptBeenShown: Bool {
+		true
+	}
+
+	func notificationsPromptShown() {
+
+	}
+	
 	func getDeviceDetailsById(deviceId: String, cellIndex: String?) async throws -> Result<DeviceDetails, NetworkErrorResponse> {
 		.success(DeviceDetails.mockDevice)
 	}

--- a/wxm-ios/DomainLayer/DomainLayer/Extensions/UserDefaults+Constants.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Extensions/UserDefaults+Constants.swift
@@ -45,6 +45,7 @@ public extension UserDefaults {
 		case termsOfUseAcceptedTimestamp = "com.weatherxm.app.UserDefaults.Key.TermsOfUseAcceptedTimestamp"
 		case arePhotoVerificationTermsAccepted = "com.weatherxm.app.UserDefaults.Key.ArePhotoVerificationTermsAccepted"
 		case isAddButtonIndicationSeen = "com.weatherxm.app.UserDefaults.Key.isAddButtonIndicationSeen"
+		case stationNotificationsPromptSeen = "com.weatherxm.app.UserDefaults.Key.StationNotificationsPromptSeen"
 
         // MARK: - UserDefaultEntry
 

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/DeviceDetailsUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/DeviceDetailsUseCase.swift
@@ -16,18 +16,30 @@ public struct DeviceDetailsUseCase: @unchecked Sendable, DeviceDetailsUseCaseApi
     private let meRepository: MeRepository
     private let explorerRepository: ExplorerRepository
     private let keychainRepository: KeychainRepository
+	private let userDefaultsRepository: UserDefaultsRepository
 	private let geocoder: GeocoderProtocol
     private let cancellables: CancellableWrapper = .init()
+
 
 	public init(meRepository: MeRepository,
 				explorerRepository: ExplorerRepository,
 				keychainRepository: KeychainRepository,
+				userDefaultsRepository: UserDefaultsRepository,
 				geocoder: GeocoderProtocol) {
         self.meRepository = meRepository
         self.explorerRepository = explorerRepository
         self.keychainRepository = keychainRepository
+		self.userDefaultsRepository = userDefaultsRepository
 		self.geocoder = geocoder
     }
+
+	public var hasNotificationsPromptBeenShown: Bool {
+		userDefaultsRepository.getValue(for: UserDefaults.GenericKey.stationNotificationsPromptSeen.rawValue) ?? false
+	}
+
+	public func notificationsPromptShown() {
+		userDefaultsRepository.saveValue(key: UserDefaults.GenericKey.stationNotificationsPromptSeen.rawValue, value: true)
+	}
 
     public func getDeviceDetailsById(deviceId: String, cellIndex: String?) async throws -> Result<DeviceDetails, NetworkErrorResponse> {
         let followStateResult = try await meRepository.getDeviceFollowState(deviceId: deviceId)

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/DeviceDetailsUseCaseApi.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/DeviceDetailsUseCaseApi.swift
@@ -8,6 +8,8 @@
 import CoreLocation
 
 public protocol DeviceDetailsUseCaseApi: Sendable {
+	var hasNotificationsPromptBeenShown: Bool { get }
+	func notificationsPromptShown()
 	func getDeviceDetailsById(deviceId: String, cellIndex: String?) async throws -> Result<DeviceDetails, NetworkErrorResponse>
 	func followStation(deviceId: String) async throws ->  Result<EmptyEntity, NetworkErrorResponse>
 	func unfollowStation(deviceId: String) async throws ->  Result<EmptyEntity, NetworkErrorResponse>

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -9493,6 +9493,50 @@
         }
       }
     },
+    "station_details_notifications_alert_button_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Take me there"
+          }
+        }
+      }
+    },
+    "station_details_notifications_alert_cancel_button_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maybe later"
+          }
+        }
+      }
+    },
+    "station_details_notifications_alert_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You’ll now receive notifications for critical issues like inactivity or low battery. This feature is enabled by default if you’ve already allowed app notifications.\n\nYou can manage these settings from the menu at the top right corner."
+          }
+        }
+      }
+    },
+    "station_details_notifications_alert_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station Notifications"
+          }
+        }
+      }
+    },
     "station_details_overview" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -9482,6 +9482,17 @@
         }
       }
     },
+    "station_details_notifications" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications"
+          }
+        }
+      }
+    },
     "station_details_overview" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/LocalizableString+StationDetails.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+StationDetails.swift
@@ -67,6 +67,7 @@ extension LocalizableString {
 		case notVerified
 		case pendingVerification
 		case noLocationData
+		case notifications
 	}
 }
 
@@ -216,6 +217,8 @@ extension LocalizableString.StationDetails: WXMLocalizable {
 				return "station_details_pending_verification"
 			case .noLocationData:
 				return "station_details_no_location_data"
+			case .notifications:
+				return "station_details_notifications"
 		}
 	}
 }

--- a/wxm-ios/Resources/Localizable/LocalizableString+StationDetails.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+StationDetails.swift
@@ -68,6 +68,10 @@ extension LocalizableString {
 		case pendingVerification
 		case noLocationData
 		case notifications
+		case notificationsAlertTitle
+		case notificationsAlertMessage
+		case notificationsAlertButtonTitle
+		case notificationsAlertCancelButtonTitle
 	}
 }
 
@@ -219,6 +223,14 @@ extension LocalizableString.StationDetails: WXMLocalizable {
 				return "station_details_no_location_data"
 			case .notifications:
 				return "station_details_notifications"
+			case .notificationsAlertTitle:
+				return "station_details_notifications_alert_title"
+			case .notificationsAlertMessage:
+				return "station_details_notifications_alert_message"
+			case .notificationsAlertButtonTitle:
+				return "station_details_notifications_alert_button_title"
+			case .notificationsAlertCancelButtonTitle:
+				return "station_details_notifications_alert_cancel_button_title"
 		}
 	}
 }

--- a/wxm-ios/Swinject/SwinjectHelper.swift
+++ b/wxm-ios/Swinject/SwinjectHelper.swift
@@ -166,6 +166,7 @@ class SwinjectHelper: SwinjectInterface {
             DeviceDetailsUseCase(meRepository: resolver.resolve(MeRepository.self)!,
                                  explorerRepository: resolver.resolve(ExplorerRepository.self)!,
                                  keychainRepository: resolver.resolve(KeychainRepository.self)!,
+								 userDefaultsRepository: resolver.resolve(UserDefaultsRepository.self)!,
 								 geocoder: resolver.resolve(GeocoderProtocol.self)!)
         }
 


### PR DESCRIPTION
## **Why?**
Feature prompt on first station details appear and the notifications option in three dots menu
### **How?**
- Added the necessary functionality in `StationDetailsViewModel`
- Added notification option for owned stations
### **Testing**
Ensure the alert is presented only once and the notifications option is only visible for owned stations
### **Additional context**
fixes fe-1881
