### PR TITLE
Use correct constant for low battery

### DIFF
--- a/PresentationLayer/Extensions/DomainExtensions/StationAlert+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/StationAlert+.swift
@@ -41,7 +41,7 @@ extension StationNotificationsTypes {
 			case .activity:
 					.activity
 			case .battery:
-					.lowBattery
+					.lowBatteryItem
 			case .firmwareUpdate:
 					.otaUpdate
 			case .health:


### PR DESCRIPTION
## **Why?**
Fixed wrong constant tracking
### **How?**
Track the `low_battery` constant as `source` in the station notification events
### **Testing**
Ensure the event tracked on low battery toggle changes contains the correct source
To enable tracking, uncheck the `-WXMAnalyticsDisabled` launch argument
### **Additional context**
fixes fe-1942
