### PR TITLE
Theme switching in device details

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/TabViewWrapper.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/TabViewWrapper.swift
@@ -12,9 +12,13 @@ import SwiftUI
 
 struct TabViewWrapper<Content: View, Selection: Hashable>: View {
     @Binding var selection: Selection
-    @ViewBuilder let content: () -> Content
+	@ViewBuilder let content: () -> Content
+	/// Observe the color scheme in order to solve a bug while switching themes.
+	/// For some reason, the content of the tab view doesn't propagate the theme changes to its children	
+	@Environment(\.colorScheme) var colorScheme
 
     var body: some View {
         TabView(selection: $selection, content: content)
+			.id(colorScheme)
     }
 }


### PR DESCRIPTION
## **Why?**
While switching themes (light/dark mode), the station details tabs (Overview, Forecast, Rewards) don't update their state.
### **How?**
Enforce UI refresh in `TabViewWrapper` which is the container of the tabs
### **Testing**
Go to station details, switch theme and ensure everything works as expected
### **Screenshots (if applicable)**
To switch from Xcode while running the app on the simulator, use the following 
<img width="353" height="539" alt="Screenshot 2025-09-26 at 10 33 11" src="https://github.com/user-attachments/assets/6b0e6bcc-4f09-4f67-85bb-84f78a88276a" />

### **Additional context**
Fixes fe-1999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Tab view and its content now reliably update when switching between light and dark modes, ensuring consistent colors, icons, and backgrounds across all tabs without needing app restart or extra navigation.
- Refactor
  - Improved theme propagation within the tab interface to enhance consistency across child screens, with no changes to how tabs are configured by developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->