### PR TITLE
Cell capacity in claiming flow

### DIFF
--- a/PresentationLayer/Extensions/DomainExtensions/PublicHex+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/PublicHex+.swift
@@ -1,0 +1,18 @@
+//
+//  PublicHexes+.swift
+//  wxm-ios
+//
+//  Created by Pantelis Giazitsis on 26/9/25.
+//
+
+import DomainLayer
+
+extension PublicHex {
+	var cellCapacityReached: Bool {
+		guard let deviceCount, let capacity else {
+			return false
+		}
+
+		return deviceCount >= capacity
+	}
+}

--- a/PresentationLayer/UIComponents/BaseComponents/SelectLocationMap/SelectLocationMapView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/SelectLocationMap/SelectLocationMapView.swift
@@ -19,6 +19,7 @@ struct SelectLocationMapView: View {
 									  annotationTitle: Binding(get: { viewModel.selectedDeviceLocation?.name },
 															   set: { _ in }),
 									  geometryProxyForFrameOfMapView: proxy.frame(in: .local),
+									  polygonPoints: viewModel.explorerData?.cellCapacityPoints,
 									  mapControls: viewModel.mapControls)
 
 				searchArea
@@ -126,5 +127,6 @@ private extension SelectLocationMapView {
 
 #Preview {
 	let useCase = SwinjectHelper.shared.getContainerForSwinject().resolve(DeviceLocationUseCaseApi.self)!
-	return SelectLocationMapView(viewModel: .init(useCase: useCase))
+	let explorerUseCase = SwinjectHelper.shared.getContainerForSwinject().resolve(ExplorerUseCaseApi.self)!
+	return SelectLocationMapView(viewModel: .init(useCase: useCase, explorerUseCase: explorerUseCase))
 }

--- a/PresentationLayer/UIComponents/BaseComponents/SelectLocationMap/SelectLocationMapView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/SelectLocationMap/SelectLocationMapView.swift
@@ -20,7 +20,9 @@ struct SelectLocationMapView: View {
 															   set: { _ in }),
 									  geometryProxyForFrameOfMapView: proxy.frame(in: .local),
 									  polygonPoints: viewModel.explorerData?.cellCapacityPoints,
-									  mapControls: viewModel.mapControls)
+									  mapControls: viewModel.mapControls) { annotations in
+					viewModel.handlePointedAnnotationsChange(annotations: annotations)
+				}
 
 				searchArea
 			}

--- a/PresentationLayer/UIComponents/BaseComponents/SelectLocationMap/SelectLocationMapView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/SelectLocationMap/SelectLocationMapView.swift
@@ -20,6 +20,7 @@ struct SelectLocationMapView: View {
 															   set: { _ in }),
 									  geometryProxyForFrameOfMapView: proxy.frame(in: .local),
 									  polygonPoints: viewModel.explorerData?.cellCapacityPoints,
+									  polylinePoints: viewModel.explorerData?.cellBorderPoints,
 									  textPoints: viewModel.explorerData?.cellCapacityTextPoints,
 									  mapControls: viewModel.mapControls) { annotations in
 					viewModel.handlePointedAnnotationsChange(annotations: annotations)

--- a/PresentationLayer/UIComponents/BaseComponents/SelectLocationMap/SelectLocationMapView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/SelectLocationMap/SelectLocationMapView.swift
@@ -20,6 +20,7 @@ struct SelectLocationMapView: View {
 															   set: { _ in }),
 									  geometryProxyForFrameOfMapView: proxy.frame(in: .local),
 									  polygonPoints: viewModel.explorerData?.cellCapacityPoints,
+									  textPoints: viewModel.explorerData?.cellCapacityTextPoints,
 									  mapControls: viewModel.mapControls) { annotations in
 					viewModel.handlePointedAnnotationsChange(annotations: annotations)
 				}

--- a/PresentationLayer/UIComponents/BaseComponents/SelectLocationMap/SelectLocationMapViewModel.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/SelectLocationMap/SelectLocationMapViewModel.swift
@@ -123,7 +123,7 @@ class SelectLocationMapViewModel: ObservableObject {
 
 	func handlePointedAnnotationsChange(annotations: [PolygonAnnotation]) {
 		latestPointedAnnotations = annotations
-		let capacityReached = isPointedCellCapaictyReached()
+		let capacityReached = isPointedCellCapacityReached()
 		
 		if capacityReached {
 			Toast.shared.show(text: LocalizableString.ClaimDevice.cellCapacityReachedMessage.localized.attributedMarkdown ?? "",
@@ -134,7 +134,7 @@ class SelectLocationMapViewModel: ObservableObject {
 		}
 	}
 
-	func isPointedCellCapaictyReached() -> Bool {
+	func isPointedCellCapacityReached() -> Bool {
 		guard let annotation = latestPointedAnnotations?.first,
 			  let count = annotation.userInfo?[ExplorerKeys.deviceCount.rawValue] as? Int,
 			  let capacity = annotation.userInfo?[ExplorerKeys.cellCapacity.rawValue] as? Int else {

--- a/PresentationLayer/UIComponents/MapBox/MapBoxClaimDevice.swift
+++ b/PresentationLayer/UIComponents/MapBox/MapBoxClaimDevice.swift
@@ -18,6 +18,7 @@ struct MapBoxClaimDeviceView: View {
 	@Binding var annotationTitle: String?
 	let geometryProxyForFrameOfMapView: CGRect
 	let polygonPoints: [PolygonAnnotation]?
+	let polylinePoints: [PolylineAnnotation]?
 	let textPoints: [PointAnnotation]?
 	let annotationPointCallback: GenericMainActorCallback<[PolygonAnnotation]>
 
@@ -30,6 +31,7 @@ struct MapBoxClaimDeviceView: View {
 		 annotationTitle: Binding<String?>,
 		 geometryProxyForFrameOfMapView: CGRect,
 		 polygonPoints: [PolygonAnnotation]?,
+		 polylinePoints: [PolylineAnnotation]?,
 		 textPoints: [PointAnnotation]?,
 		 mapControls: MapControls,
 		 annotationPointCallback: @escaping GenericMainActorCallback<[PolygonAnnotation]>) {
@@ -37,6 +39,7 @@ struct MapBoxClaimDeviceView: View {
 		_annotationTitle = annotationTitle
 		self.geometryProxyForFrameOfMapView = geometryProxyForFrameOfMapView
 		self.polygonPoints = polygonPoints
+		self.polylinePoints = polylinePoints
 		self.textPoints = textPoints
 		_controls = StateObject(wrappedValue: mapControls)
 		self.annotationPointCallback = annotationPointCallback
@@ -48,6 +51,7 @@ struct MapBoxClaimDeviceView: View {
 							  locationPoint: $locationPoint,
 							  geometryProxyForFrameOfMapView: geometryProxyForFrameOfMapView,
 							  polygonPoints: polygonPoints,
+							  polylinePoints: polylinePoints,
 							  textPoints: textPoints,
 							  controls: controls,
 							  annotationPointCallback: annotationPointCallback)
@@ -103,6 +107,7 @@ private struct MapBoxClaimDevice: UIViewControllerRepresentable {
 	@Binding var locationPoint: CGPoint
     let geometryProxyForFrameOfMapView: CGRect
 	let polygonPoints: [PolygonAnnotation]?
+	let polylinePoints: [PolylineAnnotation]?
 	let textPoints: [PointAnnotation]?
 	@StateObject var controls: MapControls
 	let annotationPointCallback: GenericMainActorCallback<[PolygonAnnotation]>
@@ -136,6 +141,7 @@ private struct MapBoxClaimDevice: UIViewControllerRepresentable {
     func updateUIViewController(_ controller: MapViewLocationController, context _: Context) {
 		controller.polygonManager?.annotations = polygonPoints ?? []
 		controller.pointManager?.annotations = textPoints ?? []
+		controller.polylineManager?.annotations = polylinePoints ?? []
     }
 
 	class Coordinator: MapViewLocationControllerDelegate {
@@ -172,6 +178,7 @@ class MapViewLocationController: UIViewController {
     internal var mapView: MapView!
 	internal weak var polygonManager: PolygonAnnotationManager?
 	internal weak var pointManager: PointAnnotationManager?
+	internal weak var polylineManager: PolylineAnnotationManager?
 	fileprivate weak var delegate: MapViewLocationControllerDelegate?
 	private var cancelablesSet = Set<AnyCancelable>()
 
@@ -303,9 +310,11 @@ extension MapViewLocationController {
 
 	func setPolygonManagers() {
 		self.polygonManager = mapView.annotations.makePolygonAnnotationManager(id: MapBoxConstants.cellCapacityPolygonManagerId)
+		self.polylineManager = mapView.annotations.makePolylineAnnotationManager(id: MapBoxConstants.bordersManagerId)
 
 		let pointAnnotationManager = mapView.annotations.makePointAnnotationManager(id: MapBoxConstants.pointManagerId)
 		pointManager = pointAnnotationManager
+
 		try? mapView.mapboxMap.updateLayer(withId: MapBoxConstants.pointManagerId, type: SymbolLayer.self) { layer in
 			layer.minZoom = 10
 
@@ -322,6 +331,5 @@ extension MapViewLocationController {
 			})
 			layer.textColor = .constant(StyleColor(UIColor(colorEnum: .textWhite)))
 		}
-
 	}
 }

--- a/PresentationLayer/UIComponents/MapBox/MapBoxClaimDevice.swift
+++ b/PresentationLayer/UIComponents/MapBox/MapBoxClaimDevice.swift
@@ -216,7 +216,7 @@ class MapViewLocationController: UIViewController {
 			}
 
 			self.locationPoint = self.mapView.mapboxMap.point(for: self.location)
-			self.upldateLocationPointedAnnotations(self.locationPoint)
+			self.updateLocationPointedAnnotations(self.locationPoint)
 		}.store(in: &cancelablesSet)
 
 		self.mapView.mapboxMap.onMapIdle.observe { [weak self] _ in
@@ -226,7 +226,7 @@ class MapViewLocationController: UIViewController {
 				if let self = self {
 					self.location = pointAnnotation.point.coordinates
 					self.locationPoint = mapView.mapboxMap.point(for: self.location)
-					self.upldateLocationPointedAnnotations(self.locationPoint)
+					self.updateLocationPointedAnnotations(self.locationPoint)
 				}
 			}
 		}.store(in: &cancelablesSet)
@@ -257,7 +257,7 @@ class MapViewLocationController: UIViewController {
         return CameraOptions(center: CLLocationCoordinate2D())
     }
 
-	func upldateLocationPointedAnnotations(_ point: CGPoint) {
+	func updateLocationPointedAnnotations(_ point: CGPoint) {
 		guard let polygonManager else {
 			return
 		}

--- a/PresentationLayer/UIComponents/MapBox/MapBoxClaimDevice.swift
+++ b/PresentationLayer/UIComponents/MapBox/MapBoxClaimDevice.swift
@@ -18,6 +18,7 @@ struct MapBoxClaimDeviceView: View {
 	@Binding var annotationTitle: String?
 	let geometryProxyForFrameOfMapView: CGRect
 	let polygonPoints: [PolygonAnnotation]?
+	let annotationPointCallback: GenericMainActorCallback<[PolygonAnnotation]>
 
 	private let markerSize: CGSize = CGSize(width: 44.0, height: 44.0)
 	@State private var locationPoint: CGPoint = .zero
@@ -28,12 +29,14 @@ struct MapBoxClaimDeviceView: View {
 		 annotationTitle: Binding<String?>,
 		 geometryProxyForFrameOfMapView: CGRect,
 		 polygonPoints: [PolygonAnnotation]?,
-		 mapControls: MapControls) {
+		 mapControls: MapControls,
+		 annotationPointCallback: @escaping GenericMainActorCallback<[PolygonAnnotation]>) {
 		_location = location
 		_annotationTitle = annotationTitle
 		self.geometryProxyForFrameOfMapView = geometryProxyForFrameOfMapView
 		self.polygonPoints = polygonPoints
 		_controls = StateObject(wrappedValue: mapControls)
+		self.annotationPointCallback = annotationPointCallback
 	}
 
 	var body: some View {
@@ -42,7 +45,8 @@ struct MapBoxClaimDeviceView: View {
 							  locationPoint: $locationPoint,
 							  geometryProxyForFrameOfMapView: geometryProxyForFrameOfMapView,
 							  polygonPoints: polygonPoints,
-							  controls: controls)
+							  controls: controls,
+							  annotationPointCallback: annotationPointCallback)
 
 			markerAnnotation
 				.offset(x: 0.0, y: markerAnnotationOffset)
@@ -95,10 +99,10 @@ private struct MapBoxClaimDevice: UIViewControllerRepresentable {
 	@Binding var locationPoint: CGPoint
     let geometryProxyForFrameOfMapView: CGRect
 	let polygonPoints: [PolygonAnnotation]?
-
 	@StateObject var controls: MapControls
+	let annotationPointCallback: GenericMainActorCallback<[PolygonAnnotation]>
 
-    func makeUIViewController(context _: Context) -> MapViewLocationController {
+    func makeUIViewController(context: Context) -> MapViewLocationController {
 		let controller = MapViewLocationController(frame: geometryProxyForFrameOfMapView,
 												   location: $location,
 												   locationPoint: $locationPoint)
@@ -115,18 +119,42 @@ private struct MapBoxClaimDevice: UIViewControllerRepresentable {
 			controller?.setCenter(coordinate)
 		}
 
+		controller.delegate = context.coordinator
+
 		return controller
     }
 
+	func makeCoordinator() -> Coordinator {
+		Coordinator(annotationPointCallback: annotationPointCallback)
+	}
+	
     func updateUIViewController(_ controller: MapViewLocationController, context _: Context) {
 		controller.polygonManager?.annotations = polygonPoints ?? []
     }
+
+	class Coordinator: MapViewLocationControllerDelegate {
+		let annotationPointCallback: GenericMainActorCallback<[PolygonAnnotation]>
+
+		init(annotationPointCallback: @escaping GenericMainActorCallback<[PolygonAnnotation]>) {
+			self.annotationPointCallback = annotationPointCallback
+		}
+
+		@MainActor
+		func didPointAnnotations(_ annotations: [PolygonAnnotation]) {
+			annotationPointCallback(annotations)
+		}
+	}
 }
 
 class MapControls: ObservableObject {
 	var zoomInAction: VoidCallback?
 	var zoomOutAction: VoidCallback?
 	var setMapCenter: GenericCallback<CLLocationCoordinate2D>?
+}
+
+@MainActor
+fileprivate protocol MapViewLocationControllerDelegate: AnyObject {
+	func didPointAnnotations(_ annotations: [PolygonAnnotation])
 }
 
 class MapViewLocationController: UIViewController {
@@ -138,6 +166,7 @@ class MapViewLocationController: UIViewController {
 	@Binding var locationPoint: CGPoint
     internal var mapView: MapView!
 	internal weak var polygonManager: PolygonAnnotationManager?
+	fileprivate weak var delegate: MapViewLocationControllerDelegate?
 	private var cancelablesSet = Set<AnyCancelable>()
 
     init(frame: CGRect,
@@ -170,6 +199,7 @@ class MapViewLocationController: UIViewController {
         mapView.ornaments.options.scaleBar.visibility = .hidden
         mapView.gestures.options.rotateEnabled = false
         mapView.gestures.options.pitchEnabled = false
+
 		mapView.mapboxMap.setCamera(to: CameraOptions(zoom: 2))
 		
 		mapView.translatesAutoresizingMaskIntoConstraints = false
@@ -186,6 +216,7 @@ class MapViewLocationController: UIViewController {
 			}
 
 			self.locationPoint = self.mapView.mapboxMap.point(for: self.location)
+			self.upldateLocationPointedAnnotations(self.locationPoint)
 		}.store(in: &cancelablesSet)
 
 		self.mapView.mapboxMap.onMapIdle.observe { [weak self] _ in
@@ -195,6 +226,7 @@ class MapViewLocationController: UIViewController {
 				if let self = self {
 					self.location = pointAnnotation.point.coordinates
 					self.locationPoint = mapView.mapboxMap.point(for: self.location)
+					self.upldateLocationPointedAnnotations(self.locationPoint)
 				}
 			}
 		}.store(in: &cancelablesSet)
@@ -224,6 +256,37 @@ class MapViewLocationController: UIViewController {
     internal func cameraSetup() -> CameraOptions {
         return CameraOptions(center: CLLocationCoordinate2D())
     }
+
+	func upldateLocationPointedAnnotations(_ point: CGPoint) {
+		guard let polygonManager else {
+			return
+		}
+		let layerIds = [polygonManager.layerId]
+		let annotations = polygonManager.annotations
+		let options = RenderedQueryOptions(layerIds: layerIds, filter: nil)
+		mapView.mapboxMap.queryRenderedFeatures(with: point, options: options) { [weak self] result in
+			switch result {
+				case .success(let features):
+					let tappedAnnotations = annotations.filter { annotation in
+						features.contains(where: { feature in
+							guard let featureid = feature.queriedFeature.feature.identifier else {
+								return false
+							}
+							switch featureid {
+								case .string(let str):
+									return annotation.id == str
+								case .number(_):
+									return false
+							}
+						})
+					}
+
+					self?.delegate?.didPointAnnotations(tappedAnnotations)
+				case .failure(let error):
+					print(error)
+			}
+		}
+	}
 }
 
 extension MapViewLocationController {

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/Location/ClaimDeviceLocationViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/Location/ClaimDeviceLocationViewModel.swift
@@ -30,7 +30,7 @@ class ClaimDeviceLocationViewModel: ObservableObject {
 			return
 		}
 
-		if locationViewModel.isPointedCellCapaictyReached() {
+		if locationViewModel.isPointedCellCapacityReached() {
 			let okAction: AlertHelper.AlertObject.Action = (LocalizableString.ClaimDevice.relocate.localized, { _ in })
 			let obj: AlertHelper.AlertObject = .init(title: LocalizableString.ClaimDevice.cellCapacityReachedAlertTitle.localized,
 													 message: LocalizableString.ClaimDevice.cellCapacityReachedMessage.localized,

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/Location/ClaimDeviceLocationViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/Location/ClaimDeviceLocationViewModel.swift
@@ -31,11 +31,11 @@ class ClaimDeviceLocationViewModel: ObservableObject {
 		}
 
 		if locationViewModel.isPointedCellCapacityReached() {
-			let okAction: AlertHelper.AlertObject.Action = (LocalizableString.ClaimDevice.relocate.localized, { _ in })
+			let okAction: AlertHelper.AlertObject.Action = (LocalizableString.ClaimDevice.proceedAnyway.localized, { [weak self] _ in self?.completion(selectedLocation) })
 			let obj: AlertHelper.AlertObject = .init(title: LocalizableString.ClaimDevice.cellCapacityReachedAlertTitle.localized,
 													 message: LocalizableString.ClaimDevice.cellCapacityReachedMessage.localized,
-													 cancelActionTitle: LocalizableString.ClaimDevice.proceedAnyway.localized,
-													 cancelAction: { [weak self] in self?.completion(selectedLocation) },
+													 cancelActionTitle: LocalizableString.ClaimDevice.relocate.localized,
+													 cancelAction: {  },
 													 okAction: okAction)
 
 			AlertHelper().showAlert(obj)

--- a/PresentationLayer/UIComponents/Screens/ClaimDevice/Location/ClaimDeviceLocationViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/ClaimDevice/Location/ClaimDeviceLocationViewModel.swift
@@ -29,6 +29,20 @@ class ClaimDeviceLocationViewModel: ObservableObject {
 		guard let selectedLocation else {
 			return
 		}
+
+		if locationViewModel.isPointedCellCapaictyReached() {
+			let okAction: AlertHelper.AlertObject.Action = (LocalizableString.ClaimDevice.relocate.localized, { _ in })
+			let obj: AlertHelper.AlertObject = .init(title: LocalizableString.ClaimDevice.cellCapacityReachedAlertTitle.localized,
+													 message: LocalizableString.ClaimDevice.cellCapacityReachedMessage.localized,
+													 cancelActionTitle: LocalizableString.ClaimDevice.proceedAnyway.localized,
+													 cancelAction: { [weak self] in self?.completion(selectedLocation) },
+													 okAction: okAction)
+
+			AlertHelper().showAlert(obj)
+
+			return
+		}
+
 		completion(selectedLocation)
 	}
 }

--- a/PresentationLayer/UIComponents/Screens/Explorer/ExplorerData.swift
+++ b/PresentationLayer/UIComponents/Screens/Explorer/ExplorerData.swift
@@ -21,6 +21,7 @@ struct ExplorerData: Equatable {
 	let coloredPolygonPoints: [PolygonAnnotation]
 	let textPoints: [PointAnnotation]
 	let cellCapacityPoints: [PolygonAnnotation]
+	let cellBorderPoints: [PolylineAnnotation]
 	let	cellCapacityTextPoints: [PointAnnotation]
 
     init() {
@@ -30,6 +31,7 @@ struct ExplorerData: Equatable {
 		self.coloredPolygonPoints = []
 		self.textPoints = []
 		self.cellCapacityPoints = []
+		self.cellBorderPoints = []
 		self.cellCapacityTextPoints = []
     }
 
@@ -39,6 +41,7 @@ struct ExplorerData: Equatable {
 		 coloredPolygonPoints: [PolygonAnnotation],
 		 textPoints: [PointAnnotation],
 		 cellCapacityPoints: [PolygonAnnotation],
+		 cellBorderPoints: [PolylineAnnotation],
 		 cellCapacityTextPoints: [PointAnnotation]
 	) {
         self.totalDevices = totalDevices
@@ -47,6 +50,7 @@ struct ExplorerData: Equatable {
 		self.coloredPolygonPoints = coloredPolygonPoints
 		self.textPoints = textPoints
 		self.cellCapacityPoints = cellCapacityPoints
+		self.cellBorderPoints = cellBorderPoints
 		self.cellCapacityTextPoints = cellCapacityTextPoints
     }
 }

--- a/PresentationLayer/UIComponents/Screens/Explorer/ExplorerData.swift
+++ b/PresentationLayer/UIComponents/Screens/Explorer/ExplorerData.swift
@@ -20,6 +20,7 @@ struct ExplorerData: Equatable {
     let polygonPoints: [PolygonAnnotation]
 	let coloredPolygonPoints: [PolygonAnnotation]
 	let textPoints: [PointAnnotation]
+	let cellCapacityPoints: [PolygonAnnotation]
 
     init() {
         self.totalDevices = 0
@@ -27,17 +28,21 @@ struct ExplorerData: Equatable {
         self.polygonPoints = []
 		self.coloredPolygonPoints = []
 		self.textPoints = []
+		self.cellCapacityPoints = []
     }
 
     init(totalDevices: Int,
 		 geoJsonSource: GeoJSONSource,
 		 polygonPoints: [PolygonAnnotation],
 		 coloredPolygonPoints: [PolygonAnnotation],
-		 textPoints: [PointAnnotation]) {
+		 textPoints: [PointAnnotation],
+		 cellCapacityPoints: [PolygonAnnotation]
+	) {
         self.totalDevices = totalDevices
         self.geoJsonSource = geoJsonSource
         self.polygonPoints = polygonPoints
 		self.coloredPolygonPoints = coloredPolygonPoints
 		self.textPoints = textPoints
+		self.cellCapacityPoints = cellCapacityPoints
     }
 }

--- a/PresentationLayer/UIComponents/Screens/Explorer/ExplorerData.swift
+++ b/PresentationLayer/UIComponents/Screens/Explorer/ExplorerData.swift
@@ -21,6 +21,7 @@ struct ExplorerData: Equatable {
 	let coloredPolygonPoints: [PolygonAnnotation]
 	let textPoints: [PointAnnotation]
 	let cellCapacityPoints: [PolygonAnnotation]
+	let	cellCapacityTextPoints: [PointAnnotation]
 
     init() {
         self.totalDevices = 0
@@ -29,6 +30,7 @@ struct ExplorerData: Equatable {
 		self.coloredPolygonPoints = []
 		self.textPoints = []
 		self.cellCapacityPoints = []
+		self.cellCapacityTextPoints = []
     }
 
     init(totalDevices: Int,
@@ -36,7 +38,8 @@ struct ExplorerData: Equatable {
 		 polygonPoints: [PolygonAnnotation],
 		 coloredPolygonPoints: [PolygonAnnotation],
 		 textPoints: [PointAnnotation],
-		 cellCapacityPoints: [PolygonAnnotation]
+		 cellCapacityPoints: [PolygonAnnotation],
+		 cellCapacityTextPoints: [PointAnnotation]
 	) {
         self.totalDevices = totalDevices
         self.geoJsonSource = geoJsonSource
@@ -44,5 +47,6 @@ struct ExplorerData: Equatable {
 		self.coloredPolygonPoints = coloredPolygonPoints
 		self.textPoints = textPoints
 		self.cellCapacityPoints = cellCapacityPoints
+		self.cellCapacityTextPoints = cellCapacityTextPoints
     }
 }

--- a/PresentationLayer/UIComponents/Screens/Explorer/ExplorerFactory.swift
+++ b/PresentationLayer/UIComponents/Screens/Explorer/ExplorerFactory.swift
@@ -14,6 +14,7 @@ enum ExplorerKeys: String {
 	case deviceCount = "device_count"
 	case cellIndex = "cell_index"
 	case cellCenter = "cell_center"
+	case cellCapacity = "cell_capacity"
 }
 
 @MainActor
@@ -70,7 +71,8 @@ struct ExplorerFactory {
 			polygonAnnotation.userInfo = [ExplorerKeys.cellCenter.rawValue: CLLocationCoordinate2D(latitude: publicHex.center.lat,
 																								   longitude: publicHex.center.lon),
 										  ExplorerKeys.cellIndex.rawValue: publicHex.index,
-										  ExplorerKeys.deviceCount.rawValue: publicHex.deviceCount ?? 0]
+										  ExplorerKeys.deviceCount.rawValue: publicHex.deviceCount ?? 0,
+										  ExplorerKeys.cellCapacity.rawValue: publicHex.capacity as Any]
 			polygonPoints.append(polygonAnnotation)
 			
 			var coloredAnnotation = polygonAnnotation

--- a/PresentationLayer/UIComponents/Screens/Explorer/ExplorerFactory.swift
+++ b/PresentationLayer/UIComponents/Screens/Explorer/ExplorerFactory.swift
@@ -48,6 +48,7 @@ struct ExplorerFactory {
 		var coloredPolygonPoints: [PolygonAnnotation] = []
 		var cellCapacityPolygonPoints: [PolygonAnnotation] = []
 		var textPoints: [PointAnnotation] = []
+		var cellCapacityPolylinePoints: [PolylineAnnotation] = []
 		var cellCapacityTextPoints: [PointAnnotation] = []
 		publicHexes.forEach { publicHex in
 			totalDevices += publicHex.deviceCount ?? 0
@@ -97,6 +98,11 @@ struct ExplorerFactory {
 				pointAnnotation.textField = "\(deviceCount)/\(capacity)"
 				cellCapacityTextPoints.append(pointAnnotation)
 			}
+
+			var polylineAnnotation = PolylineAnnotation(id: publicHex.index, lineCoordinates: ringCords)
+			polylineAnnotation.lineWidth = 2.0
+			polylineAnnotation.lineColor = capacityReached ? cellCapacityReachedFillOutlineColor : cellCapacityFillOutlineColor
+			cellCapacityPolylinePoints.append(polylineAnnotation)
 		}
 
 
@@ -106,6 +112,7 @@ struct ExplorerFactory {
 										coloredPolygonPoints: coloredPolygonPoints,
 										textPoints: textPoints,
 										cellCapacityPoints: cellCapacityPolygonPoints,
+										cellBorderPoints: cellCapacityPolylinePoints,
 										cellCapacityTextPoints: cellCapacityTextPoints)
 
 		return explorerData

--- a/PresentationLayer/UIComponents/Screens/Explorer/ExplorerFactory.swift
+++ b/PresentationLayer/UIComponents/Screens/Explorer/ExplorerFactory.swift
@@ -48,6 +48,7 @@ struct ExplorerFactory {
 		var coloredPolygonPoints: [PolygonAnnotation] = []
 		var cellCapacityPolygonPoints: [PolygonAnnotation] = []
 		var textPoints: [PointAnnotation] = []
+		var cellCapacityTextPoints: [PointAnnotation] = []
 		publicHexes.forEach { publicHex in
 			totalDevices += publicHex.deviceCount ?? 0
 			var ringCords = publicHex.polygon.map { point in
@@ -91,6 +92,11 @@ struct ExplorerFactory {
 				pointAnnotation.textField = "\(deviceCount)"
 			}
 			textPoints.append(pointAnnotation)
+
+			if let deviceCount = publicHex.deviceCount, let capacity = publicHex.capacity {
+				pointAnnotation.textField = "\(deviceCount)/\(capacity)"
+				cellCapacityTextPoints.append(pointAnnotation)
+			}
 		}
 
 
@@ -99,7 +105,8 @@ struct ExplorerFactory {
 										polygonPoints: polygonPoints,
 										coloredPolygonPoints: coloredPolygonPoints,
 										textPoints: textPoints,
-										cellCapacityPoints: cellCapacityPolygonPoints)
+										cellCapacityPoints: cellCapacityPolygonPoints,
+										cellCapacityTextPoints: cellCapacityTextPoints)
 
 		return explorerData
 	}

--- a/PresentationLayer/UIComponents/Screens/Explorer/ExplorerFactory.swift
+++ b/PresentationLayer/UIComponents/Screens/Explorer/ExplorerFactory.swift
@@ -22,7 +22,11 @@ struct ExplorerFactory {
 	private let fillOpacity = 0.5
 	private let fillColor = StyleColor(UIColor(colorEnum: .explorerPolygon))
 	private let fillOutlineColor = StyleColor(UIColor.white)
-
+	private let cellCapacityFillOpacity = 0.2
+	private let cellCapacityFillColor = StyleColor(UIColor(colorEnum: .wxmPrimary))
+	private let cellCapacityFillOutlineColor = StyleColor(UIColor(colorEnum: .wxmPrimary))
+	private let cellCapacityReachedFillColor = StyleColor(UIColor(colorEnum: .error))
+	private let cellCapacityReachedFillOutlineColor = StyleColor(UIColor(colorEnum: .error))
 
 	func generateExplorerData() -> ExplorerData {
 		var geoJsonSource = GeoJSONSource(id: "heatmap")
@@ -41,6 +45,7 @@ struct ExplorerFactory {
 		var totalDevices = 0
 		var polygonPoints: [PolygonAnnotation] = []
 		var coloredPolygonPoints: [PolygonAnnotation] = []
+		var cellCapacityPolygonPoints: [PolygonAnnotation] = []
 		var textPoints: [PointAnnotation] = []
 		publicHexes.forEach { publicHex in
 			totalDevices += publicHex.deviceCount ?? 0
@@ -72,6 +77,13 @@ struct ExplorerFactory {
 			coloredAnnotation.fillColor = StyleColor(UIColor(colorEnum: publicHex.averageDataQuality?.rewardScoreColor ?? .darkGrey))
 			coloredPolygonPoints.append(coloredAnnotation)
 
+			var cellCapacityAnnotation = polygonAnnotation
+			let capacityReached = publicHex.cellCapacityReached
+			cellCapacityAnnotation.fillColor = capacityReached ? cellCapacityReachedFillColor : cellCapacityFillColor
+			cellCapacityAnnotation.fillOpacity = cellCapacityFillOpacity
+			cellCapacityAnnotation.fillOutlineColor = capacityReached ? cellCapacityReachedFillOutlineColor : cellCapacityFillOutlineColor
+			cellCapacityPolygonPoints.append(cellCapacityAnnotation)
+
 			var pointAnnotation = PointAnnotation(point: .init(.init(latitude: publicHex.center.lat, longitude: publicHex.center.lon)))
 			if let deviceCount = publicHex.deviceCount, deviceCount > 0 {
 				pointAnnotation.textField = "\(deviceCount)"
@@ -84,7 +96,8 @@ struct ExplorerFactory {
 										geoJsonSource: geoJsonSource,
 										polygonPoints: polygonPoints,
 										coloredPolygonPoints: coloredPolygonPoints,
-										textPoints: textPoints)
+										textPoints: textPoints,
+										cellCapacityPoints: cellCapacityPolygonPoints)
 
 		return explorerData
 	}

--- a/PresentationLayer/UIComponents/Screens/SelectStationLocation/SelectStationLocationViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/SelectStationLocation/SelectStationLocationViewModel.swift
@@ -51,11 +51,11 @@ class SelectStationLocationViewModel: ObservableObject {
 		}
 
 		if locationViewModel.isPointedCellCapacityReached() {
-			let okAction: AlertHelper.AlertObject.Action = (LocalizableString.ClaimDevice.relocate.localized, { _ in })
+			let okAction: AlertHelper.AlertObject.Action = (LocalizableString.ClaimDevice.proceedAnyway.localized, { [weak self] _ in self?.setLocation() })
 			let obj: AlertHelper.AlertObject = .init(title: LocalizableString.ClaimDevice.cellCapacityReachedAlertTitle.localized,
 													 message: LocalizableString.ClaimDevice.cellCapacityReachedMessage.localized,
-													 cancelActionTitle: LocalizableString.ClaimDevice.proceedAnyway.localized,
-													 cancelAction: { [weak self] in self?.setLocation() },
+													 cancelActionTitle: LocalizableString.ClaimDevice.relocate.localized,
+													 cancelAction: { },
 													 okAction: okAction)
 
 			AlertHelper().showAlert(obj)

--- a/PresentationLayer/UIComponents/Screens/SelectStationLocation/SelectStationLocationViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/SelectStationLocation/SelectStationLocationViewModel.swift
@@ -50,7 +50,7 @@ class SelectStationLocationViewModel: ObservableObject {
 			return
 		}
 
-		if locationViewModel.isPointedCellCapaictyReached() {
+		if locationViewModel.isPointedCellCapacityReached() {
 			let okAction: AlertHelper.AlertObject.Action = (LocalizableString.ClaimDevice.relocate.localized, { _ in })
 			let obj: AlertHelper.AlertObject = .init(title: LocalizableString.ClaimDevice.cellCapacityReachedAlertTitle.localized,
 													 message: LocalizableString.ClaimDevice.cellCapacityReachedMessage.localized,

--- a/PresentationLayer/UIComponents/Screens/SelectStationLocation/SelectStationLocationViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/SelectStationLocation/SelectStationLocationViewModel.swift
@@ -50,6 +50,19 @@ class SelectStationLocationViewModel: ObservableObject {
 			return
 		}
 
+		if locationViewModel.isPointedCellCapaictyReached() {
+			let okAction: AlertHelper.AlertObject.Action = (LocalizableString.ClaimDevice.relocate.localized, { _ in })
+			let obj: AlertHelper.AlertObject = .init(title: LocalizableString.ClaimDevice.cellCapacityReachedAlertTitle.localized,
+													 message: LocalizableString.ClaimDevice.cellCapacityReachedMessage.localized,
+													 cancelActionTitle: LocalizableString.ClaimDevice.proceedAnyway.localized,
+													 cancelAction: { [weak self] in self?.setLocation() },
+													 okAction: okAction)
+
+			AlertHelper().showAlert(obj)
+
+			return
+		}
+
 		setLocation()
 	}
 }

--- a/PresentationLayer/UIComponents/ViewModelsFactory.swift
+++ b/PresentationLayer/UIComponents/ViewModelsFactory.swift
@@ -307,7 +307,8 @@ enum ViewModelsFactory {
 
 	static func getLocationMapViewModel(initialCoordinate: CLLocationCoordinate2D? = nil) -> SelectLocationMapViewModel {
 		let useCase = SwinjectHelper.shared.getContainerForSwinject().resolve(DeviceLocationUseCaseApi.self)!
-		return SelectLocationMapViewModel(useCase: useCase, initialCoordinate: initialCoordinate)
+		let exlporerUseCase = SwinjectHelper.shared.getContainerForSwinject().resolve(ExplorerUseCaseApi.self)!
+		return SelectLocationMapViewModel(useCase: useCase, explorerUseCase: exlporerUseCase, initialCoordinate: initialCoordinate)
 	}
 
 	static func getClaimDeviceLocationViewModel(completion: @escaping GenericCallback<DeviceLocation>) -> ClaimDeviceLocationViewModel {

--- a/PresentationLayer/Utils/MapBox/MapBoxConstants.swift
+++ b/PresentationLayer/Utils/MapBox/MapBoxConstants.swift
@@ -16,6 +16,7 @@ enum MapBoxConstants {
 	static let snapshotMarkerName = "marker"
 	static let polygonManagerId = "wtxm-polygon-annotation-manager"
 	static let coloredPolygonManagerId = "wtxm-colored-polygon-annotation-manager"
+	static let cellCapacityPolygonManagerId = "wtxm-cell-capacity-polygon-annotation-manager"
 	static let initialLat = 37.98075475244475
 	static let initialLon = 23.710478235562956
 	static let heatmapLayerId = "wtxm-heatmap-layer"

--- a/PresentationLayer/Utils/MapBox/MapBoxConstants.swift
+++ b/PresentationLayer/Utils/MapBox/MapBoxConstants.swift
@@ -21,6 +21,7 @@ enum MapBoxConstants {
 	static let initialLon = 23.710478235562956
 	static let heatmapLayerId = "wtxm-heatmap-layer"
 	static let pointManagerId = "wtxm-point-annotation-manager"
+	static let bordersManagerId = "wtxm-borders-annotation-manager"
 	static let heatmapSource = "heatmap"
 
 	static var styleURI: StyleURI {

--- a/wxm-ios.xcodeproj/project.pbxproj
+++ b/wxm-ios.xcodeproj/project.pbxproj
@@ -369,6 +369,7 @@
 		267EC4292A98C3D300F2C37E /* WXMAlertModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267EC4272A98C3D300F2C37E /* WXMAlertModifier.swift */; };
 		267EC42A2A98C3D300F2C37E /* WXMAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267EC4282A98C3D300F2C37E /* WXMAlertView.swift */; };
 		268028AA2AF298290031379C /* Indication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268028A92AF298290031379C /* Indication.swift */; };
+		26862DD22E86CBD000B56C21 /* PublicHex+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26862DCE2E86CBBF00B56C21 /* PublicHex+.swift */; };
 		268645982A6FA7C100EB85B1 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268645972A6FA7C100EB85B1 /* Router.swift */; };
 		268B5C372BCE7CF900E63655 /* NavigationTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268B5C362BCE7CF900E63655 /* NavigationTitleView.swift */; };
 		268B5C3A2BCE808200E63655 /* ForecastDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268B5C392BCE808200E63655 /* ForecastDetailsView.swift */; };
@@ -1157,6 +1158,7 @@
 		267EC4282A98C3D300F2C37E /* WXMAlertView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WXMAlertView.swift; sourceTree = "<group>"; };
 		267EDF5F2B67B5AC00C221B1 /* ci_post_xcodebuild.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_xcodebuild.sh; sourceTree = "<group>"; };
 		268028A92AF298290031379C /* Indication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Indication.swift; sourceTree = "<group>"; };
+		26862DCE2E86CBBF00B56C21 /* PublicHex+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PublicHex+.swift"; sourceTree = "<group>"; };
 		268645972A6FA7C100EB85B1 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		268B5C362BCE7CF900E63655 /* NavigationTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationTitleView.swift; sourceTree = "<group>"; };
 		268B5C392BCE808200E63655 /* ForecastDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForecastDetailsView.swift; sourceTree = "<group>"; };
@@ -2553,6 +2555,7 @@
 				2672B87B2C89F19A002266BE /* BoostCode+.swift */,
 				2672B87D2C8A0155002266BE /* NetworkDeviceRewardsResponse+.swift */,
 				269EC1682E327EE60099DB78 /* StationAlert+.swift */,
+				26862DCE2E86CBBF00B56C21 /* PublicHex+.swift */,
 			);
 			path = DomainExtensions;
 			sourceTree = "<group>";
@@ -4229,6 +4232,7 @@
 				267548DE29A91A87008BCF40 /* FailAPICodeEnum.swift in Sources */,
 				267547BF29A9181E008BCF40 /* FailedDeleteView.swift in Sources */,
 				26ACE8C72C86015300EA22DD /* LocalizableString+RewardAnalytics.swift in Sources */,
+				26862DD22E86CBD000B56C21 /* PublicHex+.swift in Sources */,
 				260F8E552E2FC06700CBAEB2 /* ClaimDevicePhotosManager.swift in Sources */,
 				26A4118A29BA21E600A2C10B /* FailSuccessStateObject.swift in Sources */,
 				2645823B2A41C07000195C21 /* FailSuccessViewModifier.swift in Sources */,

--- a/wxm-ios/DataLayer/DataLayer.xcodeproj/project.pbxproj
+++ b/wxm-ios/DataLayer/DataLayer.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		267EC3BF2CD0ECE60085B50A /* Pulse in Frameworks */ = {isa = PBXBuildFile; productRef = 267EC3BE2CD0ECE60085B50A /* Pulse */; };
 		267EC3C12CD0ECE60085B50A /* PulseProxy in Frameworks */ = {isa = PBXBuildFile; productRef = 267EC3C02CD0ECE60085B50A /* PulseProxy */; };
 		2683A4C42ADECF3100D5C205 /* countries_information.json in Resources */ = {isa = PBXBuildFile; fileRef = 2683A4C32ADECBA800D5C205 /* countries_information.json */; };
+		26862DD42E8ACCC300B56C21 /* ExplorerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26862DD32E8ACCBB00B56C21 /* ExplorerService.swift */; };
 		268ACD052C1B2A3500B30F83 /* DBBundle+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268ACD032C1B2A3500B30F83 /* DBBundle+CoreDataClass.swift */; };
 		268ACD062C1B2A3500B30F83 /* DBBundle+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268ACD042C1B2A3500B30F83 /* DBBundle+CoreDataProperties.swift */; };
 		2692D88B2A4DB2B50060CB3C /* DBExplorerAddress+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2692D8852A4DB2B50060CB3C /* DBExplorerAddress+CoreDataClass.swift */; };
@@ -150,6 +151,7 @@
 		267CA6EE2C1314E200ABE599 /* get_user.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = get_user.json; sourceTree = "<group>"; };
 		267EC3BB2CD0E8BD0085B50A /* MainRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainRepositoryImpl.swift; sourceTree = "<group>"; };
 		2683A4C32ADECBA800D5C205 /* countries_information.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = countries_information.json; sourceTree = "<group>"; };
+		26862DD32E8ACCBB00B56C21 /* ExplorerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplorerService.swift; sourceTree = "<group>"; };
 		268ACD032C1B2A3500B30F83 /* DBBundle+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBBundle+CoreDataClass.swift"; sourceTree = "<group>"; };
 		268ACD042C1B2A3500B30F83 /* DBBundle+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBBundle+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		2692D8852A4DB2B50060CB3C /* DBExplorerAddress+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBExplorerAddress+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -315,6 +317,7 @@
 				26AB9F512A80112900855912 /* UserDevicesService.swift */,
 				262B02F72B1F3B5300C31FE7 /* UserInfoService.swift */,
 				26C71CDB2D27D89300D2F0F3 /* FileUploaderService.swift */,
+				26862DD32E8ACCBB00B56C21 /* ExplorerService.swift */,
 			);
 			name = Services;
 			path = ..;
@@ -657,6 +660,7 @@
 				2692D88E2A4DB2B50060CB3C /* DBExplorerSearchEntity+CoreDataProperties.swift in Sources */,
 				26E88B3729E586B00023BBD5 /* DBProtocols.swift in Sources */,
 				26E88B3429E582070023BBD5 /* DBWeather+CoreDataClass.swift in Sources */,
+				26862DD42E8ACCC300B56C21 /* ExplorerService.swift in Sources */,
 				26E88B3529E582070023BBD5 /* DBWeather+CoreDataProperties.swift in Sources */,
 				26A4117829B8973E00A2C10B /* DeviceInfoRepositoryImpl.swift in Sources */,
 				7480AF562835098A002758C3 /* DevicesApiRequestBuilder.swift in Sources */,

--- a/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/ExplorerRepositoryImpl.swift
+++ b/wxm-ios/DataLayer/DataLayer/RepositoryImplementations/ExplorerRepositoryImpl.swift
@@ -13,8 +13,11 @@ import Toolkit
 
 public struct ExplorerRepositoryImpl: ExplorerRepository {
     private let locationManager = WXMLocationManager()
+	private let service: ExplorerService
 
-    public init() {}
+	public init(service: ExplorerService) {
+		self.service = service
+	}
 
     public func getUserLocation() async -> Result<CLLocationCoordinate2D, ExplorerLocationError> {
         let res = await locationManager.getUserLocation()
@@ -32,9 +35,7 @@ public struct ExplorerRepositoryImpl: ExplorerRepository {
 	}
 	
     public func getPublicHexes() throws -> AnyPublisher<DataResponse<[PublicHex], NetworkErrorResponse>, Never> {
-		let builder = CellRequestBuilder.getCells
-		let urlRequest = try builder.asURLRequest()
-		return ApiClient.shared.requestCodable(urlRequest, mockFileName: builder.mockFileName)
+		try service.getPublicHexes()
     }
 
     public func getPublicDevicesOfHex(index: String) throws -> AnyPublisher<DataResponse<[PublicDevice], NetworkErrorResponse>, Never> {

--- a/wxm-ios/DataLayer/ExplorerService.swift
+++ b/wxm-ios/DataLayer/ExplorerService.swift
@@ -1,0 +1,49 @@
+//
+//  ExplorerService.swift
+//  DataLayer
+//
+//  Created by Pantelis Giazitsis on 29/9/25.
+//
+
+import Foundation
+import DomainLayer
+import Combine
+import Alamofire
+import Toolkit
+
+public class ExplorerService {
+	private let cacheValidationInterval: TimeInterval = 3.0 * 60.0 // 3 minutes
+	private let cache: TimeValidationCache<[PublicHex]>
+	private let cacheKey = UserDefaults.GenericKey.explorerHexes.rawValue
+
+	public init(cacheManager: PersistCacheManager) {
+		self.cache = .init(persistCacheManager: cacheManager, persistKey: cacheKey)
+	}
+
+	func getPublicHexes() throws -> AnyPublisher<DataResponse<[PublicHex], NetworkErrorResponse>, Never> {
+		if let cachedValue: [PublicHex] = cache.getCachedValue(for: cacheKey) {
+			let response: DataResponse<[PublicHex], NetworkErrorResponse> = .init(request: nil,
+																				  response: nil,
+																				  data: nil,
+																				  metrics: nil,
+																				  serializationDuration: 0.0,
+																				  result: .success(cachedValue))
+			return Just(response).eraseToAnyPublisher()
+		}
+
+		let builder = CellRequestBuilder.getCells
+		let urlRequest = try builder.asURLRequest()
+		let publisher: AnyPublisher<DataResponse<[PublicHex], NetworkErrorResponse>, Never> = ApiClient.shared.requestCodable(urlRequest, mockFileName: builder.mockFileName)
+		return publisher.flatMap { [weak self] response in
+			guard let self else {
+				return Just(response)
+			}
+
+			if let value = response.value {
+				self.cache.insertValue(value, expire: self.cacheValidationInterval, for: self.cacheKey)
+			}
+
+			return Just(response)
+		}.eraseToAnyPublisher()
+	}
+}

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Cells/PublicHex.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Cells/PublicHex.swift
@@ -7,6 +7,7 @@
 
 public struct PublicHex: Codable, Sendable, Equatable {
     public var index: String = ""
+	public var capacity: Int?
     public var deviceCount: Int?
 	public var activeDeviceCount: Int?
 	public var averageDataQuality: Int?
@@ -15,6 +16,7 @@ public struct PublicHex: Codable, Sendable, Equatable {
 
     enum CodingKeys: String, CodingKey {
         case index
+		case capacity
         case deviceCount = "device_count"
 		case activeDeviceCount = "active_device_count"
 		case averageDataQuality = "avg_data_quality"
@@ -22,8 +24,15 @@ public struct PublicHex: Codable, Sendable, Equatable {
         case polygon
     }
 
-	init(index: String = "", deviceCount: Int? = nil, activeDeviceCount: Int? = nil, averageDataQuality: Int? = nil, center: HexLocation = .init(), polygon: [HexLocation] = []) {
+	init(index: String = "",
+		 capacity: Int? = nil,
+		 deviceCount: Int? = nil,
+		 activeDeviceCount: Int? = nil,
+		 averageDataQuality: Int? = nil,
+		 center: HexLocation = .init(),
+		 polygon: [HexLocation] = []) {
 		self.index = index
+		self.capacity = capacity
 		self.deviceCount = deviceCount
 		self.activeDeviceCount = activeDeviceCount
 		self.averageDataQuality = averageDataQuality
@@ -34,6 +43,7 @@ public struct PublicHex: Codable, Sendable, Equatable {
 	public init(from decoder: any Decoder) throws {
 		let container = try decoder.container(keyedBy: CodingKeys.self)
 		self.index = try container.decode(String.self, forKey: .index)
+		self.capacity = try container.decodeIfPresent(Int.self, forKey: .capacity)
 		self.deviceCount = try container.decodeIfPresent(Int.self, forKey: .deviceCount)
 		self.activeDeviceCount = try container.decodeIfPresent(Int.self, forKey: .activeDeviceCount)
 		self.averageDataQuality = try? container.decodeIfPresent(Int.self, forKey: .averageDataQuality)

--- a/wxm-ios/DomainLayer/DomainLayer/Extensions/UserDefaults+Constants.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Extensions/UserDefaults+Constants.swift
@@ -52,6 +52,7 @@ public extension UserDefaults {
 		case savedLocations = "com.weatherxm.app.UserDefaults.Key.SavedLocations"
 		case savedForecasts = "com.weatherxm.app.UserDefaults.Key.SavedForecasts"
 		case onboardingIsShown = "com.weatherxm.app.UserDefaults.Key.OnboardingIsShown"
+		case explorerHexes = "com.weatherxm.app.UserDefaults.Key.ExplorerHexes"
 
         // MARK: - UserDefaultEntry
 

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -792,6 +792,17 @@
         }
       }
     },
+    "claim_device_cell_capacity_reached_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cell already at max capacity. New stations may not be eligible for rewards."
+          }
+        }
+      }
+    },
     "claim_device_claim_d1_title" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -8103,6 +8114,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rate"
+          }
+        }
+      }
+    },
+    "read_more" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Read More"
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -792,6 +792,28 @@
         }
       }
     },
+    "claim_device_cell_capacity_reached_alert_text" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This cell has already reached its station limit based on its geospatial capacity. Only the top-ranked stations in this cell, determined by reward score and seniority, are eligible for rewards.\nIf you deploy here and your station ranks below the capacity threshold, it won’t receive any rewards.\nFor example, in a cell with a capacity of 5 stations, only the top 5 ranked devices are rewarded.\nTo maximize your earnings, consider deploying in a cell with available capacity."
+          }
+        }
+      }
+    },
+    "claim_device_cell_capacity_reached_alert_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Watch out!"
+          }
+        }
+      }
+    },
     "claim_device_cell_capacity_reached_message" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1804,6 +1826,17 @@
         }
       }
     },
+    "claim_device_proceed_anyway" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proceed anyway"
+          }
+        }
+      }
+    },
     "claim_device_pulse_title" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1811,6 +1844,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pulse | 4G"
+          }
+        }
+      }
+    },
+    "claim_device_relocate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relocate"
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/LocalizableConstants.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableConstants.swift
@@ -194,6 +194,7 @@ enum LocalizableString: WXMLocalizable {
 	case myStations
 	case explorer
 	case profile
+	case readMore
 
 	var localized: String {
 		var localized = NSLocalizedString(self.key, comment: "")
@@ -604,6 +605,8 @@ extension LocalizableString {
 				return "explorer"
 			case .profile:
 				return "profile"
+			case .readMore:
+				return "read_more"
 		}
 	}
 }

--- a/wxm-ios/Resources/Localizable/LocalizableString+ClaimDevice.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+ClaimDevice.swift
@@ -166,6 +166,7 @@ extension LocalizableString {
 		case photoVerificationText
 		case uploadAndClaim
 		case uploadAndProceed
+		case cellCapacityReachedMessage
 	}
 }
 
@@ -508,6 +509,8 @@ extension LocalizableString.ClaimDevice: WXMLocalizable {
 				return "claim_device_upload_and_claim"
 			case .uploadAndProceed:
 				return "claim_device_upload_and_proceed"
+			case .cellCapacityReachedMessage:
+				return "claim_device_cell_capacity_reached_message"
 		}
 	}
 }

--- a/wxm-ios/Resources/Localizable/LocalizableString+ClaimDevice.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableString+ClaimDevice.swift
@@ -167,6 +167,10 @@ extension LocalizableString {
 		case uploadAndClaim
 		case uploadAndProceed
 		case cellCapacityReachedMessage
+		case cellCapacityReachedAlertTitle
+		case cellCapacityReachedAlertText
+		case proceedAnyway
+		case relocate
 	}
 }
 
@@ -511,6 +515,14 @@ extension LocalizableString.ClaimDevice: WXMLocalizable {
 				return "claim_device_upload_and_proceed"
 			case .cellCapacityReachedMessage:
 				return "claim_device_cell_capacity_reached_message"
+			case .cellCapacityReachedAlertTitle:
+				return "claim_device_cell_capacity_reached_alert_title"
+			case .cellCapacityReachedAlertText:
+				return "claim_device_cell_capacity_reached_alert_text"
+			case .proceedAnyway:
+				return "claim_device_proceed_anyway"
+			case .relocate:
+				return "claim_device_relocate"
 		}
 	}
 }

--- a/wxm-ios/Swinject/SwinjectHelper.swift
+++ b/wxm-ios/Swinject/SwinjectHelper.swift
@@ -40,6 +40,11 @@ class SwinjectHelper: SwinjectInterface {
 		}
 		.inObjectScope(.container)
 
+		container.register(ExplorerService.self) { resolver in
+			ExplorerService(cacheManager: resolver.resolve(UserDefaultsService.self)!)
+		}
+		.inObjectScope(.container)
+
 		container.register(MainRepository.self) { _ in
 			MainRepositoryImpl()
 		}
@@ -96,8 +101,8 @@ class SwinjectHelper: SwinjectInterface {
         }
         // MARK: - Cells DI
 
-        container.register(ExplorerRepository.self) { _ in
-            ExplorerRepositoryImpl()
+        container.register(ExplorerRepository.self) { resolver in
+			ExplorerRepositoryImpl(service: resolver.resolve(ExplorerService.self)!)
         }
 
 		container.register(ExplorerUseCaseApi.self) { resolver in


### PR DESCRIPTION
## **Why?**
Cell capacity warnings in claim flow and edit location screen
### **How?**
- Updated the domain model `PublicHex`
- Added cell capacity annotations in `ExplorerData` with the corresponding color
- Cache functionality for explorer response
### **Testing**
Ensure everything works as expected in claim flow and edit location screen
### **Additional context**
fixes fe-2001, fe-2003


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Map shows cell capacity areas, borders and labels; tapping polygons reports pointed annotations.
* **New Features / UX**
  * Capacity-aware selection: alerts when a cell is full with "Relocate" or "Proceed anyway" actions and new localized strings (including "Read More").
* **Improvements**
  * Explorer data surfaced to the location picker for richer map context and selection handling.
* **Performance**
  * Explorer data cached for faster loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->