### PR TITLE
Start the upload of the photos after claiming is successful

### DIFF
--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceBegin/ClaimDeviceBeginView.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceBegin/ClaimDeviceBeginView.swift
@@ -56,7 +56,7 @@ struct ClaimDeviceBeginView: View {
 				Button {
 					viewModel.handleButtonTap()
 				} label: {
-					Text(LocalizableString.ClaimDevice.beginStationClaiming.localized)
+					Text(LocalizableString.ClaimDevice.enterGatewayProceedButtonTitle.localized)
 				}
 				.buttonStyle(WXMButtonStyle.filled())
 				.padding(.horizontal, CGFloat(.mediumSidePadding))

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimD1ContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimD1ContainerViewModel.swift
@@ -47,6 +47,7 @@ private extension ClaimD1ContainerViewModel {
 
 		let locationViewModel = ViewModelsFactory.getClaimDeviceLocationViewModel { [weak self] location in
 			self?.location = location
+			self?.moveNext()
 		}
 
 		let photoIntroViewModel = ViewModelsFactory.getClaimDevicePhotoViewModel { [weak self] in

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimD1ContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimD1ContainerViewModel.swift
@@ -10,8 +10,14 @@ import DomainLayer
 import Toolkit
 
 class ClaimD1ContainerViewModel: ClaimDeviceContainerViewModel {
-	override init(useCase: MeUseCaseApi, devicesUseCase: DevicesUseCaseApi, deviceLocationUseCase: DeviceLocationUseCaseApi) {
-		super.init(useCase: useCase, devicesUseCase: devicesUseCase, deviceLocationUseCase: deviceLocationUseCase)
+	override init(useCase: MeUseCaseApi,
+				  devicesUseCase: DevicesUseCaseApi,
+				  deviceLocationUseCase: DeviceLocationUseCaseApi,
+				  photoGalleryUseCase: PhotoGalleryUseCaseApi) {
+		super.init(useCase: useCase,
+				   devicesUseCase: devicesUseCase,
+				   deviceLocationUseCase: deviceLocationUseCase,
+				   photoGalleryUseCase: photoGalleryUseCase)
 		navigationTitle = ClaimStationType.d1.navigationTitle
 		steps = getSteps()
 	}

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimD1ContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimD1ContainerViewModel.swift
@@ -54,7 +54,10 @@ private extension ClaimD1ContainerViewModel {
 		}
 
 		let photoViewModel = ViewModelsFactory.getClaimDevicePhotoGalleryViewModel(linkNavigator: LinkNavigationHelper()) { [weak self] photos in
-			self?.photos = photos
+			guard let serialNumber = self?.serialNumber else {
+				return
+			}
+			self?.photosManager.setPhotos(photos, for: serialNumber)
 			self?.performClaim(retries: 0)
 		}
 

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimD1ContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimD1ContainerViewModel.swift
@@ -60,6 +60,7 @@ private extension ClaimD1ContainerViewModel {
 			self?.photosManager.setPhotos(photos, for: serialNumber)
 			self?.performClaim(retries: 0)
 		}
+		self.photosViewModel = photoViewModel
 
 		return [.beforeBegin(beforeBeginViewModel),
 				.begin(beginViewModel),

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimDeviceContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimDeviceContainerViewModel.swift
@@ -35,6 +35,7 @@ class ClaimDeviceContainerViewModel: ObservableObject {
 
 		return photosManager.getPhotos(for: serialNumber)
 	}
+	weak var photosViewModel: ClaimDevicePhotoViewModel?
 
 	private let CLAIMING_RETRIES_MAX = 25 // For 2 minutes timeout
 	private let CLAIMING_RETRIES_DELAY_SECONDS: TimeInterval = 5
@@ -105,6 +106,11 @@ extension ClaimDeviceContainerViewModel {
 		}
 
 		moveNext()
+
+		if let serialNumber,
+		   let images = photosManager.getPhotos(for: serialNumber) {
+			photosViewModel?.updateImages(images)
+		}
 	}
 
 	func performClaim(retries: Int? = nil) {

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimDeviceContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimDeviceContainerViewModel.swift
@@ -134,6 +134,13 @@ extension ClaimDeviceContainerViewModel {
 							self.loadingState = .fail(object)
 							WXMAnalytics.shared.trackEvent(.viewContent, parameters: [.contentName: .claimingResult,
 																					  .success: .custom("0")])
+
+							// Uncomment the following for testing
+							/*
+							Task { @MainActor in
+								await startPhotoUpload(deviceId: "{station-device-id}")
+							}
+							 */
 						case .success(let deviceResponse):
 							print(deviceResponse)
 							Task { @MainActor in

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimDeviceContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimDeviceContainerViewModel.swift
@@ -220,13 +220,12 @@ extension ClaimDeviceContainerViewModel {
 
 	func getSuccessObject(for device: DeviceDetails, followState: UserDeviceFollowState?) -> FailSuccessStateObject {
 		let needsUpdate = device.needsUpdate(mainVM: MainScreenViewModel.shared, followState: followState) == true
-		let cancelTitle: String? = LocalizableString.ClaimDevice.skipPhotoVerificationForNow.localized
-		let retryTitle: String? = LocalizableString.ClaimDevice.continueToPhotoVerification.localized
+		let retryTitle: String? = LocalizableString.ClaimDevice.viewStationButton.localized
 		let goToStationAction: VoidCallback = { [weak self] in
 			WXMAnalytics.shared.trackEvent(.userAction, parameters: [.actionName: .claimingResult,
 																	 .contentType: .claiming,
 																	 .action: .viewStation])
-			self?.showSkipPhotoAlert(device: device)
+			self?.dismissAndNavigate(device: device)
 		}
 
 		let updateFirmwareButton = Button(action: { [weak self] in
@@ -252,20 +251,6 @@ extension ClaimDeviceContainerViewModel {
 			.padding(.horizontal, CGFloat(.defaultSidePadding))
 		}).buttonStyle(WXMButtonStyle.filled()).toAnyView
 
-		let continueToPhotoVerificationAction: VoidCallback = { [weak self] in
-			self?.dismissAndNavigate(device: nil)
-			guard let deviceId = device.id else {
-				return
-			}
-
-			DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { // The only way found to avoid errors with navigation stack
-				PhotoIntroViewModel.startPhotoVerification(deviceId: deviceId, images: [], isNewPhotoVerification: true)
-			}
-
-			WXMAnalytics.shared.trackEvent(.selectContent, parameters: [.contentType: .goToPhotoVerification,
-																		.source: .claimingSource])
-		}
-
 		let info: CardWarningConfiguration =  .init(type: .info,
 													message: LocalizableString.ClaimDevice.updateFirmwareInfoMarkdown.localized,
 													showBorder: true,
@@ -282,12 +267,12 @@ extension ClaimDeviceContainerViewModel {
 											info: needsUpdate ? info : nil,
 											infoCustomView: needsUpdate ? updateFirmwareButton : nil,
 											infoOnAppearAction: needsUpdate ? infoAppearAction : nil,											
-											cancelTitle: cancelTitle,
+											cancelTitle: nil,
 											retryTitle: retryTitle,
 											actionButtonsLayout: .vertical,
 											contactSupportAction: nil,
-											cancelAction: goToStationAction,
-											retryAction: continueToPhotoVerificationAction)
+											cancelAction: nil,
+											retryAction: goToStationAction)
 
 		return object
 	}
@@ -310,19 +295,6 @@ extension ClaimDeviceContainerViewModel {
 																						  cellCenter: device.cellCenter?.toCLLocationCoordinate2D()))
 			Router.shared.navigateTo(route)
 		}
-	}
-
-	func showSkipPhotoAlert(device: DeviceDetails) {
-		let exitAction: AlertHelper.AlertObject.Action = (LocalizableString.skip.localized, { [weak self] _ in
-			self?.dismissAndNavigate(device: device)
-		})
-		let alertObject = AlertHelper.AlertObject(title: LocalizableString.ClaimDevice.skipPhotoVerificationAlertTitle.localized,
-												  message: LocalizableString.ClaimDevice.skipPhotoVerificationAlertText.localized,
-												  cancelActionTitle: LocalizableString.back.localized,
-												  cancelAction: {},
-												  okAction: exitAction)
-
-		AlertHelper().showAlert(alertObject)
 	}
 }
 

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimHeliumContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimHeliumContainerViewModel.swift
@@ -14,6 +14,10 @@ class ClaimHeliumContainerViewModel: ClaimDeviceContainerViewModel {
 	private var btDevice: BTWXMDevice?
 	private var heliumFrequency: Frequency?
 
+	override var photos: [GalleryView.GalleryImage]? {
+		photosManager.getPhotos(for: ClaimDevicePhotosManager.tempHeliumSerialNumber)
+	}
+
 	override init(useCase: MeUseCaseApi,
 				  devicesUseCase: DevicesUseCaseApi,
 				  deviceLocationUseCase: DeviceLocationUseCaseApi,
@@ -79,7 +83,8 @@ private extension ClaimHeliumContainerViewModel {
 		}
 
 		let photoViewModel = ViewModelsFactory.getClaimHeliumPhotoGalleryViewModel(linkNavigator: LinkNavigationHelper()) { [weak self] photos in
-			self?.photos = photos
+			// Since serial number is not available in this step we assign a dummy key only for the helium
+			self?.photosManager.setPhotos(photos, for: ClaimDevicePhotosManager.tempHeliumSerialNumber)
 			self?.moveNext()
 		}
 

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimHeliumContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimHeliumContainerViewModel.swift
@@ -14,8 +14,14 @@ class ClaimHeliumContainerViewModel: ClaimDeviceContainerViewModel {
 	private var btDevice: BTWXMDevice?
 	private var heliumFrequency: Frequency?
 
-	override init(useCase: MeUseCaseApi, devicesUseCase: DevicesUseCaseApi, deviceLocationUseCase: DeviceLocationUseCaseApi) {
-		super.init(useCase: useCase, devicesUseCase: devicesUseCase, deviceLocationUseCase: deviceLocationUseCase)
+	override init(useCase: MeUseCaseApi,
+				  devicesUseCase: DevicesUseCaseApi,
+				  deviceLocationUseCase: DeviceLocationUseCaseApi,
+				  photoGalleryUseCase: PhotoGalleryUseCaseApi) {
+		super.init(useCase: useCase,
+				   devicesUseCase: devicesUseCase,
+				   deviceLocationUseCase: deviceLocationUseCase,
+				   photoGalleryUseCase: photoGalleryUseCase)
 		navigationTitle = ClaimStationType.helium.navigationTitle
 		steps = getSteps()
 	}

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimHeliumContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimHeliumContainerViewModel.swift
@@ -87,7 +87,8 @@ private extension ClaimHeliumContainerViewModel {
 			self?.photosManager.setPhotos(photos, for: ClaimDevicePhotosManager.tempHeliumSerialNumber)
 			self?.moveNext()
 		}
-
+		self.photosViewModel = photoViewModel
+		
 		return [.beforeBegin(beforeBeginViewModel),
 				.reset(resetViewModel),
 				.selectDevice(selectDeviceViewModel),

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimM5ContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimM5ContainerViewModel.swift
@@ -11,8 +11,14 @@ import Toolkit
 
 class ClaimM5ContainerViewModel: ClaimDeviceContainerViewModel {
 	
-	override init(useCase: MeUseCaseApi, devicesUseCase: DevicesUseCaseApi, deviceLocationUseCase: DeviceLocationUseCaseApi) {
-		super.init(useCase: useCase, devicesUseCase: devicesUseCase, deviceLocationUseCase: deviceLocationUseCase)
+	override init(useCase: MeUseCaseApi,
+				  devicesUseCase: DevicesUseCaseApi,
+				  deviceLocationUseCase: DeviceLocationUseCaseApi,
+				  photoGalleryUseCase: PhotoGalleryUseCaseApi) {
+		super.init(useCase: useCase,
+				   devicesUseCase: devicesUseCase,
+				   deviceLocationUseCase: deviceLocationUseCase,
+				   photoGalleryUseCase: photoGalleryUseCase)
 		navigationTitle = ClaimStationType.m5.navigationTitle
 		steps = getSteps()
 	}

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimM5ContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimM5ContainerViewModel.swift
@@ -62,6 +62,7 @@ private extension ClaimM5ContainerViewModel {
 			self?.photosManager.setPhotos(photos, for: serialNumber)
 			self?.performClaim()
 		}
+		self.photosViewModel = photoViewModel
 
 		return [.beforeBegin(beforeBeginViewModel),
 				.begin(beginViewModel),

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimM5ContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimM5ContainerViewModel.swift
@@ -56,7 +56,10 @@ private extension ClaimM5ContainerViewModel {
 		}
 
 		let photoViewModel = ViewModelsFactory.getClaimDevicePhotoGalleryViewModel(linkNavigator: LinkNavigationHelper()) { [weak self] photos in
-			self?.photos = photos
+			guard let serialNumber = self?.serialNumber else {
+				return
+			}
+			self?.photosManager.setPhotos(photos, for: serialNumber)
 			self?.performClaim()
 		}
 

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimPulseContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimPulseContainerViewModel.swift
@@ -70,13 +70,14 @@ private extension ClaimPulseContainerViewModel {
 			self?.moveNext()
 		}
 
-		let photoViewModel = ViewModelsFactory.getClaimDevicePhotoGalleryViewModel(linkNavigator: LinkNavigationHelper(), images: p) { [weak self] photos in
+		let photoViewModel = ViewModelsFactory.getClaimDevicePhotoGalleryViewModel(linkNavigator: LinkNavigationHelper()) { [weak self] photos in
 			guard let serialNumber = self?.serialNumber else {
 				return
 			}
 			self?.photosManager.setPhotos(photos, for: serialNumber)
 			self?.performClaim()
 		}
+		self.photosViewModel = photoViewModel
 
 		return [.beforeBegin(beforeBeginViewModel),
 				.reset(resetViewModel),

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimPulseContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimPulseContainerViewModel.swift
@@ -64,6 +64,7 @@ private extension ClaimPulseContainerViewModel {
 
 		let locationViewModel = ViewModelsFactory.getClaimDeviceLocationViewModel { [weak self] location in
 			self?.location = location
+			self?.moveNext()
 		}
 
 		let photoIntroViewModel = ViewModelsFactory.getClaimDevicePhotoViewModel { [weak self] in

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimPulseContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimPulseContainerViewModel.swift
@@ -70,8 +70,11 @@ private extension ClaimPulseContainerViewModel {
 			self?.moveNext()
 		}
 
-		let photoViewModel = ViewModelsFactory.getClaimDevicePhotoGalleryViewModel(linkNavigator: LinkNavigationHelper()) { [weak self] photos in
-			self?.photos = photos
+		let photoViewModel = ViewModelsFactory.getClaimDevicePhotoGalleryViewModel(linkNavigator: LinkNavigationHelper(), images: p) { [weak self] photos in
+			guard let serialNumber = self?.serialNumber else {
+				return
+			}
+			self?.photosManager.setPhotos(photos, for: serialNumber)
 			self?.performClaim()
 		}
 

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimPulseContainerViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDeviceContainer/ClaimPulseContainerViewModel.swift
@@ -11,8 +11,14 @@ import Toolkit
 
 class ClaimPulseContainerViewModel: ClaimDeviceContainerViewModel {
 
-	override init(useCase: MeUseCaseApi, devicesUseCase: DevicesUseCaseApi, deviceLocationUseCase: DeviceLocationUseCaseApi) {
-		super.init(useCase: useCase, devicesUseCase: devicesUseCase, deviceLocationUseCase: deviceLocationUseCase)
+	override init(useCase: MeUseCaseApi,
+				  devicesUseCase: DevicesUseCaseApi,
+				  deviceLocationUseCase: DeviceLocationUseCaseApi,
+				  photoGalleryUseCase: PhotoGalleryUseCaseApi) {
+		super.init(useCase: useCase,
+				   devicesUseCase: devicesUseCase,
+				   deviceLocationUseCase: deviceLocationUseCase,
+				   photoGalleryUseCase: photoGalleryUseCase)
 		navigationTitle = ClaimStationType.pulse.navigationTitle
 		steps = getSteps()
 	}

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDevicePhoto/ClaimDevicePhotoViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDevicePhoto/ClaimDevicePhotoViewModel.swift
@@ -29,6 +29,11 @@ class ClaimDevicePhotoViewModel: ObservableObject {
 		photosViewModel.images.count >= minPhotosCount
 	}
 
+	func updateImages(_ images: [GalleryView.GalleryImage]) {
+		photosViewModel.images = images
+		photosViewModel.selectedImage = images.last
+	}
+
 	func handleCtaButtonTap() {
 		completion?(photosViewModel.images)
 	}

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDevicePhotosManager.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/ClaimDevicePhotosManager.swift
@@ -1,0 +1,28 @@
+//
+//  ClaimDevicePhotosManager.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 22/7/25.
+//
+
+import Foundation
+
+@MainActor
+class ClaimDevicePhotosManager {
+	static let shared = ClaimDevicePhotosManager()
+	private(set) var photos: [String: [GalleryView.GalleryImage]] = [:]
+
+	private init() {}
+
+	func setPhotos(_ photos: [GalleryView.GalleryImage], for deviceId: String) {
+		self.photos[deviceId] = photos
+	}
+
+	func getPhotos(for deviceId: String) -> [GalleryView.GalleryImage]? {
+		return photos[deviceId]
+	}
+}
+
+extension ClaimDevicePhotosManager {
+	static let tempHeliumSerialNumber = "temp-helium-serial-number"
+}

--- a/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
+++ b/PresentationLayer/UIComponents/Screens/PhotoVerification/GalleryView/GalleryView.swift
@@ -103,7 +103,7 @@ extension GalleryView {
 	struct GalleryImage: Identifiable, Equatable {
 		let remoteUrl: String?
 		let uiImage: UIImage?
-		let metadata: NSDictionary?
+		nonisolated(unsafe) let metadata: NSDictionary?
 		let source: ImageSource?
 
 		var id: String {

--- a/PresentationLayer/UIComponents/ViewModelsFactory.swift
+++ b/PresentationLayer/UIComponents/ViewModelsFactory.swift
@@ -184,16 +184,29 @@ enum ViewModelsFactory {
 		let useCase = SwinjectHelper.shared.getContainerForSwinject().resolve(MeUseCaseApi.self)!
 		let devicesUseCase = SwinjectHelper.shared.getContainerForSwinject().resolve(DevicesUseCaseApi.self)!
 		let deviceLocationUseCase = SwinjectHelper.shared.getContainerForSwinject().resolve(DeviceLocationUseCaseApi.self)!
+		let photoGalleryUseCase = SwinjectHelper.shared.getContainerForSwinject().resolve(PhotoGalleryUseCaseApi.self)!
 
 		switch type {
 			case .m5:
-				return ClaimM5ContainerViewModel(useCase: useCase, devicesUseCase: devicesUseCase, deviceLocationUseCase: deviceLocationUseCase)
+				return ClaimM5ContainerViewModel(useCase: useCase,
+												 devicesUseCase: devicesUseCase,
+												 deviceLocationUseCase: deviceLocationUseCase,
+												 photoGalleryUseCase: photoGalleryUseCase)
 			case .d1:
-				return ClaimD1ContainerViewModel(useCase: useCase, devicesUseCase: devicesUseCase, deviceLocationUseCase: deviceLocationUseCase)
+				return ClaimD1ContainerViewModel(useCase: useCase,
+												 devicesUseCase: devicesUseCase,
+												 deviceLocationUseCase: deviceLocationUseCase,
+												 photoGalleryUseCase: photoGalleryUseCase)
 			case .helium:
-				return ClaimHeliumContainerViewModel(useCase: useCase, devicesUseCase: devicesUseCase, deviceLocationUseCase: deviceLocationUseCase)
+				return ClaimHeliumContainerViewModel(useCase: useCase,
+													 devicesUseCase: devicesUseCase,
+													 deviceLocationUseCase: deviceLocationUseCase,
+													 photoGalleryUseCase: photoGalleryUseCase)
 			case .pulse:
-				return ClaimPulseContainerViewModel(useCase: useCase, devicesUseCase: devicesUseCase, deviceLocationUseCase: deviceLocationUseCase)
+				return ClaimPulseContainerViewModel(useCase: useCase,
+													devicesUseCase: devicesUseCase,
+													deviceLocationUseCase: deviceLocationUseCase,
+													photoGalleryUseCase: photoGalleryUseCase)
 		}
 	}
 

--- a/WeatherXMTests/PresentationLayer/ViewModels/ClaimDeviceContainerViewModelTests.swift
+++ b/WeatherXMTests/PresentationLayer/ViewModels/ClaimDeviceContainerViewModelTests.swift
@@ -17,14 +17,17 @@ struct ClaimDeviceContainerViewModelTests {
 	let useCase: MockMeUseCase
 	let devicesUseCase: MockDevicesUseCase
 	let deviceLocationUseCase: MockDeviceLocationUseCase
+	let photogalleryUseCase: MockPhotoGalleryUseCase
 
 	init() {
 		useCase = .init()
 		devicesUseCase = .init()
 		deviceLocationUseCase = .init()
+		photogalleryUseCase = .init()
 		viewModel = .init(useCase: useCase,
 						  devicesUseCase: devicesUseCase,
-						  deviceLocationUseCase: deviceLocationUseCase)
+						  deviceLocationUseCase: deviceLocationUseCase,
+						  photoGalleryUseCase: photogalleryUseCase)
 	}
 
 	@Test func testInitialization() {

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		260F8E432E2678B300CBAEB2 /* ClaimDevicePhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260F8E422E2678B300CBAEB2 /* ClaimDevicePhotoView.swift */; };
 		260F8E452E2678CE00CBAEB2 /* ClaimDevicePhotoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260F8E442E2678CE00CBAEB2 /* ClaimDevicePhotoViewModel.swift */; };
 		260F8E4D2E2F882900CBAEB2 /* ClaimGalleryImagesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260F8E4C2E2F882900CBAEB2 /* ClaimGalleryImagesViewModel.swift */; };
+		260F8E552E2FC06700CBAEB2 /* ClaimDevicePhotosManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260F8E542E2FC06700CBAEB2 /* ClaimDevicePhotosManager.swift */; };
 		2612AC1A2AB45B1700285896 /* FilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2612AC192AB45B1700285896 /* FilterView.swift */; };
 		2612AC1C2AB45B2800285896 /* FilterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2612AC1B2AB45B2800285896 /* FilterViewModel.swift */; };
 		2612AC3A2AB47BA200285896 /* LocalizableString+Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2612AC392AB47BA200285896 /* LocalizableString+Filters.swift */; };
@@ -810,6 +811,7 @@
 		260F8E422E2678B300CBAEB2 /* ClaimDevicePhotoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaimDevicePhotoView.swift; sourceTree = "<group>"; };
 		260F8E442E2678CE00CBAEB2 /* ClaimDevicePhotoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaimDevicePhotoViewModel.swift; sourceTree = "<group>"; };
 		260F8E4C2E2F882900CBAEB2 /* ClaimGalleryImagesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaimGalleryImagesViewModel.swift; sourceTree = "<group>"; };
+		260F8E542E2FC06700CBAEB2 /* ClaimDevicePhotosManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaimDevicePhotosManager.swift; sourceTree = "<group>"; };
 		2612AC192AB45B1700285896 /* FilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterView.swift; sourceTree = "<group>"; };
 		2612AC1B2AB45B2800285896 /* FilterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterViewModel.swift; sourceTree = "<group>"; };
 		2612AC392AB47BA200285896 /* LocalizableString+Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalizableString+Filters.swift"; sourceTree = "<group>"; };
@@ -2195,6 +2197,7 @@
 				26AA21C12BF36B0100B91A7C /* SNValidator.swift */,
 				26C5AF3F2BF7632700476B89 /* ClaimDeviceProgressView.swift */,
 				2675471B29A9181E008BCF40 /* UITextField+StationSerialNumber.swift */,
+				260F8E542E2FC06700CBAEB2 /* ClaimDevicePhotosManager.swift */,
 			);
 			path = ClaimDevice;
 			sourceTree = "<group>";
@@ -4093,6 +4096,7 @@
 				267548DE29A91A87008BCF40 /* FailAPICodeEnum.swift in Sources */,
 				267547BF29A9181E008BCF40 /* FailedDeleteView.swift in Sources */,
 				26ACE8C72C86015300EA22DD /* LocalizableString+RewardAnalytics.swift in Sources */,
+				260F8E552E2FC06700CBAEB2 /* ClaimDevicePhotosManager.swift in Sources */,
 				26A4118A29BA21E600A2C10B /* FailSuccessStateObject.swift in Sources */,
 				2645823B2A41C07000195C21 /* FailSuccessViewModifier.swift in Sources */,
 				267547F729A9181E008BCF40 /* FailView.swift in Sources */,

--- a/wxm-ios/Toolkit/Toolkit/Utils/AsyncOperations.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/AsyncOperations.swift
@@ -9,41 +9,59 @@ import Foundation
 
 public extension Sequence {
 
-    /// Iterates the sequence with async operations. Similar functionality to `ForEach`
-    /// - Parameter operation: The async operation to be performed for each element
+	/// Iterates the sequence with async operations. Similar functionality to `ForEach`
+	/// - Parameter operation: The async operation to be performed for each element
 	nonisolated func asyncForEach(_ operation: @Sendable (Element) async throws -> Void) async rethrows {
-        for element in self {
-            try await operation(element)
-        }
-    }
+		for element in self {
+			try await operation(element)
+		}
+	}
 
-    /// Returns an array containing the results of mapping the given async operation, similar to `map`
-    /// - Parameter transform: The async operation to be performed for each element
-    /// - Returns: The array with the mapped elements
+	/// Returns an array containing the results of mapping the given async operation, similar to `map`
+	/// - Parameter transform: The async operation to be performed for each element
+	/// - Returns: The array with the mapped elements
 	nonisolated func asyncMap<T>(_ transform: (Element) async throws -> T) async rethrows -> [T] {
-        var values = [T]()
+		var values = [T]()
 
-        for element in self {
-            try await values.append(transform(element))
-        }
+		for element in self {
+			try await values.append(transform(element))
+		}
 
-        return values
-    }
+		return values
+	}
 
-    /// Returns an array containing the non-nil results of mapping the given async operation, similar to `map`
-    /// - Parameter transform: The async operation to be performed for each element
-    /// - Returns: The array with the mapped elements
+	/// Returns an array containing the non-nil results of mapping the given async operation, similar to `map`
+	/// - Parameter transform: The async operation to be performed for each element
+	/// - Returns: The array with the mapped elements
 	nonisolated func asyncCompactMap<T>(_ transform: @Sendable (Element) async throws -> T?) async rethrows -> [T] {
-        var values = [T]()
+		var values = [T]()
 
-        for element in self {
-            guard let value = try await transform(element) else {
-                continue
-            }
+		for element in self {
+			guard let value = try await transform(element) else {
+				continue
+			}
 
-            values.append(value)
-        }
+			values.append(value)
+		}
 
-        return values
-    }
+		return values
+	}
+}
+
+public extension Sequence where Element: Sendable {
+	@MainActor
+	func asyncMainActorCompactMap<T: Sendable>(_ transform: @Sendable (Element) async throws -> T?) async rethrows -> [T] {
+		var values = [T]()
+
+		for element in self {
+			guard let value = try await transform(element) else {
+				continue
+			}
+
+			values.append(value)
+		}
+
+		return values
+	}
+
 }


### PR DESCRIPTION
## **Why?**
Start the upload process once the claim is successful 
### **How?**
- `ClaimDeviceContainerViewModel` starts the process once the claim is finished
- `ClaimDevicePhotosManager` keeps the captured photos to be prepopulated for the next retry in case of claim failure
### **Testing**
- Ensure the images are prepopulated in case of error
- To test the upload functionality, since there is no easy way to test the happy path, uncomment the lines 152-156 in `ClaimDeviceContainerViewModel` and set your station device id as argument in the `startPhotoUpload` function call
### **Additional context**
fixes fe-1909
