### PR TITLE
Station notifications screen

### DIFF
--- a/PresentationLayer/Navigation/Router.swift
+++ b/PresentationLayer/Navigation/Router.swift
@@ -78,6 +78,8 @@ enum Route: Hashable, Equatable {
 				hasher.combine(vm)
 			case .networkGrowth(let vm):
 				hasher.combine(vm)
+			case .stationNotifications(let vm):
+				hasher.combine(vm)
 			case .safariView(let url):
 				hasher.combine(url)
 		}
@@ -145,6 +147,8 @@ enum Route: Hashable, Equatable {
 				"tokenMetrics"
 			case .networkGrowth:
 				"netWorkGrowth"
+			case .stationNotifications:
+				"stationNotifications"
 			case .safariView:
 				"safariView"
 		}
@@ -179,6 +183,7 @@ enum Route: Hashable, Equatable {
 	case proPromo(ProPromotionalViewModel)
 	case tokenMetrics(NetworkStatsViewModel)
 	case networkGrowth(NetworkStatsViewModel)
+	case stationNotifications(StationNotificationsViewModel)
 	case safariView(URL)
 }
 
@@ -279,6 +284,10 @@ extension Route {
 			case .networkGrowth(let netStatsViewModel):
 				NavigationContainerView {
 					NetworkGrowthView(viewModel: netStatsViewModel)
+				}
+			case .stationNotifications(let notificationsViewModel):
+				NavigationContainerView {
+					StationsNotificationsView(viewModel: notificationsViewModel)
 				}
 			case .safariView(let url):
 				SafariView(url: url)

--- a/PresentationLayer/UIComponents/Modifiers/WXMToggleStyle.swift
+++ b/PresentationLayer/UIComponents/Modifiers/WXMToggleStyle.swift
@@ -10,34 +10,43 @@ import SwiftUI
 struct WXMToggleStyle: ToggleStyle {
     static var Default: WXMToggleStyle = .init(
         onColor: Color(colorEnum: .wxmPrimary),
+		onColorDisabled: Color(colorEnum: .midGrey),
+		offColorDisabled: Color(colorEnum: .layer2),
         onIcon: Image(asset: .toggleCheckmark),
         offIcon: Image(asset: .toggleXMark),
         thumbColorOff: Color(colorEnum: .darkGrey),
-        strokeColorOff: Color(colorEnum: .darkGrey)
+		thumbColorOffDisabled: Color(colorEnum: .midGrey),
+        strokeColorOff: Color(colorEnum: .darkGrey),
+		strokeColorOffDisabled: Color(colorEnum: .midGrey)
     )
 
     var label = ""
     var onColor = Color(UIColor.green)
+	var onColorDisabled = Color(UIColor.green)
     var offColor = Color(UIColor.systemGray5)
+	var offColorDisabled = Color(UIColor.systemGray5)
     var onIcon: Image?
     var offIcon: Image?
     var thumbPadding: CGFloat = 2
     var thumbColorOn = Color.white
     var thumbColorOff = Color.white
+	var thumbColorOffDisabled = Color.white
     var strokeColorOn = Color.clear
     var strokeColorOff = Color.clear
+	var strokeColorOffDisabled = Color.clear
     var strokeWidth: CGFloat = 1
 
+	@Environment(\.isEnabled) var isEnabled
+
     func makeBody(configuration: Self.Configuration) -> some View {
-        HStack {
+        HStack {			
             let overlayIcon = configuration.isOn && onIcon != nil || !configuration.isOn && offIcon != nil
                 ? configuration.isOn ? onIcon! : offIcon!
                 : nil
 
             let circle = Circle()
-                .fill(configuration.isOn ? thumbColorOn : thumbColorOff)
+				.fill(thumbColor(configuration: configuration))
                 .overlay(overlayIcon)
-                .shadow(radius: 1, x: 0, y: 1)
                 .padding(thumbPadding)
                 .offset(x: configuration.isOn ? 10 : -10)
 
@@ -51,9 +60,9 @@ struct WXMToggleStyle: ToggleStyle {
 			} label: {
                 RoundedRectangle(cornerRadius: 16, style: .circular)
                     .style(
-                        withStroke: configuration.isOn ? strokeColorOn : strokeColorOff,
+						withStroke: strokeColor(configuration: configuration),
                         lineWidth: strokeWidth,
-                        fill: configuration.isOn ? onColor : offColor
+						fill: fillColor(configuration: configuration)
                     )
                     .frame(width: 50, height: 29)
                     .overlay(circle)
@@ -63,4 +72,35 @@ struct WXMToggleStyle: ToggleStyle {
         }
         .font(.title)
     }
+}
+
+private extension WXMToggleStyle {
+	func fillColor(configuration: Configuration) -> Color {
+		var color = configuration.isOn ? onColor : offColor
+		let disabledColor = configuration.isOn ? onColorDisabled : offColorDisabled
+		color = isEnabled ? color : disabledColor
+		return color
+	}
+
+	func strokeColor(configuration: Configuration) -> Color {
+		var color = configuration.isOn ? strokeColorOn : strokeColorOff
+		let disabledColor = strokeColorOffDisabled
+		color = isEnabled ? color : disabledColor
+		return color
+	}
+
+	func thumbColor(configuration: Configuration) -> Color {
+		let disabledColor = configuration.isOn ? thumbColorOn : thumbColorOffDisabled
+		var color = configuration.isOn ? thumbColorOn : thumbColorOff
+		color = isEnabled ? color : disabledColor
+		return color
+	}
+}
+
+
+#Preview {
+	Toggle("", isOn: .constant(false))
+		.labelsHidden()
+		.toggleStyle(WXMToggleStyle.Default)
+		.disabled(true)
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsTypes.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsTypes.swift
@@ -34,4 +34,12 @@ extension StationNotificationsTypes: @retroactive CustomStringConvertible {
 				LocalizableString.StationDetails.healthDescription.localized
 		}
 	}
+
+	static func casesForDevice(_ device: DeviceDetails) -> [StationNotificationsTypes] {
+		guard device.isHelium else {
+			return [.activity, .battery, .health]
+		}
+
+		return [.activity, .battery, .firmwareUpdate, .health]
+	}
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsTypes.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsTypes.swift
@@ -6,13 +6,9 @@
 //
 
 import Foundation
+import DomainLayer
 
-enum StationNotificationsTypes: CaseIterable, CustomStringConvertible {
-	case activity
-	case battery
-	case firmwareUpdate
-	case health
-
+extension StationNotificationsTypes: @retroactive CustomStringConvertible {
 	var title: String {
 		switch self {
 			case .activity:
@@ -26,7 +22,7 @@ enum StationNotificationsTypes: CaseIterable, CustomStringConvertible {
 		}
 	}
 
-	var description: String {
+	public var description: String {
 		switch self {
 			case .activity:
 				LocalizableString.StationDetails.activityDescription.localized

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsTypes.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsTypes.swift
@@ -1,0 +1,41 @@
+//
+//  StationNotificationsTypes.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 8/7/25.
+//
+
+import Foundation
+
+enum StationNotificationsTypes: CaseIterable, CustomStringConvertible {
+	case activity
+	case battery
+	case firmwareUpdate
+	case health
+
+	var title: String {
+		switch self {
+			case .activity:
+				LocalizableString.StationDetails.activity.localized
+			case .battery:
+				LocalizableString.StationDetails.battery.localized
+			case .firmwareUpdate:
+				LocalizableString.StationDetails.firmwareUpdate.localized
+			case .health:
+				LocalizableString.StationDetails.health.localized
+		}
+	}
+
+	var description: String {
+		switch self {
+			case .activity:
+				LocalizableString.StationDetails.activityDescription.localized
+			case .battery:
+				LocalizableString.StationDetails.batteryDescription.localized
+			case .firmwareUpdate:
+				LocalizableString.StationDetails.firmwareUpdateDescription.localized
+			case .health:
+				LocalizableString.StationDetails.healthDescription.localized
+		}
+	}
+}

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
@@ -17,7 +17,9 @@ class StationNotificationsViewModel: ObservableObject {
 	let useCase: StationNotificationsUseCaseApi
 	@Published private(set) var masterSwitchValue: Bool = false
 	@Published private(set) var options: [StationNotificationsTypes: Bool] = [:]
-
+	var availableNotifications: [StationNotificationsTypes] {
+		StationNotificationsTypes.casesForDevice(device)
+	}
 	private var cancellableSet: Set<AnyCancellable> = .init()
 
 	init(device: DeviceDetails, followState: UserDeviceFollowState, useCase: StationNotificationsUseCaseApi) {
@@ -64,7 +66,7 @@ class StationNotificationsViewModel: ObservableObject {
 
 private extension StationNotificationsViewModel {
 	func updateOptions() {
-		options = Dictionary(uniqueKeysWithValues: StationNotificationsTypes.allCases.map {
+		options = Dictionary(uniqueKeysWithValues: StationNotificationsTypes.casesForDevice(device).map {
 			($0, valueFor(notificationType: $0))
 		})
 	}

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
@@ -6,7 +6,14 @@
 //
 
 import Foundation
+import DomainLayer
 
 class StationNotificationsViewModel: ObservableObject {
-	
+	let device: DeviceDetails
+	let followState: UserDeviceFollowState
+
+	init(device: DeviceDetails, followState: UserDeviceFollowState) {
+		self.device = device
+		self.followState = followState
+	}
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
@@ -11,10 +11,7 @@ import DomainLayer
 class StationNotificationsViewModel: ObservableObject {
 	let device: DeviceDetails
 	let followState: UserDeviceFollowState
-	var valueFromMasterSwitch: Bool {
-		true
-	}
-
+	@Published var masterSwitchValue: Bool = false
 
 	init(device: DeviceDetails, followState: UserDeviceFollowState) {
 		self.device = device
@@ -26,10 +23,10 @@ class StationNotificationsViewModel: ObservableObject {
 	}
 
 	func setValue(_ value: Bool, for notificationType: StationNotificationsTypes) {
-
 	}
 
 	func setmasterSwitchValue(_ value: Bool) {
-		
+		print(value)
+		masterSwitchValue = value
 	}
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
@@ -11,9 +11,25 @@ import DomainLayer
 class StationNotificationsViewModel: ObservableObject {
 	let device: DeviceDetails
 	let followState: UserDeviceFollowState
+	var valueFromMasterSwitch: Bool {
+		true
+	}
+
 
 	init(device: DeviceDetails, followState: UserDeviceFollowState) {
 		self.device = device
 		self.followState = followState
+	}
+
+	func valueFor(notificationType: StationNotificationsTypes) -> Bool {
+		true
+	}
+
+	func setValue(_ value: Bool, for notificationType: StationNotificationsTypes) {
+
+	}
+
+	func setmasterSwitchValue(_ value: Bool) {
+		
 	}
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
@@ -11,18 +11,21 @@ import DomainLayer
 class StationNotificationsViewModel: ObservableObject {
 	let device: DeviceDetails
 	let followState: UserDeviceFollowState
+	let useCase: StationNotificationsUseCaseApi
 	@Published var masterSwitchValue: Bool = false
 
-	init(device: DeviceDetails, followState: UserDeviceFollowState) {
+	init(device: DeviceDetails, followState: UserDeviceFollowState, useCase: StationNotificationsUseCaseApi) {
 		self.device = device
 		self.followState = followState
+		self.useCase = useCase
 	}
 
 	func valueFor(notificationType: StationNotificationsTypes) -> Bool {
-		true
+		useCase.isNotificationEnabled(notificationType)
 	}
 
 	func setValue(_ value: Bool, for notificationType: StationNotificationsTypes) {
+		useCase.setNotificationEnabled(value, for: notificationType)
 	}
 
 	func setmasterSwitchValue(_ value: Bool) {

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
@@ -33,3 +33,9 @@ class StationNotificationsViewModel: ObservableObject {
 		masterSwitchValue = value
 	}
 }
+
+extension StationNotificationsViewModel: HashableViewModel {
+	nonisolated func hash(into hasher: inout Hasher) {
+
+	}
+}

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
@@ -12,25 +12,35 @@ class StationNotificationsViewModel: ObservableObject {
 	let device: DeviceDetails
 	let followState: UserDeviceFollowState
 	let useCase: StationNotificationsUseCaseApi
-	@Published var masterSwitchValue: Bool = false
+	@Published private(set) var masterSwitchValue: Bool = false
+	@Published private(set) var options: [StationNotificationsTypes: Bool] = [:]
 
 	init(device: DeviceDetails, followState: UserDeviceFollowState, useCase: StationNotificationsUseCaseApi) {
 		self.device = device
 		self.followState = followState
 		self.useCase = useCase
-	}
-
-	func valueFor(notificationType: StationNotificationsTypes) -> Bool {
-		useCase.isNotificationEnabled(notificationType)
+		updateOptions()
 	}
 
 	func setValue(_ value: Bool, for notificationType: StationNotificationsTypes) {
 		useCase.setNotificationEnabled(value, for: notificationType)
+		updateOptions()
 	}
 
 	func setmasterSwitchValue(_ value: Bool) {
-		print(value)
 		masterSwitchValue = value
+	}
+}
+
+private extension StationNotificationsViewModel {
+	func updateOptions() {
+		options = Dictionary(uniqueKeysWithValues: StationNotificationsTypes.allCases.map {
+			($0, valueFor(notificationType: $0))
+		})
+	}
+
+	func valueFor(notificationType: StationNotificationsTypes) -> Bool {
+		useCase.isNotificationEnabled(notificationType)
 	}
 }
 

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  StationNotificationsViewModel.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 8/7/25.
+//
+
+import Foundation
+
+class StationNotificationsViewModel: ObservableObject {
+	
+}

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
@@ -30,7 +30,11 @@ class StationNotificationsViewModel: ObservableObject {
 	}
 
 	func setValue(_ value: Bool, for notificationType: StationNotificationsTypes) {
-		useCase.setNotificationEnabled(value, for: notificationType)
+		guard let deviceId = device.id else {
+			return
+		}
+
+		useCase.setNotificationEnabled(value, deviceId: deviceId, for: notificationType)
 		updateOptions()
 	}
 
@@ -66,7 +70,11 @@ private extension StationNotificationsViewModel {
 	}
 
 	func valueFor(notificationType: StationNotificationsTypes) -> Bool {
-		useCase.isNotificationEnabled(notificationType)
+		guard let deviceId = device.id else {
+			return false
+		}
+
+		return useCase.isNotificationEnabled(notificationType, deviceId: deviceId)
 	}
 
 	func observeAuthorizationStatus() {

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
@@ -22,7 +22,7 @@ struct StationsNotificationsView: View {
 						   switchOn: Binding(get: {
 					viewModel.masterSwitchValue
 				}, set: { value in
-					viewModel.setmasterSwitchValue(value)
+					viewModel.setMasterSwitchValue(value)
 				}))
 
 				WXMDivider()

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
@@ -13,34 +13,38 @@ struct StationsNotificationsView: View {
 	@EnvironmentObject var navigationObject: NavigationObject
 
     var body: some View {
-		ScrollView {
-			VStack(spacing: CGFloat(.defaultSpacing)) {
-				titleView
+		ZStack {
+			Color(colorEnum: .top)
+				.ignoresSafeArea()
+			ScrollView {
+				VStack(spacing: CGFloat(.defaultSpacing)) {
+					titleView
 
-				optionView(title: LocalizableString.StationDetails.showNotifications.localized,
-						   description: nil,
-						   switchOn: Binding(get: {
-					viewModel.masterSwitchValue
-				}, set: { value in
-					viewModel.setMasterSwitchValue(value)
-				}))
-
-				WXMDivider()
-
-				ForEach(StationNotificationsTypes.allCases, id: \.self) { notificationType in
-					optionView(title: notificationType.title,
-							   description: notificationType.description,
-							   switchOn: .init(get: {
-						viewModel.options[notificationType] ?? false
+					optionView(title: LocalizableString.StationDetails.showNotifications.localized,
+							   description: nil,
+							   switchOn: Binding(get: {
+						viewModel.masterSwitchValue
 					}, set: { value in
-						viewModel.setValue(value, for: notificationType)
+						viewModel.setMasterSwitchValue(value)
 					}))
-					.disabled(!viewModel.masterSwitchValue)
+
+					WXMDivider()
+
+					ForEach(StationNotificationsTypes.allCases, id: \.self) { notificationType in
+						optionView(title: notificationType.title,
+								   description: notificationType.description,
+								   switchOn: .init(get: {
+							viewModel.options[notificationType] ?? false
+						}, set: { value in
+							viewModel.setValue(value, for: notificationType)
+						}))
+						.disabled(!viewModel.masterSwitchValue)
+					}
 				}
+				.padding(CGFloat(.defaultSidePadding))
 			}
-			.padding(CGFloat(.defaultSidePadding))
+			.scrollIndicators(.hidden)
 		}
-		.scrollIndicators(.hidden)
 		.onAppear {
 			navigationObject.title = LocalizableString.StationDetails.notifications.localized
 		}

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
@@ -19,7 +19,7 @@ struct StationsNotificationsView: View {
 				optionView(title: LocalizableString.StationDetails.showNotifications.localized,
 						   description: nil,
 						   switchOn: Binding(get: {
-					viewModel.valueFromMasterSwitch
+					viewModel.masterSwitchValue
 				}, set: { value in
 					viewModel.setmasterSwitchValue(value)
 				}))
@@ -34,6 +34,7 @@ struct StationsNotificationsView: View {
 					}, set: { value in
 						viewModel.setValue(value, for: notificationType)
 					}))
+					.disabled(!viewModel.masterSwitchValue)
 				}
 			}
 			.padding(CGFloat(.defaultSidePadding))

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import DomainLayer
 
 struct StationsNotificationsView: View {
 	@StateObject var viewModel: StationNotificationsViewModel
@@ -97,8 +98,7 @@ private extension StationsNotificationsView {
 
 #Preview {
 	NavigationContainerView {
-		StationsNotificationsView(viewModel: .init(device: .mockDevice,
-												   followState: .init(deviceId: "",
-																	  relation: .owned)))
+		StationsNotificationsView(viewModel: ViewModelsFactory.getStationNotificationsViewModel(device: .mockDevice,
+																								followState: .init(deviceId: "", relation: .owned)))
 	}
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
@@ -65,7 +65,7 @@ private extension StationsNotificationsView {
 				}
 				.cornerRadius(CGFloat(.buttonCornerRadius))
 
-			Text(viewModel.device.friendlyName ?? "")
+			Text(viewModel.device.displayName)
 				.foregroundStyle(Color(colorEnum: .text))
 				.font(.system(size: CGFloat(.smallTitleFontSize)))
 

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
@@ -31,7 +31,7 @@ struct StationsNotificationsView: View {
 					optionView(title: notificationType.title,
 							   description: notificationType.description,
 							   switchOn: .init(get: {
-						viewModel.valueFor(notificationType: notificationType)
+						viewModel.options[notificationType] ?? false
 					}, set: { value in
 						viewModel.setValue(value, for: notificationType)
 					}))

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
@@ -1,0 +1,25 @@
+//
+//  StationsNotificationsView.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 8/7/25.
+//
+
+import SwiftUI
+
+struct StationsNotificationsView: View {
+	@EnvironmentObject var navigationObject: NavigationObject
+
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+			.onAppear {
+				navigationObject.title = LocalizableString.StationDetails.notVerified.localized
+			}
+    }
+}
+
+#Preview {
+	NavigationContainerView {
+		StationsNotificationsView()
+	}
+}

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
@@ -30,7 +30,7 @@ struct StationsNotificationsView: View {
 
 					WXMDivider()
 
-					ForEach(StationNotificationsTypes.allCases, id: \.self) { notificationType in
+					ForEach(viewModel.availableNotifications, id: \.self) { notificationType in
 						optionView(title: notificationType.title,
 								   description: notificationType.description,
 								   switchOn: .init(get: {

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
@@ -8,18 +8,51 @@
 import SwiftUI
 
 struct StationsNotificationsView: View {
+	@StateObject var viewModel: StationNotificationsViewModel
 	@EnvironmentObject var navigationObject: NavigationObject
 
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
-			.onAppear {
-				navigationObject.title = LocalizableString.StationDetails.notVerified.localized
+		ScrollView {
+			VStack(spacing: CGFloat(.defaultSpacing)) {
+				titleView
+				Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
 			}
-    }
+			.padding(CGFloat(.defaultSidePadding))
+		}
+		.scrollIndicators(.hidden)
+		.onAppear {
+			navigationObject.title = LocalizableString.StationDetails.notifications.localized
+		}
+	}
+}
+
+private extension StationsNotificationsView {
+	@ViewBuilder
+	var titleView: some View {
+		HStack(spacing: CGFloat(.smallToMediumSpacing)) {
+			let faIcon = viewModel.followState.state.FAIcon
+			Text(faIcon.icon.rawValue)
+				.font(.fontAwesome(font: faIcon.font, size: CGFloat(.mediumFontSize)))
+				.foregroundColor(Color(colorEnum: faIcon.color))
+				.padding(CGFloat(.smallSidePadding))
+				.background {
+					Color(colorEnum: .layer1)
+				}
+				.cornerRadius(CGFloat(.buttonCornerRadius))
+
+			Text(viewModel.device.friendlyName ?? "")
+				.foregroundStyle(Color(colorEnum: .text))
+				.font(.system(size: CGFloat(.smallTitleFontSize)))
+			
+			Spacer()
+		}
+	}
 }
 
 #Preview {
 	NavigationContainerView {
-		StationsNotificationsView()
+		StationsNotificationsView(viewModel: .init(device: .mockDevice,
+												   followState: .init(deviceId: "",
+																	  relation: .owned)))
 	}
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
@@ -15,7 +15,26 @@ struct StationsNotificationsView: View {
 		ScrollView {
 			VStack(spacing: CGFloat(.defaultSpacing)) {
 				titleView
-				Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+
+				optionView(title: LocalizableString.StationDetails.showNotifications.localized,
+						   description: nil,
+						   switchOn: Binding(get: {
+					viewModel.valueFromMasterSwitch
+				}, set: { value in
+					viewModel.setmasterSwitchValue(value)
+				}))
+
+				WXMDivider()
+
+				ForEach(StationNotificationsTypes.allCases, id: \.self) { notificationType in
+					optionView(title: notificationType.title,
+							   description: notificationType.description,
+							   switchOn: .init(get: {
+						viewModel.valueFor(notificationType: notificationType)
+					}, set: { value in
+						viewModel.setValue(value, for: notificationType)
+					}))
+				}
 			}
 			.padding(CGFloat(.defaultSidePadding))
 		}
@@ -43,8 +62,34 @@ private extension StationsNotificationsView {
 			Text(viewModel.device.friendlyName ?? "")
 				.foregroundStyle(Color(colorEnum: .text))
 				.font(.system(size: CGFloat(.smallTitleFontSize)))
-			
+
 			Spacer()
+		}
+	}
+
+	@ViewBuilder
+	func optionView(title: String,
+					description: String?,
+					switchOn: Binding<Bool>) -> some View {
+		HStack {
+			VStack(alignment: .leading, spacing: CGFloat(.minimumSpacing)) {
+				Text(title)
+					.foregroundStyle(Color(colorEnum: .text))
+					.font(.system(size: CGFloat(.smallTitleFontSize)))
+
+				if let description {
+					Text(description)
+						.foregroundStyle(Color(colorEnum: .text))
+						.font(.system(size: CGFloat(.normalFontSize)))
+						.fixedSize(horizontal: false, vertical: true)
+				}
+			}
+
+			Spacer()
+
+			Toggle("", isOn: switchOn)
+				.labelsHidden()
+				.toggleStyle(WXMToggleStyle.Default)
 		}
 	}
 }

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
@@ -106,7 +106,13 @@ class StationDetailsViewModel: ObservableObject {
     }
 
 	func notificationsButtonTapped() {
-		// Route to notifications screen
+		guard let device, let followState else {
+			return
+		}
+
+		let viewModel = ViewModelsFactory.getStationNotificationsViewModel(device: device,
+																		   followState: followState)
+		Router.shared.navigateTo(.stationNotifications(viewModel))
 	}
 
 	func warningTapped() {

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
@@ -106,13 +106,7 @@ class StationDetailsViewModel: ObservableObject {
     }
 
 	func notificationsButtonTapped() {
-		guard let device, let followState else {
-			return
-		}
-
-		let viewModel = ViewModelsFactory.getStationNotificationsViewModel(device: device,
-																		   followState: followState)
-		Router.shared.navigateTo(.stationNotifications(viewModel))
+		navigateToNotifications()
 	}
 
 	func warningTapped() {
@@ -325,6 +319,16 @@ private extension StationDetailsViewModel {
 		Router.shared.navigateTo(.viewMoreAlerts(.init(device: device, mainVM: .shared, followState: followState)))
 	}
 
+	func navigateToNotifications() {
+		guard let device, let followState else {
+			return
+		}
+
+		let viewModel = ViewModelsFactory.getStationNotificationsViewModel(device: device,
+																		   followState: followState)
+		Router.shared.navigateTo(.stationNotifications(viewModel))
+	}
+
 	func showStationNotificationsAlertIfNeeded() {
 //		guard followState?.relation == .owned else {
 //			return
@@ -337,7 +341,10 @@ private extension StationDetailsViewModel {
 										 secondaryButtons: [.init(title: LocalizableString.StationDetails.notificationsAlertCancelButtonTitle.localized,
 																  action: { self.showNotificationsAlert = false })],
 										 primaryButtons: [.init(title: LocalizableString.StationDetails.notificationsAlertButtonTitle.localized,
-																action: { self.showNotificationsAlert = false })])
+																action: {
+			self.showNotificationsAlert = false
+			self.navigateToNotifications()
+		})])
 		notificationsAlertConfiguration = conf
 		showNotificationsAlert = true
 		useCase?.notificationsPromptShown()

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/StationDetailsViewModel.swift
@@ -97,7 +97,6 @@ class StationDetailsViewModel: ObservableObject {
 
 	func viewAppeared() {
 		trackExplorerDeviceEventIfNeeded(isInitialized: isFollowStateInitialized)
-		showStationNotificationsAlertIfNeeded()
 	}
 
     func settingsButtonTapped() {
@@ -330,9 +329,10 @@ private extension StationDetailsViewModel {
 	}
 
 	func showStationNotificationsAlertIfNeeded() {
-//		guard followState?.relation == .owned else {
-//			return
-//		}
+		guard followState?.relation == .owned,
+		useCase?.hasNotificationsPromptBeenShown == false else {
+			return
+		}
 
 		let conf = WXMAlertConfiguration(title: LocalizableString.StationDetails.notificationsAlertTitle.localized,
 										 text: LocalizableString.StationDetails.notificationsAlertMessage.localized.attributedMarkdown ?? "",

--- a/PresentationLayer/UIComponents/ViewModelsFactory.swift
+++ b/PresentationLayer/UIComponents/ViewModelsFactory.swift
@@ -307,6 +307,7 @@ enum ViewModelsFactory {
 	}
 
 	static func getStationNotificationsViewModel(device: DeviceDetails, followState: UserDeviceFollowState) -> StationNotificationsViewModel {
-		StationNotificationsViewModel(device: device, followState: followState)
+		let useCase = SwinjectHelper.shared.getContainerForSwinject().resolve(StationNotificationsUseCaseApi.self)!
+		return StationNotificationsViewModel(device: device, followState: followState, useCase: useCase)
 	}
 }

--- a/PresentationLayer/UIComponents/ViewModelsFactory.swift
+++ b/PresentationLayer/UIComponents/ViewModelsFactory.swift
@@ -305,4 +305,8 @@ enum ViewModelsFactory {
 	static func getProPromotionalViewModel() -> ProPromotionalViewModel {
 		return ProPromotionalViewModel()
 	}
+
+	static func getStationNotificationsViewModel(device: DeviceDetails, followState: UserDeviceFollowState) -> StationNotificationsViewModel {
+		StationNotificationsViewModel(device: device, followState: followState)
+	}
 }

--- a/WeatherXMTests/DomainLayer/UseCases/StationNotificationsUseCaseTests.swift
+++ b/WeatherXMTests/DomainLayer/UseCases/StationNotificationsUseCaseTests.swift
@@ -1,0 +1,53 @@
+//
+//  StationNotificationsUseCaseTests.swift
+//  WeatherXMTests
+//
+//  Created by Pantelis Giazitsis on 10/7/25.
+//
+
+import Testing
+@testable import DomainLayer
+
+struct StationNotificationsUseCaseTests {
+	let userDefaultsRepository: MockUserDefaultsRepositoryImpl = .init()
+	let useCase: StationNotificationsUseCase
+
+	init() {
+		self.useCase = .init(userDefaultsRepository: userDefaultsRepository)
+	}
+
+	@Test func notificationsEnabledDefaultTrue() {
+		// No value set, should default to true
+		#expect(useCase.areNotificationsEnalbedForDevice("device1") == true)
+	}
+
+	@Test func setNotificationsForDevice() {
+		useCase.setNotificationsForDevice("device1", enabled: false)
+		#expect(useCase.areNotificationsEnalbedForDevice("device1") == false)
+		useCase.setNotificationsForDevice("device1", enabled: true)
+		#expect(useCase.areNotificationsEnalbedForDevice("device1") == true)
+	}
+
+	@Test func setAndGetNotificationTypeEnabled() {
+		let deviceId = "device2"
+		#expect(useCase.isNotificationEnabled(.activity, deviceId: deviceId) == true)
+		useCase.setNotificationEnabled(false, deviceId: deviceId, for: .activity)
+		#expect(useCase.isNotificationEnabled(.activity, deviceId: deviceId) == false)
+		useCase.setNotificationEnabled(true, deviceId: deviceId, for: .activity)
+		#expect(useCase.isNotificationEnabled(.activity, deviceId: deviceId) == true)
+	}
+
+	@Test func notificationTypeDefaultTrue() {
+		let deviceId = "device3"
+		#expect(useCase.isNotificationEnabled(.battery, deviceId: deviceId) == true)
+	}
+
+	@Test func multipleTypesPerDevice() {
+		let deviceId = "device4"
+		useCase.setNotificationEnabled(false, deviceId: deviceId, for: .activity)
+		useCase.setNotificationEnabled(true, deviceId: deviceId, for: .battery)
+		#expect(useCase.isNotificationEnabled(.activity, deviceId: deviceId) == false)
+		#expect(useCase.isNotificationEnabled(.battery, deviceId: deviceId) == true)
+		#expect(useCase.isNotificationEnabled(.firmwareUpdate, deviceId: deviceId) == true)
+	}
+}

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		261913F32E1D208300F7E51C /* StationNotificationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261913F22E1D208300F7E51C /* StationNotificationsViewModel.swift */; };
 		261913F52E1D20AE00F7E51C /* StationsNotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261913F42E1D20AE00F7E51C /* StationsNotificationsView.swift */; };
 		261913F72E1D266900F7E51C /* StationNotificationsTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261913F62E1D266900F7E51C /* StationNotificationsTypes.swift */; };
+		261914152E1FF5AE00F7E51C /* StationNotificationsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261914142E1FF5AE00F7E51C /* StationNotificationsUseCaseTests.swift */; };
 		261CD81829CB2D5B00C0CECE /* PercentageGridLayoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CD81729CB2D5A00C0CECE /* PercentageGridLayoutView.swift */; };
 		261E9EA729A9275C00E8EBA3 /* Swinject in Frameworks */ = {isa = PBXBuildFile; productRef = 261E9EA629A9275C00E8EBA3 /* Swinject */; };
 		261E9EAA29A927BE00E8EBA3 /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; productRef = 261E9EA929A927BE00E8EBA3 /* CodeScanner */; };
@@ -814,6 +815,7 @@
 		261913F22E1D208300F7E51C /* StationNotificationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationNotificationsViewModel.swift; sourceTree = "<group>"; };
 		261913F42E1D20AE00F7E51C /* StationsNotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationsNotificationsView.swift; sourceTree = "<group>"; };
 		261913F62E1D266900F7E51C /* StationNotificationsTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationNotificationsTypes.swift; sourceTree = "<group>"; };
+		261914142E1FF5AE00F7E51C /* StationNotificationsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationNotificationsUseCaseTests.swift; sourceTree = "<group>"; };
 		261CD81729CB2D5A00C0CECE /* PercentageGridLayoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PercentageGridLayoutView.swift; sourceTree = "<group>"; };
 		2623E2222A6FC29100E3E306 /* RouterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterView.swift; sourceTree = "<group>"; };
 		2623FF902AF147A800BCDAC6 /* RewardDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardDetailsView.swift; sourceTree = "<group>"; };
@@ -3167,6 +3169,7 @@
 				26710E952D7F15B000878298 /* DevicesUseCaseTests.swift */,
 				26710E972D7F2B2C00878298 /* DeviceLocationUseCaseTests.swift */,
 				26710E9B2D7F36A700878298 /* DeviceInfoUseCaseTests.swift */,
+				261914142E1FF5AE00F7E51C /* StationNotificationsUseCaseTests.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -3778,6 +3781,7 @@
 				26710E3E2D7AF73D00878298 /* UpdateFirmwareUseCaseTests.swift in Sources */,
 				26F83CBD2D9E711200E5A8B8 /* DeleteAccountViewModelTests.swift in Sources */,
 				26A0A98B2DC0BCFA005A6646 /* BluetoothStateTests.swift in Sources */,
+				261914152E1FF5AE00F7E51C /* StationNotificationsUseCaseTests.swift in Sources */,
 				268BAD4C2DC0DC4600748439 /* FiltersTest.swift in Sources */,
 				26A0A9932DC0D326005A6646 /* DeviceDetailsTests.swift in Sources */,
 				26D657332DBB942900990B80 /* DeepLinkHandlerTests.swift in Sources */,

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		2618A7142A20FFCA00983B7B /* MultipleAlertsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618A7132A20FFCA00983B7B /* MultipleAlertsView.swift */; };
 		2618A7162A21014200983B7B /* AlertsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618A7152A21014200983B7B /* AlertsViewModel.swift */; };
 		2618A7262A24F93000983B7B /* BottomSheetModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618A7252A24F93000983B7B /* BottomSheetModifier.swift */; };
+		261913F32E1D208300F7E51C /* StationNotificationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261913F22E1D208300F7E51C /* StationNotificationsViewModel.swift */; };
+		261913F52E1D20AE00F7E51C /* StationsNotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261913F42E1D20AE00F7E51C /* StationsNotificationsView.swift */; };
 		261CD81829CB2D5B00C0CECE /* PercentageGridLayoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CD81729CB2D5A00C0CECE /* PercentageGridLayoutView.swift */; };
 		261E9EA729A9275C00E8EBA3 /* Swinject in Frameworks */ = {isa = PBXBuildFile; productRef = 261E9EA629A9275C00E8EBA3 /* Swinject */; };
 		261E9EAA29A927BE00E8EBA3 /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; productRef = 261E9EA929A927BE00E8EBA3 /* CodeScanner */; };
@@ -808,6 +810,8 @@
 		2618A7132A20FFCA00983B7B /* MultipleAlertsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleAlertsView.swift; sourceTree = "<group>"; };
 		2618A7152A21014200983B7B /* AlertsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertsViewModel.swift; sourceTree = "<group>"; };
 		2618A7252A24F93000983B7B /* BottomSheetModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetModifier.swift; sourceTree = "<group>"; };
+		261913F22E1D208300F7E51C /* StationNotificationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationNotificationsViewModel.swift; sourceTree = "<group>"; };
+		261913F42E1D20AE00F7E51C /* StationsNotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationsNotificationsView.swift; sourceTree = "<group>"; };
 		261CD81729CB2D5A00C0CECE /* PercentageGridLayoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PercentageGridLayoutView.swift; sourceTree = "<group>"; };
 		2623E2222A6FC29100E3E306 /* RouterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterView.swift; sourceTree = "<group>"; };
 		2623FF902AF147A800BCDAC6 /* RewardDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardDetailsView.swift; sourceTree = "<group>"; };
@@ -1526,6 +1530,15 @@
 				2618A7132A20FFCA00983B7B /* MultipleAlertsView.swift */,
 			);
 			path = MultipleAlerts;
+			sourceTree = "<group>";
+		};
+		261913F12E1D201600F7E51C /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				261913F22E1D208300F7E51C /* StationNotificationsViewModel.swift */,
+				261913F42E1D20AE00F7E51C /* StationsNotificationsView.swift */,
+			);
+			path = Notifications;
 			sourceTree = "<group>";
 		};
 		2623FF8F2AF1467E00BCDAC6 /* DailyRewards */ = {
@@ -3014,6 +3027,7 @@
 		26DD42DF29B0F66A008E277E /* StationDetails */ = {
 			isa = PBXGroup;
 			children = (
+				261913F12E1D201600F7E51C /* Notifications */,
 				2664832729C35ABA00748F9C /* Forecast */,
 				26A4115729B6061900A2C10B /* Overview */,
 				2646D8F129C8BF240000237F /* Rewards */,
@@ -4010,6 +4024,7 @@
 				26A4117E29B8A17D00A2C10B /* DeviceInfoViewModel+Content.swift in Sources */,
 				26A4116D29B744FD00A2C10B /* DeviceInfoViewModel.swift in Sources */,
 				2672B87C2C89F19A002266BE /* BoostCode+.swift in Sources */,
+				261913F52E1D20AE00F7E51C /* StationsNotificationsView.swift in Sources */,
 				26A4118229BA1A9900A2C10B /* DeviceUpdatesLoadingView.swift in Sources */,
 				26E5B0C229F8152800834899 /* Dimensions.swift in Sources */,
 				267548DD29A91A87008BCF40 /* DisplayedLinks.swift in Sources */,
@@ -4152,6 +4167,7 @@
 				266B018F2B836EC6007AC689 /* NoRewardsView.swift in Sources */,
 				26A4119529BF203400A2C10B /* SelectFrequencyView.swift in Sources */,
 				268B5C432BCEB61A00E63655 /* ForecastFieldCardView.swift in Sources */,
+				261913F32E1D208300F7E51C /* StationNotificationsViewModel.swift in Sources */,
 				2672B8802C8A02D0002266BE /* BoostDetailsView.swift in Sources */,
 				267547BE29A9181E008BCF40 /* SettingsButtonView.swift in Sources */,
 				267548DF29A91A87008BCF40 /* SettingsEnum.swift in Sources */,

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		2618A7262A24F93000983B7B /* BottomSheetModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618A7252A24F93000983B7B /* BottomSheetModifier.swift */; };
 		261913F32E1D208300F7E51C /* StationNotificationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261913F22E1D208300F7E51C /* StationNotificationsViewModel.swift */; };
 		261913F52E1D20AE00F7E51C /* StationsNotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261913F42E1D20AE00F7E51C /* StationsNotificationsView.swift */; };
+		261913F72E1D266900F7E51C /* StationNotificationsTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261913F62E1D266900F7E51C /* StationNotificationsTypes.swift */; };
 		261CD81829CB2D5B00C0CECE /* PercentageGridLayoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CD81729CB2D5A00C0CECE /* PercentageGridLayoutView.swift */; };
 		261E9EA729A9275C00E8EBA3 /* Swinject in Frameworks */ = {isa = PBXBuildFile; productRef = 261E9EA629A9275C00E8EBA3 /* Swinject */; };
 		261E9EAA29A927BE00E8EBA3 /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; productRef = 261E9EA929A927BE00E8EBA3 /* CodeScanner */; };
@@ -812,6 +813,7 @@
 		2618A7252A24F93000983B7B /* BottomSheetModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetModifier.swift; sourceTree = "<group>"; };
 		261913F22E1D208300F7E51C /* StationNotificationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationNotificationsViewModel.swift; sourceTree = "<group>"; };
 		261913F42E1D20AE00F7E51C /* StationsNotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationsNotificationsView.swift; sourceTree = "<group>"; };
+		261913F62E1D266900F7E51C /* StationNotificationsTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationNotificationsTypes.swift; sourceTree = "<group>"; };
 		261CD81729CB2D5A00C0CECE /* PercentageGridLayoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PercentageGridLayoutView.swift; sourceTree = "<group>"; };
 		2623E2222A6FC29100E3E306 /* RouterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterView.swift; sourceTree = "<group>"; };
 		2623FF902AF147A800BCDAC6 /* RewardDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardDetailsView.swift; sourceTree = "<group>"; };
@@ -1537,6 +1539,7 @@
 			children = (
 				261913F22E1D208300F7E51C /* StationNotificationsViewModel.swift */,
 				261913F42E1D20AE00F7E51C /* StationsNotificationsView.swift */,
+				261913F62E1D266900F7E51C /* StationNotificationsTypes.swift */,
 			);
 			path = Notifications;
 			sourceTree = "<group>";
@@ -4261,6 +4264,7 @@
 				2623FF912AF147A800BCDAC6 /* RewardDetailsView.swift in Sources */,
 				26AF27802A0B9D870067A1B8 /* UIImage+.swift in Sources */,
 				267EC4262A98C14700F2C37E /* UIKitUtils.swift in Sources */,
+				261913F72E1D266900F7E51C /* StationNotificationsTypes.swift in Sources */,
 				267547DC29A9181E008BCF40 /* UITextField+StationSerialNumber.swift in Sources */,
 				26C5AF402BF7632700476B89 /* ClaimDeviceProgressView.swift in Sources */,
 				26AF277C2A0B8F810067A1B8 /* UnitConstants.swift in Sources */,

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/UserDefaultsRepositoryImp.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/UserDefaultsRepositoryImp.swift
@@ -5,8 +5,7 @@
 //  Created by Lampros Zouloumis on 1/9/22.
 //
 
-import protocol DomainLayer.UnitsProtocol
-import protocol DomainLayer.UserDefaultsRepository
+import DomainLayer
 import Foundation
 
 public struct UserDefaultsRepositoryImp: UserDefaultsRepository {

--- a/wxm-ios/DataLayer/UserDefaultsService/UserDefaultsService.swift
+++ b/wxm-ios/DataLayer/UserDefaultsService/UserDefaultsService.swift
@@ -9,7 +9,7 @@ import DomainLayer
 import Foundation
 import Toolkit
 
-public struct UserDefaultsService: PersistCacheManager {
+public struct UserDefaultsService: PersistCacheManager, @unchecked Sendable {
 	private let userDefaults: UserDefaults?
 
 	public init() {

--- a/wxm-ios/DomainLayer/DomainLayer.xcodeproj/project.pbxproj
+++ b/wxm-ios/DomainLayer/DomainLayer.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		2612AC202AB45F3C00285896 /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2612AC1F2AB45F3C00285896 /* Filters.swift */; };
 		2612AC222AB4621A00285896 /* FiltersRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2612AC212AB4621A00285896 /* FiltersRepository.swift */; };
 		2612AC262AB46AF200285896 /* FiltersUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2612AC252AB46AF200285896 /* FiltersUseCase.swift */; };
+		261914052E1E5FA100F7E51C /* StationNotificationsUseCaseApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261914042E1E5FA100F7E51C /* StationNotificationsUseCaseApi.swift */; };
+		261914072E1E6BE300F7E51C /* StationNotificationsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261914062E1E6BE300F7E51C /* StationNotificationsUseCase.swift */; };
 		261FFAB6299B9E8F00FCDC65 /* UpdateFirmwareUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261FFAB5299B9E8F00FCDC65 /* UpdateFirmwareUseCase.swift */; };
 		26348E0C2A434CCB000846C6 /* NetworkSearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26348E0B2A434CCB000846C6 /* NetworkSearchResponse.swift */; };
 		26348E0E2A44360A000846C6 /* LocationCoordinates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26348E0D2A44360A000846C6 /* LocationCoordinates.swift */; };
@@ -116,6 +118,8 @@
 		2612AC1F2AB45F3C00285896 /* Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filters.swift; sourceTree = "<group>"; };
 		2612AC212AB4621A00285896 /* FiltersRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersRepository.swift; sourceTree = "<group>"; };
 		2612AC252AB46AF200285896 /* FiltersUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersUseCase.swift; sourceTree = "<group>"; };
+		261914042E1E5FA100F7E51C /* StationNotificationsUseCaseApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationNotificationsUseCaseApi.swift; sourceTree = "<group>"; };
+		261914062E1E6BE300F7E51C /* StationNotificationsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationNotificationsUseCase.swift; sourceTree = "<group>"; };
 		261FFAB5299B9E8F00FCDC65 /* UpdateFirmwareUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateFirmwareUseCase.swift; sourceTree = "<group>"; };
 		26348E0B2A434CCB000846C6 /* NetworkSearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSearchResponse.swift; sourceTree = "<group>"; };
 		26348E0D2A44360A000846C6 /* LocationCoordinates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationCoordinates.swift; sourceTree = "<group>"; };
@@ -246,6 +250,7 @@
 				26F83C712D9BC9E800E5A8B8 /* HistoryUseCaseApi.swift */,
 				26F83C732D9BCB2500E5A8B8 /* MainUseCaseApi.swift */,
 				26F83C752D9BD11B00E5A8B8 /* MeUseCaseApi.swift */,
+				261914042E1E5FA100F7E51C /* StationNotificationsUseCaseApi.swift */,
 				26F83C772D9BEC7F00E5A8B8 /* NetworkUseCaseApi.swift */,
 				26F83C792D9BEE6D00E5A8B8 /* RewardsUseCaseApi.swift */,
 				26F83C7B2D9BF0C900E5A8B8 /* SettingsUseCaseApi.swift */,
@@ -400,6 +405,7 @@
 				267401712A37687000E54E35 /* NetworkUseCase.swift */,
 				26A9619F2A78FFDD00A0E7B9 /* RewardsUseCase.swift */,
 				26D47E992A1779310078723A /* SettingsUseCase.swift */,
+				261914062E1E6BE300F7E51C /* StationNotificationsUseCase.swift */,
 				99A31FA828D0C1F7003BE981 /* RewardsTimelineUseCase.swift */,
 				261FFAB5299B9E8F00FCDC65 /* UpdateFirmwareUseCase.swift */,
 				266D17F82AC71280007CDB06 /* WidgetUseCase.swift */,
@@ -644,6 +650,7 @@
 				26ACE8ED2C8833B800EA22DD /* NetworkDevicesRewardsResponse.swift in Sources */,
 				B5E6B8892833B75D0060D050 /* MeUseCase.swift in Sources */,
 				B5611E812834E0150092F204 /* NetworkDeviceForecastResponse.swift in Sources */,
+				261914052E1E5FA100F7E51C /* StationNotificationsUseCaseApi.swift in Sources */,
 				26F83C802D9BF4A500E5A8B8 /* UpdateFirmwareUseCaseApi.swift in Sources */,
 				26D47E882A1633E10078723A /* NetworkDeviceHistoryResponse.swift in Sources */,
 				267227AF2D9BBB520045BBDC /* DeviceLocationUseCaseApi.swift in Sources */,
@@ -685,6 +692,7 @@
 				99A31FA928D0C1F7003BE981 /* RewardsTimelineUseCase.swift in Sources */,
 				264C10612AF3DBA100F6FF3E /* DeviceAnnotation.swift in Sources */,
 				2691840C2C08ABD300705755 /* BluetoothHeliumError.swift in Sources */,
+				261914072E1E6BE300F7E51C /* StationNotificationsUseCase.swift in Sources */,
 				26AF27782A0B8B090067A1B8 /* UnitsEnum.swift in Sources */,
 				261FFAB6299B9E8F00FCDC65 /* UpdateFirmwareUseCase.swift in Sources */,
 				26F83C702D9BC60B00E5A8B8 /* FiltersUseCaseApi.swift in Sources */,

--- a/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/UserDefaultsRepository.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/UserDefaultsRepository.swift
@@ -5,7 +5,7 @@
 //  Created by Lampros Zouloumis on 1/9/22.
 //
 
-public protocol UserDefaultsRepository {
+public protocol UserDefaultsRepository: Sendable {
     func readWeatherUnit(key: String) -> UnitsProtocol?
     func saveDefaultUnitForKey(key: String) -> UnitsProtocol?
     func saveWeatherUnit(unitProtocol: UnitsProtocol)

--- a/wxm-ios/DomainLayer/DomainLayer/Extensions/UserDefaults+Constants.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Extensions/UserDefaults+Constants.swift
@@ -46,6 +46,7 @@ public extension UserDefaults {
 		case arePhotoVerificationTermsAccepted = "com.weatherxm.app.UserDefaults.Key.ArePhotoVerificationTermsAccepted"
 		case isAddButtonIndicationSeen = "com.weatherxm.app.UserDefaults.Key.isAddButtonIndicationSeen"
 		case stationNotificationsPromptSeen = "com.weatherxm.app.UserDefaults.Key.StationNotificationsPromptSeen"
+		case stationNotificationOptions = "com.weatherxm.app.UserDefaults.Key.StationNotificationOptions"
 
         // MARK: - UserDefaultEntry
 
@@ -60,7 +61,8 @@ public extension UserDefaults {
 									  .lastInfoBannerId,
 									  .lastAnnouncementId,
 									  .arePhotoVerificationTermsAccepted,
-									  .isAddButtonIndicationSeen]
+									  .isAddButtonIndicationSeen,
+									  .stationNotificationOptions]
             return keys.map { $0.rawValue }
         }
     }

--- a/wxm-ios/DomainLayer/DomainLayer/Extensions/UserDefaults+Constants.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Extensions/UserDefaults+Constants.swift
@@ -47,6 +47,7 @@ public extension UserDefaults {
 		case isAddButtonIndicationSeen = "com.weatherxm.app.UserDefaults.Key.isAddButtonIndicationSeen"
 		case stationNotificationsPromptSeen = "com.weatherxm.app.UserDefaults.Key.StationNotificationsPromptSeen"
 		case stationNotificationOptions = "com.weatherxm.app.UserDefaults.Key.StationNotificationOptions"
+		case stationNotificationEnabled = "com.weatherxm.app.UserDefaults.Key.StationNotificationEnabled"
 
         // MARK: - UserDefaultEntry
 
@@ -62,7 +63,8 @@ public extension UserDefaults {
 									  .lastAnnouncementId,
 									  .arePhotoVerificationTermsAccepted,
 									  .isAddButtonIndicationSeen,
-									  .stationNotificationOptions]
+									  .stationNotificationOptions,
+									  .stationNotificationEnabled]
             return keys.map { $0.rawValue }
         }
     }

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/StationNotificationsUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/StationNotificationsUseCase.swift
@@ -9,6 +9,8 @@ import Foundation
 
 private typealias StationOptions = [StationNotificationsTypes: Bool]
 private typealias Stations = [String: StationOptions]
+private typealias EnabledStations = [String: Bool]
+
 public struct StationNotificationsUseCase: StationNotificationsUseCaseApi {
 	private let userDefaultsRepository: UserDefaultsRepository
 	private let stationsUDKey = UserDefaults.GenericKey.stationNotificationOptions.rawValue
@@ -19,21 +21,18 @@ public struct StationNotificationsUseCase: StationNotificationsUseCaseApi {
 	}
 
 	public func areNotificationsEnalbedForDevice(_ deviceId: String) -> Bool {
-		let deviceIds: [String]? = userDefaultsRepository.getValue(for: notificationsEnabledUDKey)
-		return deviceIds?.contains(deviceId) ?? false
+		let devices: EnabledStations? = userDefaultsRepository.getValue(for: notificationsEnabledUDKey)
+		guard let isEnabled = devices?[deviceId] else {
+			return true
+		}
+
+		return isEnabled
 	}
 
 	public func setNotificationsForDevice(_ deviceId: String, enabled: Bool) {
-		let deviceIdsArray: [String] = userDefaultsRepository.getValue(for: notificationsEnabledUDKey) ?? []
-		var deviceIds: Set<String> = Set(deviceIdsArray)
-
-		if enabled {
-			deviceIds.insert(deviceId)
-		} else {
-			deviceIds.remove(deviceId)
-		}
-
-		userDefaultsRepository.saveValue(key: notificationsEnabledUDKey, value: Array(deviceIds))
+		var enabledStations: EnabledStations = userDefaultsRepository.getValue(for: notificationsEnabledUDKey) ?? [:]
+		enabledStations[deviceId] = enabled
+		userDefaultsRepository.saveValue(key: notificationsEnabledUDKey, value: enabledStations)
 	}
 
 	public func setNotificationEnabled(_ enabled: Bool, deviceId: String, for type: StationNotificationsTypes) {
@@ -53,7 +52,7 @@ public struct StationNotificationsUseCase: StationNotificationsUseCaseApi {
 
 	public func isNotificationEnabled(_ type: StationNotificationsTypes, deviceId: String) -> Bool {
 		let options = getStations()?[deviceId]
-		return options?[type] ?? false
+		return options?[type] ?? true
 	}
 }
 

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/StationNotificationsUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/StationNotificationsUseCase.swift
@@ -11,9 +11,28 @@ private typealias StationOptions = [StationNotificationsTypes: Bool]
 public struct StationNotificationsUseCase: StationNotificationsUseCaseApi {
 	private let userDefaultsRepository: UserDefaultsRepository
 	private let udKey = UserDefaults.GenericKey.stationNotificationOptions.rawValue
+	private let notificationsEnabledUDKey = UserDefaults.GenericKey.stationNotificationEnabled.rawValue
 
 	public init(userDefaultsRepository: UserDefaultsRepository) {
 		self.userDefaultsRepository = userDefaultsRepository
+	}
+
+	public func areNotificationsEnalbedForDevice(_ deviceId: String) -> Bool {
+		let deviceIds: [String]? = userDefaultsRepository.getValue(for: notificationsEnabledUDKey)
+		return deviceIds?.contains(deviceId) ?? false
+	}
+
+	public func setNotificationsForDevice(_ deviceId: String, enabled: Bool) {
+		let deviceIdsArray: [String] = userDefaultsRepository.getValue(for: notificationsEnabledUDKey) ?? []
+		var deviceIds: Set<String> = Set(deviceIdsArray)
+
+		if enabled {
+			deviceIds.insert(deviceId)
+		} else {
+			deviceIds.remove(deviceId)
+		}
+
+		userDefaultsRepository.saveValue(key: notificationsEnabledUDKey, value: Array(deviceIds))
 	}
 
 	public func setNotificationEnabled(_ enabled: Bool, for type: StationNotificationsTypes) {

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/StationNotificationsUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/StationNotificationsUseCase.swift
@@ -17,19 +17,43 @@ public struct StationNotificationsUseCase: StationNotificationsUseCaseApi {
 	}
 
 	public func setNotificationEnabled(_ enabled: Bool, for type: StationNotificationsTypes) {
-		guard var options: StationOptions = userDefaultsRepository.getValue(for: udKey) else {
+		guard var options = getOptions() else {
 			var options: StationOptions = [:]
 			options[type] = enabled
-			userDefaultsRepository.saveValue(key: udKey, value: options)
+			saveOptions(options)
 			return
 		}
 
 		options[type] = enabled
-		userDefaultsRepository.saveValue(key: udKey, value: options)
+		saveOptions(options)
 	}
 
 	public func isNotificationEnabled(_ type: StationNotificationsTypes) -> Bool {
-		let options: StationOptions? = userDefaultsRepository.getValue(for: udKey)
+		let options = getOptions()
 		return options?[type] ?? false
+	}
+}
+
+private extension StationNotificationsUseCase {
+	func saveOptions(_ options: StationOptions) {
+		let convertedDict = Dictionary(uniqueKeysWithValues: options.map({ key, value in
+			(key.rawValue, value)
+		}))
+
+		userDefaultsRepository.saveValue(key: udKey, value: convertedDict)
+	}
+
+	func getOptions() -> StationOptions? {
+		guard let optionsDict: [String: Bool] = userDefaultsRepository.getValue(for: udKey) else {
+			return nil
+		}
+		
+		return Dictionary(uniqueKeysWithValues: optionsDict.compactMap({ key, value in
+			guard let key = StationNotificationsTypes(rawValue: key) else {
+				return nil
+			}
+
+			return (key, value)
+		}))
 	}
 }

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/StationNotificationsUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/StationNotificationsUseCase.swift
@@ -1,0 +1,35 @@
+//
+//  StationNotificationsUseCase.swift
+//  DomainLayer
+//
+//  Created by Pantelis Giazitsis on 9/7/25.
+//
+
+import Foundation
+
+private typealias StationOptions = [StationNotificationsTypes: Bool]
+public struct StationNotificationsUseCase: StationNotificationsUseCaseApi {
+	private let userDefaultsRepository: UserDefaultsRepository
+	private let udKey = UserDefaults.GenericKey.stationNotificationOptions.rawValue
+
+	public init(userDefaultsRepository: UserDefaultsRepository) {
+		self.userDefaultsRepository = userDefaultsRepository
+	}
+
+	public func setNotificationEnabled(_ enabled: Bool, for type: StationNotificationsTypes) {
+		guard var options: StationOptions = userDefaultsRepository.getValue(for: udKey) else {
+			var options: StationOptions = [:]
+			options[type] = enabled
+			userDefaultsRepository.saveValue(key: udKey, value: options)
+			return
+		}
+
+		options[type] = enabled
+		userDefaultsRepository.saveValue(key: udKey, value: options)
+	}
+
+	public func isNotificationEnabled(_ type: StationNotificationsTypes) -> Bool {
+		let options: StationOptions? = userDefaultsRepository.getValue(for: udKey)
+		return options?[type] ?? false
+	}
+}

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/StationNotificationsUseCaseApi.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/StationNotificationsUseCaseApi.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum StationNotificationsTypes: String, CaseIterable {
+public enum StationNotificationsTypes: String {
 	case activity
 	case battery
 	case firmwareUpdate

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/StationNotificationsUseCaseApi.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/StationNotificationsUseCaseApi.swift
@@ -1,0 +1,20 @@
+//
+//  StationNotificationsUseCaseApi.swift
+//  DomainLayer
+//
+//  Created by Pantelis Giazitsis on 9/7/25.
+//
+
+import Foundation
+
+public enum StationNotificationsTypes: CaseIterable {
+	case activity
+	case battery
+	case firmwareUpdate
+	case health
+}
+
+public protocol StationNotificationsUseCaseApi: Sendable {
+	func setNotificationEnabled(_ enabled: Bool, for type: StationNotificationsTypes)
+	func isNotificationEnabled(_ type: StationNotificationsTypes) -> Bool
+}

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/StationNotificationsUseCaseApi.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/StationNotificationsUseCaseApi.swift
@@ -17,6 +17,6 @@ public enum StationNotificationsTypes: String, CaseIterable {
 public protocol StationNotificationsUseCaseApi: Sendable {
 	func areNotificationsEnalbedForDevice(_ deviceId: String) -> Bool
 	func setNotificationsForDevice(_ deviceId: String, enabled: Bool)
-	func setNotificationEnabled(_ enabled: Bool, for type: StationNotificationsTypes)
-	func isNotificationEnabled(_ type: StationNotificationsTypes) -> Bool
+	func setNotificationEnabled(_ enabled: Bool, deviceId: String, for type: StationNotificationsTypes)
+	func isNotificationEnabled(_ type: StationNotificationsTypes, deviceId: String) -> Bool
 }

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/StationNotificationsUseCaseApi.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/StationNotificationsUseCaseApi.swift
@@ -15,6 +15,8 @@ public enum StationNotificationsTypes: String, CaseIterable {
 }
 
 public protocol StationNotificationsUseCaseApi: Sendable {
+	func areNotificationsEnalbedForDevice(_ deviceId: String) -> Bool
+	func setNotificationsForDevice(_ deviceId: String, enabled: Bool)
 	func setNotificationEnabled(_ enabled: Bool, for type: StationNotificationsTypes)
 	func isNotificationEnabled(_ type: StationNotificationsTypes) -> Bool
 }

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/StationNotificationsUseCaseApi.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/StationNotificationsUseCaseApi.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum StationNotificationsTypes: CaseIterable {
+public enum StationNotificationsTypes: String, CaseIterable {
 	case activity
 	case battery
 	case firmwareUpdate

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -9251,6 +9251,28 @@
         }
       }
     },
+    "station_details_activity" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activity"
+          }
+        }
+      }
+    },
+    "station_details_activity_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get notified when the station goes inactive."
+          }
+        }
+      }
+    },
     "station_details_base_reward" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -9269,6 +9291,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Base reward scores from %@ to %@"
+          }
+        }
+      }
+    },
+    "station_details_battery" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Battery"
+          }
+        }
+      }
+    },
+    "station_details_battery_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get notified when the outdoor unit has a low battery warning."
           }
         }
       }
@@ -9339,6 +9383,28 @@
         }
       }
     },
+    "station_details_firmware_update" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Firmware Update"
+          }
+        }
+      }
+    },
+    "station_details_firmware_update_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get notified when the station has a new firmware update."
+          }
+        }
+      }
+    },
     "station_details_forecast" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -9357,6 +9423,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Got %d%%"
+          }
+        }
+      }
+    },
+    "station_details_health" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Health"
+          }
+        }
+      }
+    },
+    "station_details_health_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get notified when there are issues affecting the station’s health."
           }
         }
       }
@@ -9863,6 +9951,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "7D"
+          }
+        }
+      }
+    },
+    "station_details_show_notifications" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show notifications"
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/LocalizableString+StationDetails.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+StationDetails.swift
@@ -72,6 +72,15 @@ extension LocalizableString {
 		case notificationsAlertMessage
 		case notificationsAlertButtonTitle
 		case notificationsAlertCancelButtonTitle
+		case showNotifications
+		case activity
+		case activityDescription
+		case battery
+		case batteryDescription
+		case firmwareUpdate
+		case firmwareUpdateDescription
+		case health
+		case healthDescription
 	}
 }
 
@@ -231,6 +240,24 @@ extension LocalizableString.StationDetails: WXMLocalizable {
 				return "station_details_notifications_alert_button_title"
 			case .notificationsAlertCancelButtonTitle:
 				return "station_details_notifications_alert_cancel_button_title"
+			case .showNotifications:
+				return "station_details_show_notifications"
+			case .activity:
+				return "station_details_activity"
+			case .activityDescription:
+				return "station_details_activity_description"
+			case .battery:
+				return "station_details_battery"
+			case .batteryDescription:
+				return "station_details_battery_description"
+			case .firmwareUpdate:
+				return "station_details_firmware_update"
+			case .firmwareUpdateDescription:
+				return "station_details_firmware_update_description"
+			case .health:
+				return "station_details_health"
+			case .healthDescription:
+				return "station_details_health_description"
 		}
 	}
 }

--- a/wxm-ios/Swinject/SwinjectHelper.swift
+++ b/wxm-ios/Swinject/SwinjectHelper.swift
@@ -242,6 +242,12 @@ class SwinjectHelper: SwinjectInterface {
 			PhotoGalleryUseCase(photosRepository: resolver.resolve(PhotosRepository.self)!)
 		}
 
+		// MARK: - Station notifications
+		
+		container.register(StationNotificationsUseCaseApi.self) { resolver in
+			StationNotificationsUseCase(userDefaultsRepository: resolver.resolve(UserDefaultsRepository.self)!)
+		}
+
         // MARK: - Return the Container
 
         return container

--- a/wxm-ios/Toolkit/Toolkit/Utils/TimeValidationCache.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/TimeValidationCache.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// An object that conforms to this protocol will be responsible to save and load the cache data
-public protocol PersistCacheManager {
+public protocol PersistCacheManager: Sendable {
 	func save<T>(value: T, key: String)
 	func get<T>(key: String) -> T?
 	func remove(key: String)


### PR DESCRIPTION
## **Why?**
Station notifications settings screen 
### **How?**
- `StationNotificationsViewModel` contains the business logic of the notifications screen
- `StationNotificationsUseCase` handles the persistence of the options per station in user defaults
- Added `StationNotificationsUseCase` tests
### **Testing**
Play with different owned stations and ensure everything works as expected 
### **Additional context**
fixes fe-1882
