### PR TITLE
Show search on empty area tap

### DIFF
--- a/PresentationLayer/UIComponents/Screens/Home/HomeView.swift
+++ b/PresentationLayer/UIComponents/Screens/Home/HomeView.swift
@@ -142,6 +142,9 @@ private extension HomeView {
 			RoundedRectangle(cornerRadius: CGFloat(.cardCornerRadius))
 				.stroke(Color(colorEnum: .top), style: StrokeStyle(lineWidth: 2, dash: [4, 4]))
 		}
+		.onTapGesture {
+			viewModel.handleSearchButtonTap()
+		}
 	}
 
 	@ViewBuilder


### PR DESCRIPTION
## **Why?**
Activate the search view once the user taps on the saved locations' empty state
### **How?**
Added `onTapGesture` modifier to trigger the search activation
### **Testing**
Just test the functionality
### **Additional context**
fixes fe-1968


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The empty Saved Locations card on the Home screen is now tappable, launching the search flow directly from the empty state.
  * Improves discoverability and reduces steps to start finding locations when no saved places are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->