### PR TITLE
Background job to schedule station alert notifications

### DIFF
--- a/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
@@ -199,17 +199,7 @@ extension DeviceDetails {
 		
 		return checkFirmwareIfNeedsUpdate()
 	}
-	
-	func checkFirmwareIfNeedsUpdate() -> Bool {
-		guard isHelium,
-			  let current = firmware?.current,
-			  let assigned = firmware?.assigned else {
-			return false
-		}
-		
-		return assigned != current
-	}
-	
+
 	/// True if the stations current version is different from the assigned
 	func needsUpdate(mainVM: MainScreenViewModel, followState: UserDeviceFollowState?) -> Bool {
 		guard isHelium, followState?.state == .owned else {
@@ -242,6 +232,18 @@ extension DeviceDetails {
 		}
 		
 		return issues
+	}
+}
+
+extension DeviceDetails {
+	func checkFirmwareIfNeedsUpdate() -> Bool {
+		guard isHelium,
+			  let current = firmware?.current,
+			  let assigned = firmware?.assigned else {
+			return false
+		}
+
+		return assigned != current
 	}
 }
 

--- a/PresentationLayer/Extensions/DomainExtensions/StationAlert+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/StationAlert+.swift
@@ -9,12 +9,12 @@ import Foundation
 import DomainLayer
 import Toolkit
 
-extension StationAlert {
+extension StationNotificationsTypes {
 	var notificationTitle: String {
 		switch self {
-			case .inactive:
+			case .activity:
 				LocalizableString.Error.notificationInactiveTitle.localized
-			case .firmware:
+			case .firmwareUpdate:
 				LocalizableString.Error.notificationFirmwareTitle.localized
 			case .battery:
 				LocalizableString.Error.notificationBatteryTitle.localized
@@ -25,9 +25,9 @@ extension StationAlert {
 
 	func notificationDescription(for stationName: String) -> String {
 		switch self {
-			case .inactive:
+			case .activity:
 				LocalizableString.Error.notificationInactiveDescription(stationName).localized
-			case .firmware:
+			case .firmwareUpdate:
 				LocalizableString.Error.notificationFirmwareDescription(stationName).localized
 			case .battery:
 				LocalizableString.Error.notificationBatteryDescription(stationName).localized
@@ -35,9 +35,7 @@ extension StationAlert {
 				LocalizableString.Error.notificationHealthDescription(stationName).localized
 		}
 	}
-}
 
-extension StationNotificationsTypes {
 	var analyticsValue: ParameterValue {
 		switch self {
 			case .activity:

--- a/PresentationLayer/Extensions/DomainExtensions/StationAlert+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/StationAlert+.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import DomainLayer
+import Toolkit
 
 extension StationAlert {
 	var notificationTitle: String {
@@ -32,6 +33,21 @@ extension StationAlert {
 				LocalizableString.Error.notificationBatteryDescription(stationName).localized
 			case .health:
 				LocalizableString.Error.notificationHealthDescription(stationName).localized
+		}
+	}
+}
+
+extension StationNotificationsTypes {
+	var analyticsValue: ParameterValue {
+		switch self {
+			case .activity:
+					.activity
+			case .battery:
+					.lowBattery
+			case .firmwareUpdate:
+					.otaUpdate
+			case .health:
+					.stationHealth
 		}
 	}
 }

--- a/PresentationLayer/Extensions/DomainExtensions/StationAlert+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/StationAlert+.swift
@@ -1,0 +1,37 @@
+//
+//  StationAlert+.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 24/7/25.
+//
+
+import Foundation
+import DomainLayer
+
+extension StationAlert {
+	var notificationTitle: String {
+		switch self {
+			case .inactive:
+				LocalizableString.Error.notificationInactiveTitle.localized
+			case .firmware:
+				LocalizableString.Error.notificationFirmwareTitle.localized
+			case .battery:
+				LocalizableString.Error.notificationBatteryTitle.localized
+			case .health:
+				LocalizableString.Error.notificationHealthTitle.localized
+		}
+	}
+
+	func notificationDescription(for stationName: String) -> String {
+		switch self {
+			case .inactive:
+				LocalizableString.Error.notificationInactiveDescription(stationName).localized
+			case .firmware:
+				LocalizableString.Error.notificationFirmwareDescription(stationName).localized
+			case .battery:
+				LocalizableString.Error.notificationBatteryDescription(stationName).localized
+			case .health:
+				LocalizableString.Error.notificationHealthDescription(stationName).localized
+		}
+	}
+}

--- a/PresentationLayer/Navigation/DeepLinkHandler.swift
+++ b/PresentationLayer/Navigation/DeepLinkHandler.swift
@@ -277,14 +277,14 @@ private enum NotificationType {
 	case device(String)
 }
 
-private extension UNNotificationResponse {
+extension UNNotificationResponse {
 	static let typeKey = "type"
 	static let announcementVal = "announcement"
 	static let stationVal = "station"
 	static let urlKey = "url"
 	static let deviceIdKey = "device_id"
 
-	var toNotificationType: NotificationType? {
+	fileprivate var toNotificationType: NotificationType? {
 		let userInfo = notification.request.content.userInfo
 		guard let type = userInfo[Self.typeKey] as? String else {
 			return nil

--- a/PresentationLayer/Navigation/DeepLinkHandler.swift
+++ b/PresentationLayer/Navigation/DeepLinkHandler.swift
@@ -87,6 +87,7 @@ class DeepLinkHandler {
 				}
 			case .device(let deviceId):
 				moveToStation(deviceId: deviceId, cellIndex: nil, cellCenter: nil)
+				WXMAnalytics.shared.trackEvent(.viewContent, parameters: [.contentName: .openStationFromNotification])
 				return true
 		}
 

--- a/PresentationLayer/UIComponents/Screens/MainScreen/MainScreenViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/MainScreen/MainScreenViewModel.swift
@@ -87,7 +87,9 @@ class MainScreenViewModel: ObservableObject {
 		networkMonitor = NWPathMonitor()
 		settingsUseCase = swinjectHelper.getContainerForSwinject().resolve(SettingsUseCaseApi.self)!
 
-		let _ = backgroundScheduler
+		if !isRunningTests {
+			let _ = backgroundScheduler
+		}
 
         checkIfUserIsLoggedIn()
         settingsUseCase.initializeAnalyticsTracking()

--- a/PresentationLayer/UIComponents/Screens/MainScreen/MainScreenViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/MainScreen/MainScreenViewModel.swift
@@ -44,6 +44,7 @@ class MainScreenViewModel: ObservableObject {
 	private let meUseCase: MeUseCaseApi
 	private let settingsUseCase: SettingsUseCaseApi
 	private let photosUseCase: PhotoGalleryUseCaseApi
+	private let stationNotificationsUseCase: StationNotificationsUseCaseApi
 	private lazy var backgroundScheduler: BackgroundScheduler = {
 		let scheduler = BackgroundScheduler { [weak self] in
 			Task { @MainActor in
@@ -83,6 +84,7 @@ class MainScreenViewModel: ObservableObject {
 		mainUseCase = swinjectHelper.getContainerForSwinject().resolve(MainUseCaseApi.self)!
 		meUseCase = swinjectHelper.getContainerForSwinject().resolve(MeUseCaseApi.self)!
 		photosUseCase = swinjectHelper.getContainerForSwinject().resolve(PhotoGalleryUseCaseApi.self)!
+		stationNotificationsUseCase = swinjectHelper.getContainerForSwinject().resolve(StationNotificationsUseCaseApi.self)!
 
 		networkMonitor = NWPathMonitor()
 		settingsUseCase = swinjectHelper.getContainerForSwinject().resolve(SettingsUseCaseApi.self)!
@@ -392,7 +394,8 @@ class MainScreenViewModel: ObservableObject {
 	// MARK: - Background tasks
 
 	func performBackgroundProcess() {
-		let alertsManager = StationAlertsManager(meUseCase: meUseCase)
+		let alertsManager = StationAlertsManager(meUseCase: meUseCase,
+												 stationNotificationsUseCase: stationNotificationsUseCase)
 		Task {
 			await alertsManager.checkForStationIssues()
 		}

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationNotificationsViewModel.swift
@@ -32,6 +32,10 @@ class StationNotificationsViewModel: ObservableObject {
 	}
 
 	func setValue(_ value: Bool, for notificationType: StationNotificationsTypes) {
+		WXMAnalytics.shared.trackEvent(.userAction, parameters: [.actionName: .toggleStationNotificationType,
+																 .action: value ? .enable : .disable,
+																 .source: notificationType.analyticsValue])
+
 		guard let deviceId = device.id else {
 			return
 		}
@@ -41,6 +45,9 @@ class StationNotificationsViewModel: ObservableObject {
 	}
 
 	func setMasterSwitchValue(_ value: Bool) {
+		WXMAnalytics.shared.trackEvent(.userAction, parameters: [.actionName: .toggleStationNotifications,
+																 .action: value ? .enable : .disable])
+
 		Task { @MainActor in
 			let status = await FirebaseManager.shared.gatAuthorizationStatus()
 			switch status {

--- a/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
+++ b/PresentationLayer/UIComponents/Screens/WeatherStations/StationDetails/Notifications/StationsNotificationsView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import DomainLayer
+import Toolkit
 
 struct StationsNotificationsView: View {
 	@StateObject var viewModel: StationNotificationsViewModel
@@ -47,6 +48,7 @@ struct StationsNotificationsView: View {
 		}
 		.onAppear {
 			navigationObject.title = LocalizableString.StationDetails.notifications.localized
+			WXMAnalytics.shared.trackScreen(.stationNotifications)
 		}
 	}
 }

--- a/PresentationLayer/Utils/BackgroundScheduler.swift
+++ b/PresentationLayer/Utils/BackgroundScheduler.swift
@@ -19,6 +19,7 @@ final class BackgroundScheduler: Sendable {
 	init(callback: @escaping VoidSendableCallback) {
 		self.callback = callback
 		registerBackgroundTask()
+		scheduleAppRefresh()
 	}
 }
 

--- a/PresentationLayer/Utils/BackgroundScheduler.swift
+++ b/PresentationLayer/Utils/BackgroundScheduler.swift
@@ -8,13 +8,16 @@
 import Foundation
 import BackgroundTasks
 import UIKit
+import Toolkit
 
 private let taskIdentifier = "com.weatherxm.app.fetch"
 private let interval: TimeInterval = 60 * 60 * 2 // 2 hours
 
 final class BackgroundScheduler: Sendable {
+	private let callback: VoidSendableCallback
 
-	init() {
+	init(callback: @escaping VoidSendableCallback) {
+		self.callback = callback
 		registerBackgroundTask()
 	}
 }
@@ -30,7 +33,9 @@ private extension BackgroundScheduler {
 
 	func handleAppRefresh(_ task: BGTask) {
 		scheduleAppRefresh()
-		print("Refresh handled")
+
+		callback()
+		
 		task.setTaskCompleted(success: true)
 	}
 

--- a/PresentationLayer/Utils/BackgroundScheduler.swift
+++ b/PresentationLayer/Utils/BackgroundScheduler.swift
@@ -1,0 +1,49 @@
+//
+//  BackgroundScheduler.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 24/7/25.
+//
+
+import Foundation
+import BackgroundTasks
+import UIKit
+
+private let taskIdentifier = "com.weatherxm.app.fetch"
+private let interval: TimeInterval = 60 * 60 * 2 // 2 hours
+
+final class BackgroundScheduler: Sendable {
+
+	init() {
+		registerBackgroundTask()
+	}
+}
+
+private extension BackgroundScheduler {
+	func registerBackgroundTask() {
+		let registered = BGTaskScheduler.shared.register(forTaskWithIdentifier: taskIdentifier, using: nil) { [weak self] task in
+			self?.handleAppRefresh(task)
+		}
+
+		print(registered)
+	}
+
+	func handleAppRefresh(_ task: BGTask) {
+		scheduleAppRefresh()
+		print("Refresh handled")
+		task.setTaskCompleted(success: true)
+	}
+
+	func scheduleAppRefresh() {
+		let request = BGAppRefreshTaskRequest(identifier: taskIdentifier)
+		request.earliestBeginDate = Date(timeIntervalSinceNow: interval)
+
+		do {
+			try BGTaskScheduler.shared.submit(request)
+		} catch {
+			print("Could not schedule app refresh: \(error)")
+		}
+
+		print(request)
+	}
+}

--- a/PresentationLayer/Utils/StationAlertsManager.swift
+++ b/PresentationLayer/Utils/StationAlertsManager.swift
@@ -59,6 +59,7 @@ private extension StationAlertsManager {
 			notificationsScheduler.postNotification(id: "\(String(describing: device.id))_\($0)",
 													title: $0.notificationTitle,
 													body: $0.notificationDescription(for: device.displayName),
+													threadId: deviceId,
 													userInfo: userInfo)
 			meUseCase.notificationAlertSent(for: deviceId, alert: $0)
 		}

--- a/PresentationLayer/Utils/StationAlertsManager.swift
+++ b/PresentationLayer/Utils/StationAlertsManager.swift
@@ -8,6 +8,7 @@
 import Foundation
 import DomainLayer
 import Toolkit
+import UserNotifications
 
 struct StationAlertsManager {
 	let meUseCase: MeUseCaseApi
@@ -53,9 +54,12 @@ private extension StationAlertsManager {
 
 		let notificationsScheduler = LocalNotificationScheduler()
 		alerts.forEach {
+			let userInfo = [UNNotificationResponse.typeKey: UNNotificationResponse.stationVal,
+							UNNotificationResponse.deviceIdKey: deviceId]
 			notificationsScheduler.postNotification(id: "\(String(describing: device.id))_\($0)",
 													title: $0.notificationTitle,
-													body: $0.notificationDescription(for: device.displayName))
+													body: $0.notificationDescription(for: device.displayName),
+													userInfo: userInfo)
 			meUseCase.notificationAlertSent(for: deviceId, alert: $0)
 		}
 	}

--- a/PresentationLayer/Utils/StationAlertsManager.swift
+++ b/PresentationLayer/Utils/StationAlertsManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import DomainLayer
+import Toolkit
 
 struct StationAlertsManager {
 	let meUseCase: MeUseCaseApi
@@ -46,6 +47,11 @@ private extension StationAlertsManager {
 	}
 
 	func handleAlerts(for device: DeviceDetails, alerts: [StationAlert]) {
-
+		let notificationsScheduler = LocalNotificationScheduler()
+		alerts.forEach {
+			notificationsScheduler.postNotification(id: "\(String(describing: device.id))_\($0)",
+													title: $0.notificationTitle,
+													body: $0.notificationDescription(for: device.displayName))
+		}
 	}
 }

--- a/PresentationLayer/Utils/StationAlertsManager.swift
+++ b/PresentationLayer/Utils/StationAlertsManager.swift
@@ -1,0 +1,51 @@
+//
+//  StationAlertsManager.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 24/7/25.
+//
+
+import Foundation
+import DomainLayer
+
+struct StationAlertsManager {
+	let meUseCase: MeUseCaseApi
+
+	func checkForStationIssues() async {
+		let devices = try? await meUseCase.getOwnedDevices().toAsync().get()
+		devices?.forEach {
+			checkStation($0)
+		}
+	}
+}
+
+private extension StationAlertsManager {
+	func checkStation(_ device: DeviceDetails) {
+		var alerts: [StationAlert] = []
+		// Is active
+		if !device.isActive {
+			alerts.append(.inactive)
+		}
+
+		// Low battery
+		if device.batteryState == .low {
+			alerts.append(.battery)
+		}
+		
+		// Firmware
+		if device.checkFirmwareIfNeedsUpdate() {
+			alerts.append(.firmware)
+		}
+
+		// Health
+		if let qod = device.qod, qod < 80 {
+			alerts.append(.health)
+		}
+
+		handleAlerts(for: device, alerts: alerts)
+	}
+
+	func handleAlerts(for device: DeviceDetails, alerts: [StationAlert]) {
+
+	}
+}

--- a/PresentationLayer/Utils/StationAlertsManager.swift
+++ b/PresentationLayer/Utils/StationAlertsManager.swift
@@ -24,22 +24,22 @@ private extension StationAlertsManager {
 	func checkStation(_ device: DeviceDetails) {
 		var alerts: [StationAlert] = []
 		// Is active
-		if !device.isActive {
+		if shouldSendInactiveNotification(for: device) {
 			alerts.append(.inactive)
 		}
 
 		// Low battery
-		if device.batteryState == .low {
+		if shouldSendLowBatteryNotification(for: device) {
 			alerts.append(.battery)
 		}
 		
 		// Firmware
-		if device.checkFirmwareIfNeedsUpdate() {
+		if shouldSendFirmwareNotification(for: device) {
 			alerts.append(.firmware)
 		}
 
 		// Health
-		if let qod = device.qod, qod < 80 {
+		if shouldSendHealthNotification(for: device) {
 			alerts.append(.health)
 		}
 
@@ -47,11 +47,77 @@ private extension StationAlertsManager {
 	}
 
 	func handleAlerts(for device: DeviceDetails, alerts: [StationAlert]) {
+		guard let deviceId = device.id else {
+			return
+		}
+
 		let notificationsScheduler = LocalNotificationScheduler()
 		alerts.forEach {
 			notificationsScheduler.postNotification(id: "\(String(describing: device.id))_\($0)",
 													title: $0.notificationTitle,
 													body: $0.notificationDescription(for: device.displayName))
+			meUseCase.notificationAlertSent(for: deviceId, alert: $0)
 		}
+	}
+
+	func shouldSendInactiveNotification(for device: DeviceDetails) -> Bool {
+		guard let deviceId = device.id,
+			  let lastActiveAt = device.lastActiveAt?.timestampToDate() else {
+			return false
+		}
+
+		var shouldSend: Bool = false
+		if let lastNotificationSent = meUseCase.lastNotificationAlertSent(for: deviceId, alert: .inactive) {
+			if lastActiveAt > lastNotificationSent {
+				shouldSend = true
+			} else if lastNotificationSent.isToday {
+				shouldSend = false
+			}
+		}
+
+		return shouldSend && device.isActive == false
+	}
+
+	func shouldSendLowBatteryNotification(for device: DeviceDetails) -> Bool {
+		guard let deviceId = device.id else {
+			return false
+		}
+
+		let lastNotificationSent = meUseCase.lastNotificationAlertSent(for: deviceId, alert: .battery)
+		if lastNotificationSent?.isToday == true {
+			return false
+		}
+
+		return device.batteryState == .low
+	}
+
+	func shouldSendFirmwareNotification(for device: DeviceDetails) -> Bool {
+		guard let deviceId = device.id else {
+			return false
+		}
+
+		let lastNotificationSent = meUseCase.lastNotificationAlertSent(for: deviceId, alert: .firmware)
+		if lastNotificationSent?.isToday == true {
+			return false
+		}
+
+		return device.checkFirmwareIfNeedsUpdate()
+	}
+
+	func shouldSendHealthNotification(for device: DeviceDetails) -> Bool {
+		guard let deviceId = device.id,
+			  let qod = device.qod,
+			  let pol = device.pol,
+			  let qodTs = device.latestQodTs,
+			  qodTs.isYesterday else {
+			return false
+		}
+
+		let lastNotificationSent = meUseCase.lastNotificationAlertSent(for: deviceId, alert: .health)
+		if lastNotificationSent?.isToday == true {
+			return false
+		}
+
+		return qod < 80 || pol != .verified
 	}
 }

--- a/WeatherXMTests/DomainLayer/MockRepositories/MockMeRepositoryImpl.swift
+++ b/WeatherXMTests/DomainLayer/MockRepositories/MockMeRepositoryImpl.swift
@@ -63,7 +63,18 @@ extension MockMeRepositoryImpl: MeRepository {
 																	   result: .success(emptyEntity))
 		return Just(response).eraseToAnyPublisher()
 	}
-	
+
+	func getOwnedDevices() throws -> AnyPublisher<DataResponse<[NetworkDevicesResponse], NetworkErrorResponse>, Never> {
+		let device = NetworkDevicesResponse()
+		let response = DataResponse<[NetworkDevicesResponse], NetworkErrorResponse>(request: nil,
+																					response: nil,
+																					data: nil,
+																					metrics: nil,
+																					serializationDuration: 0,
+																					result: .success([device]))
+		return Just(response).eraseToAnyPublisher()
+	}
+
 	func getDevices(useCache: Bool) throws -> AnyPublisher<DataResponse<[NetworkDevicesResponse], NetworkErrorResponse>, Never> {
 		let device = NetworkDevicesResponse()
 		let response = DataResponse<[NetworkDevicesResponse], NetworkErrorResponse>(request: nil,

--- a/WeatherXMTests/PresentationLayer/MockUseCases/MockMeUseCase.swift
+++ b/WeatherXMTests/PresentationLayer/MockUseCases/MockMeUseCase.swift
@@ -12,6 +12,7 @@ import Combine
 import Alamofire
 
 final class MockMeUseCase: MeUseCaseApi {
+
 	nonisolated(unsafe) var addButtonIndicationSeen: Bool = false
 
 	var userInfoPublisher: AnyPublisher<NetworkUserInfoResponse?, Never> {
@@ -61,6 +62,10 @@ final class MockMeUseCase: MeUseCaseApi {
 																	   serializationDuration: 0,
 																	   result: .success(emptyEntity))
 		return Just(response).eraseToAnyPublisher()
+	}
+
+	func getOwnedDevices() throws -> AnyPublisher<Result<[DomainLayer.DeviceDetails], DomainLayer.NetworkErrorResponse>, Never> {
+		try getDevices()
 	}
 
 	func getDevices() throws -> AnyPublisher<Result<[DeviceDetails], NetworkErrorResponse>, Never> {
@@ -179,11 +184,11 @@ final class MockMeUseCase: MeUseCaseApi {
 		return Just(.success(device)).eraseToAnyPublisher()
 	}
 
-	func shouldSendNotificationAlert(for deviceId: String, alert: StationAlert) -> Bool {
-		true
+	func lastNotificationAlertSent(for deviceId: String, alert: StationAlert) -> Date? {
+		nil
 	}
-
+	
 	func notificationAlertSent(for deviceId: String, alert: StationAlert) {
-		
+
 	}
 }

--- a/WeatherXMTests/PresentationLayer/MockUseCases/MockMeUseCase.swift
+++ b/WeatherXMTests/PresentationLayer/MockUseCases/MockMeUseCase.swift
@@ -179,5 +179,11 @@ final class MockMeUseCase: MeUseCaseApi {
 		return Just(.success(device)).eraseToAnyPublisher()
 	}
 
+	func shouldSendNotificationAlert(for deviceId: String, alert: StationAlert) -> Bool {
+		true
+	}
 
+	func notificationAlertSent(for deviceId: String, alert: StationAlert) {
+		
+	}
 }

--- a/WeatherXMTests/PresentationLayer/MockUseCases/MockMeUseCase.swift
+++ b/WeatherXMTests/PresentationLayer/MockUseCases/MockMeUseCase.swift
@@ -184,11 +184,11 @@ final class MockMeUseCase: MeUseCaseApi {
 		return Just(.success(device)).eraseToAnyPublisher()
 	}
 
-	func lastNotificationAlertSent(for deviceId: String, alert: StationAlert) -> Date? {
+	func lastNotificationAlertSent(for deviceId: String, alert: StationNotificationsTypes) -> Date? {
 		nil
 	}
 	
-	func notificationAlertSent(for deviceId: String, alert: StationAlert) {
+	func notificationAlertSent(for deviceId: String, alert: StationNotificationsTypes) {
 
 	}
 }

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -395,6 +395,8 @@
 		269C968A2BDBD5660035B8F1 /* Mixpanel in Frameworks */ = {isa = PBXBuildFile; productRef = 269C96892BDBD5660035B8F1 /* Mixpanel */; };
 		269E85712B0242C100BE774C /* WXMShareModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269E85702B0242C100BE774C /* WXMShareModifier.swift */; };
 		269EC14D2E324ED90099DB78 /* BackgroundScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269EC14C2E324ED90099DB78 /* BackgroundScheduler.swift */; };
+		269EC1672E3274930099DB78 /* StationAlertsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269EC1662E3274930099DB78 /* StationAlertsManager.swift */; };
+		269EC1692E327EE60099DB78 /* StationAlert+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269EC1682E327EE60099DB78 /* StationAlert+.swift */; };
 		26A0A98B2DC0BCFA005A6646 /* BluetoothStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A0A98A2DC0BCFA005A6646 /* BluetoothStateTests.swift */; };
 		26A0A98D2DC0CD0E005A6646 /* AnnouncementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A0A98C2DC0CD0E005A6646 /* AnnouncementTests.swift */; };
 		26A0A98F2DC0CEE9005A6646 /* NetworkDeviceForecastResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A0A98E2DC0CEE9005A6646 /* NetworkDeviceForecastResponseTests.swift */; };
@@ -1149,6 +1151,8 @@
 		269C809B2AB9E76F005F9BD6 /* Badge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Badge.swift; sourceTree = "<group>"; };
 		269E85702B0242C100BE774C /* WXMShareModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WXMShareModifier.swift; sourceTree = "<group>"; };
 		269EC14C2E324ED90099DB78 /* BackgroundScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundScheduler.swift; sourceTree = "<group>"; };
+		269EC1662E3274930099DB78 /* StationAlertsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationAlertsManager.swift; sourceTree = "<group>"; };
+		269EC1682E327EE60099DB78 /* StationAlert+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StationAlert+.swift"; sourceTree = "<group>"; };
 		26A0A98A2DC0BCFA005A6646 /* BluetoothStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothStateTests.swift; sourceTree = "<group>"; };
 		26A0A98C2DC0CD0E005A6646 /* AnnouncementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementTests.swift; sourceTree = "<group>"; };
 		26A0A98E2DC0CEE9005A6646 /* NetworkDeviceForecastResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDeviceForecastResponseTests.swift; sourceTree = "<group>"; };
@@ -2462,6 +2466,7 @@
 				2608A7932C09F67A00452E40 /* DeviceLocation+.swift */,
 				2672B87B2C89F19A002266BE /* BoostCode+.swift */,
 				2672B87D2C8A0155002266BE /* NetworkDeviceRewardsResponse+.swift */,
+				269EC1682E327EE60099DB78 /* StationAlert+.swift */,
 			);
 			path = DomainExtensions;
 			sourceTree = "<group>";
@@ -2674,6 +2679,7 @@
 				2664830029C0C73E00748F9C /* Toast.swift */,
 				261729CC2C32CF7700A1CEFA /* Haptics.swift */,
 				269EC14C2E324ED90099DB78 /* BackgroundScheduler.swift */,
+				269EC1662E3274930099DB78 /* StationAlertsManager.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -4171,6 +4177,7 @@
 				2646D8F329C8BF3D0000237F /* StationRewardsView.swift in Sources */,
 				268645982A6FA7C100EB85B1 /* Router.swift in Sources */,
 				2623E2232A6FC29100E3E306 /* RouterView.swift in Sources */,
+				269EC1672E3274930099DB78 /* StationAlertsManager.swift in Sources */,
 				26FFCCDD2BD28E3900880AAD /* WeatherChartTypes.swift in Sources */,
 				2672C7802AA9DA4600E1FDCC /* ScrollingPagerView.swift in Sources */,
 				26348DFC2A42FCB9000846C6 /* SearchView+Content.swift in Sources */,
@@ -4180,6 +4187,7 @@
 				268B5C432BCEB61A00E63655 /* ForecastFieldCardView.swift in Sources */,
 				261913F32E1D208300F7E51C /* StationNotificationsViewModel.swift in Sources */,
 				2672B8802C8A02D0002266BE /* BoostDetailsView.swift in Sources */,
+				269EC1692E327EE60099DB78 /* StationAlert+.swift in Sources */,
 				267547BE29A9181E008BCF40 /* SettingsButtonView.swift in Sources */,
 				267548DF29A91A87008BCF40 /* SettingsEnum.swift in Sources */,
 				267547B929A9181E008BCF40 /* SettingsSectionTitle.swift in Sources */,

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -394,6 +394,7 @@
 		269C809C2AB9E76F005F9BD6 /* Badge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269C809B2AB9E76F005F9BD6 /* Badge.swift */; };
 		269C968A2BDBD5660035B8F1 /* Mixpanel in Frameworks */ = {isa = PBXBuildFile; productRef = 269C96892BDBD5660035B8F1 /* Mixpanel */; };
 		269E85712B0242C100BE774C /* WXMShareModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269E85702B0242C100BE774C /* WXMShareModifier.swift */; };
+		269EC14D2E324ED90099DB78 /* BackgroundScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269EC14C2E324ED90099DB78 /* BackgroundScheduler.swift */; };
 		26A0A98B2DC0BCFA005A6646 /* BluetoothStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A0A98A2DC0BCFA005A6646 /* BluetoothStateTests.swift */; };
 		26A0A98D2DC0CD0E005A6646 /* AnnouncementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A0A98C2DC0CD0E005A6646 /* AnnouncementTests.swift */; };
 		26A0A98F2DC0CEE9005A6646 /* NetworkDeviceForecastResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A0A98E2DC0CEE9005A6646 /* NetworkDeviceForecastResponseTests.swift */; };
@@ -1147,6 +1148,7 @@
 		269C6E782C4A97C800879263 /* CompactNumberFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompactNumberFormatterTests.swift; sourceTree = "<group>"; };
 		269C809B2AB9E76F005F9BD6 /* Badge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Badge.swift; sourceTree = "<group>"; };
 		269E85702B0242C100BE774C /* WXMShareModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WXMShareModifier.swift; sourceTree = "<group>"; };
+		269EC14C2E324ED90099DB78 /* BackgroundScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundScheduler.swift; sourceTree = "<group>"; };
 		26A0A98A2DC0BCFA005A6646 /* BluetoothStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothStateTests.swift; sourceTree = "<group>"; };
 		26A0A98C2DC0CD0E005A6646 /* AnnouncementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementTests.swift; sourceTree = "<group>"; };
 		26A0A98E2DC0CEE9005A6646 /* NetworkDeviceForecastResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDeviceForecastResponseTests.swift; sourceTree = "<group>"; };
@@ -2671,6 +2673,7 @@
 				267401932A3A038300E54E35 /* SwiftUIUtils.swift */,
 				2664830029C0C73E00748F9C /* Toast.swift */,
 				261729CC2C32CF7700A1CEFA /* Haptics.swift */,
+				269EC14C2E324ED90099DB78 /* BackgroundScheduler.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -4015,6 +4018,7 @@
 				2675480429A9181E008BCF40 /* CustomPicker.swift in Sources */,
 				2675483629A9181E008BCF40 /* CustomRangeSlider.swift in Sources */,
 				26D5013C29B2152F00BC2951 /* CustomSegmentView.swift in Sources */,
+				269EC14D2E324ED90099DB78 /* BackgroundScheduler.swift in Sources */,
 				267548FA29A91A87008BCF40 /* CustomYAxisFormatter.swift in Sources */,
 				265D7CE72AB1CA5D00782606 /* DateRange.swift in Sources */,
 				26B7C98B2A6EBFBE00C30CE1 /* DeepLinkHandler.swift in Sources */,

--- a/wxm-ios/AppCore/AppDelegate.swift
+++ b/wxm-ios/AppCore/AppDelegate.swift
@@ -12,7 +12,6 @@ import UIKit
 import Network
 
 class AppDelegate: NSObject, UIApplicationDelegate {
-	private var backgroundScheduler: BackgroundScheduler?
 
 	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
 		// Fixe the crash in iOS 26
@@ -24,8 +23,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 			WXMAnalytics.shared.launch(with: [.firebase, .mixpanel(mixpanelToken)])
 		}
 
-		backgroundScheduler = BackgroundScheduler()
-
 		return true
     }
 
@@ -36,8 +33,4 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 	func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
 		FirebaseManager.shared.setApnsToken(deviceToken)
 	}
-
-//	func applicationDidEnterBackground(_ application: UIApplication) {
-//		backgroundScheduler?.scheduleAppRefresh()
-//	}
 }

--- a/wxm-ios/AppCore/AppDelegate.swift
+++ b/wxm-ios/AppCore/AppDelegate.swift
@@ -12,6 +12,8 @@ import UIKit
 import Network
 
 class AppDelegate: NSObject, UIApplicationDelegate {
+	private var backgroundScheduler: BackgroundScheduler?
+
 	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
 		// Fixe the crash in iOS 26
 		nw_tls_create_options()
@@ -21,7 +23,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 		if let mixpanelToken: String = Bundle.main.getConfiguration(for: .mixpanelToken) {
 			WXMAnalytics.shared.launch(with: [.firebase, .mixpanel(mixpanelToken)])
 		}
-        
+
+		backgroundScheduler = BackgroundScheduler()
+
 		return true
     }
 
@@ -32,4 +36,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 	func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
 		FirebaseManager.shared.setApnsToken(deviceToken)
 	}
+
+//	func applicationDidEnterBackground(_ application: UIApplication) {
+//		backgroundScheduler?.scheduleAppRefresh()
+//	}
 }

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/MeRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/MeRepositoryImpl.swift
@@ -54,7 +54,24 @@ public struct MeRepositoryImpl: MeRepository {
 	public func getCachedDevices() -> [NetworkDevicesResponse]? {
 		userDevicesService.getCachedDevices()
 	}
-	
+
+	public func getOwnedDevices() throws -> AnyPublisher<DataResponse<[NetworkDevicesResponse], NetworkErrorResponse>, Never> {
+		try userDevicesService.getDevices(useCache: false).flatMap { response in
+			switch response.result {
+					case .success(let devices):
+					let ownedDevices = devices.filter { $0.relation == .owned }
+					return Just(DataResponse<[NetworkDevicesResponse], NetworkErrorResponse>(request: nil,
+																							 response: nil,
+																							 data: nil,
+																							 metrics: nil,
+																							 serializationDuration: 0,
+																							 result: .success(ownedDevices)))
+				case .failure(let error):
+					return Just(response)
+			}
+		}.eraseToAnyPublisher()
+	}
+
 	public func getDevices(useCache: Bool) throws -> AnyPublisher<DataResponse<[NetworkDevicesResponse], NetworkErrorResponse>, Never> {
         try userDevicesService.getDevices(useCache: useCache)
     }

--- a/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/MeRepository.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/DomainRepositoryInterfaces/MeRepository.swift
@@ -41,6 +41,7 @@ public protocol MeRepository {
     func getUser() throws -> AnyPublisher<DataResponse<NetworkUserInfoResponse, NetworkErrorResponse>, Never>
     func getUserWallet() throws -> AnyPublisher<DataResponse<Wallet, NetworkErrorResponse>, Never>
     func saveUserWallet(address: String) throws -> AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never>
+	func getOwnedDevices() throws -> AnyPublisher<DataResponse<[NetworkDevicesResponse], NetworkErrorResponse>, Never>
 	func getDevices(useCache: Bool) throws -> AnyPublisher<DataResponse<[NetworkDevicesResponse], NetworkErrorResponse>, Never>
 	func getCachedDevices() -> [NetworkDevicesResponse]?
     func claimDevice(claimDeviceBody: ClaimDeviceBody) throws -> AnyPublisher<DataResponse<NetworkDevicesResponse, NetworkErrorResponse>, Never>

--- a/wxm-ios/DomainLayer/DomainLayer/Extensions/UserDefaults+Constants.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Extensions/UserDefaults+Constants.swift
@@ -48,6 +48,7 @@ public extension UserDefaults {
 		case stationNotificationsPromptSeen = "com.weatherxm.app.UserDefaults.Key.StationNotificationsPromptSeen"
 		case stationNotificationOptions = "com.weatherxm.app.UserDefaults.Key.StationNotificationOptions"
 		case stationNotificationEnabled = "com.weatherxm.app.UserDefaults.Key.StationNotificationEnabled"
+		case stationAlertNotificationsTimestamps = "com.weatherxm.app.UserDefaults.Key.StationAlertNotificationsTimestamps"
 
         // MARK: - UserDefaultEntry
 
@@ -64,7 +65,8 @@ public extension UserDefaults {
 									  .arePhotoVerificationTermsAccepted,
 									  .isAddButtonIndicationSeen,
 									  .stationNotificationOptions,
-									  .stationNotificationEnabled]
+									  .stationNotificationEnabled,
+									  .stationAlertNotificationsTimestamps]
             return keys.map { $0.rawValue }
         }
     }

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/MeUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/MeUseCase.swift
@@ -153,11 +153,18 @@ public struct MeUseCase: @unchecked Sendable, MeUseCaseApi {
 		return publisher.convertedToDeviceDetailsResultPublisher
 	}
 
-	public func shouldSendNotificationAlert(for deviceId: String, alert: StationAlert) -> Bool {
-		true
+	public func lastNotificationAlertSent(for deviceId: String, alert: StationAlert) -> Date? {
+		let timestamps: [String: Date]? = userDefaultsrRepository.getValue(for: UserDefaults.GenericKey.stationAlertNotificationsTimestamps.rawValue)
+		let key = "\(deviceId)-\(alert)"
+
+		return timestamps?[key]
 	}
 
 	public func notificationAlertSent(for deviceId: String, alert: StationAlert) {
-		
+		var timestamps: [String: Date] = userDefaultsrRepository.getValue(for: UserDefaults.GenericKey.stationAlertNotificationsTimestamps.rawValue) ?? [:]
+		let key = "\(deviceId)-\(alert)"
+		timestamps[key] = Date()
+
+		userDefaultsrRepository.saveValue(key: UserDefaults.GenericKey.stationAlertNotificationsTimestamps.rawValue, value: timestamps)
 	}
 }

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/MeUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/MeUseCase.swift
@@ -153,14 +153,14 @@ public struct MeUseCase: @unchecked Sendable, MeUseCaseApi {
 		return publisher.convertedToDeviceDetailsResultPublisher
 	}
 
-	public func lastNotificationAlertSent(for deviceId: String, alert: StationAlert) -> Date? {
+	public func lastNotificationAlertSent(for deviceId: String, alert: StationNotificationsTypes) -> Date? {
 		let timestamps: [String: Date]? = userDefaultsrRepository.getValue(for: UserDefaults.GenericKey.stationAlertNotificationsTimestamps.rawValue)
 		let key = "\(deviceId)-\(alert)"
 
 		return timestamps?[key]
 	}
 
-	public func notificationAlertSent(for deviceId: String, alert: StationAlert) {
+	public func notificationAlertSent(for deviceId: String, alert: StationNotificationsTypes) {
 		var timestamps: [String: Date] = userDefaultsrRepository.getValue(for: UserDefaults.GenericKey.stationAlertNotificationsTimestamps.rawValue) ?? [:]
 		let key = "\(deviceId)-\(alert)"
 		timestamps[key] = Date()

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/MeUseCase.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/MeUseCase.swift
@@ -59,6 +59,10 @@ public struct MeUseCase: @unchecked Sendable, MeUseCaseApi {
         return saveUserWallet
     }
 
+	public func getOwnedDevices() throws -> AnyPublisher<Result<[DeviceDetails], NetworkErrorResponse>, Never> {
+		try meRepository.getOwnedDevices().convertedToDeviceDetailsResultPublisher
+	}
+
     public func getDevices() throws -> AnyPublisher<Result<[DeviceDetails], NetworkErrorResponse>, Never> {
         let userDevices = try meRepository.getDevices(useCache: false)
         return userDevices.convertedToDeviceDetailsResultPublisher
@@ -147,5 +151,13 @@ public struct MeUseCase: @unchecked Sendable, MeUseCaseApi {
 	public func setDeviceLocationById(deviceId: String, lat: Double, lon: Double) throws -> AnyPublisher<Result<DeviceDetails, NetworkErrorResponse>, Never> {
 		let publisher = try meRepository.setDeviceLocationById(deviceId: deviceId, lat: lat, lon: lon)
 		return publisher.convertedToDeviceDetailsResultPublisher
+	}
+
+	public func shouldSendNotificationAlert(for deviceId: String, alert: StationAlert) -> Bool {
+		true
+	}
+
+	public func notificationAlertSent(for deviceId: String, alert: StationAlert) {
+		
 	}
 }

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/MeUseCaseApi.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/MeUseCaseApi.swift
@@ -20,6 +20,7 @@ public protocol MeUseCaseApi: Sendable {
 	func getUserWallet() throws -> AnyPublisher<DataResponse<Wallet, NetworkErrorResponse>, Never>
 	func saveUserWallet(address: String) throws -> AnyPublisher<DataResponse<EmptyEntity, NetworkErrorResponse>, Never>
 	func getDevices() throws -> AnyPublisher<Result<[DeviceDetails], NetworkErrorResponse>, Never>
+	func getOwnedDevices() throws -> AnyPublisher<Result<[DeviceDetails], NetworkErrorResponse>, Never>
 	func claimDevice(claimDeviceBody: ClaimDeviceBody) throws -> AnyPublisher<Result<DeviceDetails, NetworkErrorResponse>, Never>
 	func setFrequency(_ serialNumber: String, frequency: Frequency) async throws -> NetworkErrorResponse?
 	func getFirmwares(testSearch: String) throws -> AnyPublisher<DataResponse<[NetworkFirmwareResponse], NetworkErrorResponse>, Never>
@@ -35,4 +36,13 @@ public protocol MeUseCaseApi: Sendable {
 	func hasOwnedDevices() async -> Bool
 	func getUserRewards(wallet: String) throws -> AnyPublisher<DataResponse<NetworkUserRewardsResponse, NetworkErrorResponse>, Never>
 	func setDeviceLocationById(deviceId: String, lat: Double, lon: Double) throws -> AnyPublisher<Result<DeviceDetails, NetworkErrorResponse>, Never>
+	func shouldSendNotificationAlert(for deviceId: String, alert: StationAlert) -> Bool
+	func notificationAlertSent(for deviceId: String, alert: StationAlert)
+}
+
+public enum StationAlert: CaseIterable {
+	case inactive
+	case firmware
+	case battery
+	case health
 }

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/MeUseCaseApi.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/MeUseCaseApi.swift
@@ -36,11 +36,11 @@ public protocol MeUseCaseApi: Sendable {
 	func hasOwnedDevices() async -> Bool
 	func getUserRewards(wallet: String) throws -> AnyPublisher<DataResponse<NetworkUserRewardsResponse, NetworkErrorResponse>, Never>
 	func setDeviceLocationById(deviceId: String, lat: Double, lon: Double) throws -> AnyPublisher<Result<DeviceDetails, NetworkErrorResponse>, Never>
-	func shouldSendNotificationAlert(for deviceId: String, alert: StationAlert) -> Bool
+	func lastNotificationAlertSent(for deviceId: String, alert: StationAlert) -> Date?
 	func notificationAlertSent(for deviceId: String, alert: StationAlert)
 }
 
-public enum StationAlert: CaseIterable {
+public enum StationAlert: String, CaseIterable {
 	case inactive
 	case firmware
 	case battery

--- a/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/MeUseCaseApi.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/UseCases/UseCaseApi/MeUseCaseApi.swift
@@ -36,13 +36,6 @@ public protocol MeUseCaseApi: Sendable {
 	func hasOwnedDevices() async -> Bool
 	func getUserRewards(wallet: String) throws -> AnyPublisher<DataResponse<NetworkUserRewardsResponse, NetworkErrorResponse>, Never>
 	func setDeviceLocationById(deviceId: String, lat: Double, lon: Double) throws -> AnyPublisher<Result<DeviceDetails, NetworkErrorResponse>, Never>
-	func lastNotificationAlertSent(for deviceId: String, alert: StationAlert) -> Date?
-	func notificationAlertSent(for deviceId: String, alert: StationAlert)
-}
-
-public enum StationAlert: String, CaseIterable {
-	case inactive
-	case firmware
-	case battery
-	case health
+	func lastNotificationAlertSent(for deviceId: String, alert: StationNotificationsTypes) -> Date?
+	func notificationAlertSent(for deviceId: String, alert: StationNotificationsTypes)
 }

--- a/wxm-ios/Info.plist
+++ b/wxm-ios/Info.plist
@@ -10,6 +10,10 @@
 	<string>$(AppGroup)</string>
 	<key>AppStoreUrl</key>
 	<string>$(AppStoreUrl)</string>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.weatherxm.app.fetch</string>
+	</array>
 	<key>BranchName</key>
 	<string>$(BranchName)</string>
 	<key>CFBundleURLTypes</key>
@@ -79,6 +83,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>
+		<string>fetch</string>
 	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -6105,6 +6105,94 @@
         }
       }
     },
+    "notification_battery_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To avoid data interruptions, please replace the batteries of %@."
+          }
+        }
+      }
+    },
+    "notification_battery_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station Low Battery"
+          }
+        }
+      }
+    },
+    "notification_firmware_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A new version is available for %@. Upgrade to enjoy the latest improvements."
+          }
+        }
+      }
+    },
+    "notification_firmware_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Firmware Update"
+          }
+        }
+      }
+    },
+    "notification_health_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your station %@ has some health issues. Tap to view its status."
+          }
+        }
+      }
+    },
+    "notification_health_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station Health Issues"
+          }
+        }
+      }
+    },
+    "notification_inactive_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your station %@ appears inactive. Please check its status."
+          }
+        }
+      }
+    },
+    "notification_inactive_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station Inactive"
+          }
+        }
+      }
+    },
     "offline_station" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/LocalizableString+Errors.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+Errors.swift
@@ -72,6 +72,14 @@ extension LocalizableString {
 		case invalidSerialNumber
 		case invalidWXMAddress
 		case invalidPassword
+		case notificationInactiveTitle
+		case notificationInactiveDescription(String)
+		case notificationBatteryTitle
+		case notificationBatteryDescription(String)
+		case notificationFirmwareTitle
+		case notificationFirmwareDescription(String)
+		case notificationHealthTitle
+		case notificationHealthDescription(String)
     }
 }
 
@@ -91,7 +99,11 @@ extension LocalizableString.Error: WXMLocalizable {
 					.unidentifiedSpikeDescription(let text),
 					.unownedUnidentifiedSpikeDescription(let text),
 					.unidentifiedAnomalousChangeDescription(let text),
-					.unownedUnidentifiedAnomalousDescription(let text):
+					.unownedUnidentifiedAnomalousDescription(let text),
+					.notificationInactiveDescription(let text),
+					.notificationBatteryDescription(let text),
+					.notificationHealthDescription(let text),
+					.notificationFirmwareDescription(let text):
 				localized = String(format: localized, text)
 			default:
 				break
@@ -227,6 +239,22 @@ extension LocalizableString.Error: WXMLocalizable {
 				return "error_invalid_wxm_address"
 			case .invalidPassword:
 				return "error_invalid_password"
+			case .notificationInactiveTitle:
+				return "notification_inactive_title"
+			case .notificationInactiveDescription:
+				return "notification_inactive_description"
+			case .notificationBatteryTitle:
+				return "notification_battery_title"
+			case .notificationBatteryDescription:
+				return "notification_battery_description"
+			case .notificationFirmwareTitle:
+				return "notification_firmware_title"
+			case .notificationFirmwareDescription:
+				return "notification_firmware_description"
+			case .notificationHealthTitle:
+				return "notification_health_title"
+			case .notificationHealthDescription:
+				return "notification_health_description"
 		}
 	}
 }

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants+.swift
@@ -594,6 +594,20 @@ extension ParameterValue: RawRepresentable {
 				return "data_quality"
 			case .dataQualityScore:
 				return "data_quality_score"
+			case .toggleStationNotifications:
+				return "Toggle Station Notifications"
+			case .toggleStationNotificationType:
+				return "Toggle Station Notification Type"
+			case .activity:
+				return "activity"
+			case .stationHealth:
+				return "station_health"
+			case .enable:
+				return "enable"
+			case .disable:
+				return "disable"
+			case .openStationFromNotification:
+				return "Open Station from Notification"
 		}
 	}
 }

--- a/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
+++ b/wxm-ios/Toolkit/Toolkit/Analytics/AnalyticsConstants/AnalyticsConstants.swift
@@ -69,6 +69,7 @@ public enum Screen: String {
 	case mapLayerPicker = "Map Layer Picker"
 	case tokenMetrics = "Token Metrics"
 	case networkGrowth = "Network Growth"
+	case stationNotifications = "Station Notifications"
 }
 
 public enum Event: String {
@@ -342,5 +343,12 @@ public enum ParameterValue {
 	case density
 	case dataQuality
 	case dataQualityScore
+	case toggleStationNotifications
+	case toggleStationNotificationType
+	case activity
+	case stationHealth
+	case enable
+	case disable
+	case openStationFromNotification
 	case custom(String)
 }

--- a/wxm-ios/Toolkit/Toolkit/FirebaseManager/NotificationsHandler.swift
+++ b/wxm-ios/Toolkit/Toolkit/FirebaseManager/NotificationsHandler.swift
@@ -15,7 +15,7 @@ final class NotificationsHandler: NSObject, Sendable {
 	let authorizationStatusPublisher: AnyPublisher<UNAuthorizationStatus?, Never>
 	let fcmTokenPublisher: AnyPublisher<String?, Never>
 
-	private let latestNotificationSubject: PassthroughSubject<UNNotificationResponse?, Never> = .init()
+	private let latestNotificationSubject: CurrentValueSubject<UNNotificationResponse?, Never> = .init(nil)
 	private let authorizationStatusSubject: CurrentValueSubject<UNAuthorizationStatus?, Never> = .init(nil)
 	private let fcmTokenSubject: PassthroughSubject<String?, Never> = .init()
 

--- a/wxm-ios/Toolkit/Toolkit/Types/CallbackTypes.swift
+++ b/wxm-ios/Toolkit/Toolkit/Types/CallbackTypes.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public typealias VoidCallback = () -> Void
+public typealias VoidSendableCallback = @Sendable () -> Void
 public typealias GenericCallback<T> = (T) -> Void
 public typealias GenericSendableCallback<T> = @Sendable (T) -> Void
 public typealias GenericMainActorCallback<T> = @MainActor (T) -> Void

--- a/wxm-ios/Toolkit/Toolkit/Utils/LocalNotificationScheduler.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/LocalNotificationScheduler.swift
@@ -11,10 +11,19 @@ import UserNotifications
 public struct LocalNotificationScheduler {
 	public init() {}
 
-	public func postNotification(id: String, title: String, body: String?, userInfo: [AnyHashable: Any]? = nil) {
+	public func postNotification(id: String,
+								 title: String,
+								 body: String?,
+								 threadId: String? = nil,
+								 userInfo: [AnyHashable: Any]? = nil) {
 		let content = UNMutableNotificationContent()
 		content.title = title
 		content.userInfo = userInfo ?? [:]
+
+		if let threadId {
+			content.threadIdentifier = threadId
+		}
+
 		if let body {
 			content.body = body
 		}

--- a/wxm-ios/Toolkit/Toolkit/Utils/LocalNotificationScheduler.swift
+++ b/wxm-ios/Toolkit/Toolkit/Utils/LocalNotificationScheduler.swift
@@ -11,9 +11,10 @@ import UserNotifications
 public struct LocalNotificationScheduler {
 	public init() {}
 
-	public func postNotification(id: String, title: String, body: String?) {
+	public func postNotification(id: String, title: String, body: String?, userInfo: [AnyHashable: Any]? = nil) {
 		let content = UNMutableNotificationContent()
 		content.title = title
+		content.userInfo = userInfo ?? [:]
 		if let body {
 			content.body = body
 		}


### PR DESCRIPTION
## **Why?**
Background job to iterate the user devices and send local notifications
### **How?**
- `BackgroundScheduler` is initialized inside the `MainScreenViewModel` singleton and schedules the bg task
- `StationAlertsManager` contains the logic to send the notifications. Fetches the owned devices and iterates for issues.
- Added analytics events
### **Testing**
Run the app on a physical device; otherwise, it doesn't work. To force the scheduled background tasks to execute, run the following command on the debugger (lldb).
```
e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.weatherxm.app.fetch"]
```
While the app is running, tap the pause button, paste the command above, tap enter, and once the command is executed, resume to the app by tapping the "resume" button (previously "pause")

### **Screenshots (if applicable)**
<img width="400" alt="Screenshot 2025-07-25 at 15 42 16" src="https://github.com/user-attachments/assets/675263b1-903d-4f04-a92c-9848d4ea5931" />

<img width="400" alt="Screenshot 2025-07-25 at 15 42 02" src="https://github.com/user-attachments/assets/490d9748-4ff7-4574-b514-6833d8a8b212" />

### **Additional context**
fixes fe-1883, fe-1884