### PR TITLE
Fixed size updates

### DIFF
--- a/PresentationLayer/UIComponents/Screens/Onboarding/OnboardingView.swift
+++ b/PresentationLayer/UIComponents/Screens/Onboarding/OnboardingView.swift
@@ -105,7 +105,7 @@ private extension OnboardingView {
 				LazyHStack(spacing: 0.05 * proxy.size.width) {
 					ForEach(slides) { slide in
 						cardView(slide: slide,
-								 height: proxy.size.height)
+								 size: proxy.size)
 						.frame(width: 0.8 * proxy.size.width)
 						.id(slide.id)
 					}
@@ -142,12 +142,12 @@ private extension OnboardingView {
 	}
 
 	@ViewBuilder
-	func cardView(slide: Slide, height: CGFloat) -> some View {
+	func cardView(slide: Slide, size: CGSize) -> some View {
 		ZStack {
 			Image(asset: slide.image)
 				.resizable()
 				.aspectRatio(contentMode: .fill)
-				.frame(height: height)
+				.frame(width: 0.8 * size.width, height: size.height)
 				.overlay {
 					VStack {
 						Spacer()


### PR DESCRIPTION
## **Why?**
There was an issue when you resized the window on Mac app
### **How?**
Improved the way we update the onboarding cards frame
### **Testing**
Run the app on a Mac, resize the window and ensure the cards are rendered properly
### **Screenshots (if applicable)**
The bug
<img width="400" alt="Screenshot 2025-09-09 at 16 29 51" src="https://github.com/user-attachments/assets/e9cd5d50-64c8-4f63-b08f-b2c85190c76a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive sizing of onboarding cards and images for a more consistent look across devices.
  * Images now scale proportionally with both width and height, reducing cropping and layout inconsistencies.

* **Refactor**
  * Updated onboarding layout logic to use full size metrics for components, enabling more accurate and flexible rendering across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->