### PR TITLE
Pulse metadata in stations list and details

### DIFF
--- a/PresentationLayer/Constants/Strings/DisplayedLinks.swift
+++ b/PresentationLayer/Constants/Strings/DisplayedLinks.swift
@@ -39,6 +39,7 @@ enum DisplayedLinks {
 	case m5Batteries
 	case heliumBatteries
 	case d1Batteries
+	case pulseBatteries
 	case m5VideoLink
 	case d1VideoLink
 	case weatherXMPro
@@ -103,6 +104,8 @@ enum DisplayedLinks {
 				return "https://docs.weatherxm.com/wxm-devices/helium/assemble#battery-installation-diagram-external-box"
 			case .d1Batteries:
 				return "https://docs.weatherxm.com/wxm-devices/d1/assemble#installing-batteries"
+			case .pulseBatteries:
+				return "https://docs.weatherxm.com/wxm-devices/pulse/assemble#installing-batteries"
 			case .m5VideoLink:
 				return "https://www.youtube.com/watch?v=sUJEwuFq1CE"
 			case .d1VideoLink:

--- a/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
@@ -118,6 +118,7 @@ extension DeviceDetails {
 		case needsUpdate
 		case lowBattery
 		case gwLowBattery
+		case wsLowBattery
 
 		var description: String {
 			switch self {
@@ -126,6 +127,8 @@ extension DeviceDetails {
 				case .needsUpdate:
 					return LocalizableString.updateRequiredTitle.localized
 				case .lowBattery:
+					return LocalizableString.lowBatteryWarningTitle.localized
+				case .wsLowBattery:
 					return LocalizableString.wsLowBatteryWarningTitle.localized
 				case .gwLowBattery:
 					return LocalizableString.gwLowBatteryWarningTitle.localized
@@ -138,7 +141,7 @@ extension DeviceDetails {
 						.hexagonXmark
 				case .needsUpdate:
 						.arrowsRotate
-				case .lowBattery, .gwLowBattery:
+				case .lowBattery, .gwLowBattery, .wsLowBattery:
 						.batteryLow
 			}
 		}
@@ -153,7 +156,7 @@ extension DeviceDetails {
 					return nil
 				case .needsUpdate:
 					return .otaUpdate
-				case .lowBattery:
+				case .lowBattery, .wsLowBattery:
 					return .lowBatteryItem
 				case .gwLowBattery:
 					// Temp, declare the analytics value
@@ -237,7 +240,11 @@ extension DeviceDetails {
 		}
 		
 		if isBatteryLow(followState: followState) {
-			issues.append(.init(type: .lowBattery, warningType: .warning))
+			if bundle?.connectivity == .cellular {
+				issues.append(.init(type: .wsLowBattery, warningType: .warning))
+			} else {
+				issues.append(.init(type: .lowBattery, warningType: .warning))
+			}
 		}
 
 		if isGWBatteryLow(followState: followState) {

--- a/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
+++ b/PresentationLayer/Extensions/DomainExtensions/DeviceDetails+.swift
@@ -126,7 +126,7 @@ extension DeviceDetails {
 				case .needsUpdate:
 					return LocalizableString.updateRequiredTitle.localized
 				case .lowBattery:
-					return LocalizableString.lowBatteryWarningTitle.localized
+					return LocalizableString.wsLowBatteryWarningTitle.localized
 				case .gwLowBattery:
 					return LocalizableString.gwLowBatteryWarningTitle.localized
 			}

--- a/PresentationLayer/UIComponents/Modifiers/ButtonStyles/WXMButtonStyle.swift
+++ b/PresentationLayer/UIComponents/Modifiers/ButtonStyles/WXMButtonStyle.swift
@@ -120,7 +120,7 @@ extension WXMButtonStyle {
 	static func transparent(fillColor: ColorEnum) -> Self {
 		Self.init(textColor: Color(colorEnum: .wxmPrimary),
 				  textColorDisabled: Color(colorEnum: .midGrey),
-				  fillColor: Color(colorEnum: fillColor).opacity(0.5),
+				  fillColor: Color(colorEnum: fillColor).opacity(0.3),
 				  fillColorDisabled: Color(colorEnum: .midGrey).opacity(0.15),
 				  strokeColor: Color.clear,
 				  strokeColorDisabled: Color.clear)

--- a/PresentationLayer/UIComponents/Screens/MultipleAlerts/AlertsViewModel.swift
+++ b/PresentationLayer/UIComponents/Screens/MultipleAlerts/AlertsViewModel.swift
@@ -18,11 +18,13 @@ class AlertsViewModel: ObservableObject {
 	let device: DeviceDetails
 	let mainVM: MainScreenViewModel
 	let followState: UserDeviceFollowState?
-	
-	init(device: DeviceDetails, mainVM: MainScreenViewModel, followState: UserDeviceFollowState?) {
+	let linkNavigation: LinkNavigation
+
+	init(device: DeviceDetails, mainVM: MainScreenViewModel, followState: UserDeviceFollowState?, linkNavigation: LinkNavigation = LinkNavigationHelper()) {
 		self.device = device
 		self.mainVM = mainVM
 		self.followState = followState
+		self.linkNavigation = linkNavigation
 		generateAlerts()
 	}
 	
@@ -75,7 +77,18 @@ private extension AlertsViewModel {
 												 appearAction: nil)
 			alerts.append(alert)
 		}
-		
+
+		if device.isGWBatteryLow(followState: followState) {
+			let alert = MultipleAlertsView.Alert(type: .warning,
+												 title: LocalizableString.stationWarningGWLowBatteryTitle.localized,
+												 message: LocalizableString.stationWarningGWLowBatteryDescription.localized,
+												 icon: .batteryLow,
+												 buttonTitle: LocalizableString.stationWarningLowBatteryButtonTitle.localized,
+												 buttonAction: handleLowBatteryTap,
+												 appearAction: nil)
+			alerts.append(alert)
+		}
+
 		self.alerts = alerts
 	}
 	
@@ -100,19 +113,13 @@ private extension AlertsViewModel {
 		}
 		switch name {
 			case .m5:
-				if let url = URL(string: DisplayedLinks.m5Batteries.linkURL) {
-					UIApplication.shared.open(url)
-				}
+				linkNavigation.openUrl(DisplayedLinks.m5Batteries.linkURL)
 			case .h1, .h2:
-				if let url = URL(string: DisplayedLinks.heliumBatteries.linkURL) {
-					UIApplication.shared.open(url)
-				}
+				linkNavigation.openUrl(DisplayedLinks.heliumBatteries.linkURL)
 			case .d1:
-				if let url = URL(string: DisplayedLinks.heliumBatteries.linkURL) {
-					UIApplication.shared.open(url)
-				}
+				linkNavigation.openUrl(DisplayedLinks.d1Batteries.linkURL)
 			case .pulse:
-#warning("Open pulse link")
+				linkNavigation.openUrl(DisplayedLinks.pulseBatteries.linkURL)
 		}
 		
 	}

--- a/PresentationLayer/UIComponents/Screens/MultipleAlerts/MultipleAlertsView.swift
+++ b/PresentationLayer/UIComponents/Screens/MultipleAlerts/MultipleAlertsView.swift
@@ -35,7 +35,7 @@ struct MultipleAlertsView: View {
 										Button(action: buttonAction) {
 											Text(buttonTitle)
 										}
-										.buttonStyle(WXMButtonStyle.transparent)
+										.buttonStyle(WXMButtonStyle.transparent(fillColor: .textDarkStable))
 										.padding(.top, CGFloat(.smallSidePadding))
 									} else {
 										EmptyView()

--- a/WeatherXMTests/DataLayer/RepositoryImplementations/MeRepositoryImplTests.swift
+++ b/WeatherXMTests/DataLayer/RepositoryImplementations/MeRepositoryImplTests.swift
@@ -61,7 +61,7 @@ struct MeRepositoryImplTests {
 		#expect(cachedDevices == nil)
 
 		let devices = try await repositoryImpl.getDevices(useCache: false).toAsync().result.get()
-		#expect(devices.count == 2)
+		#expect(devices.count == 3)
 
 		cachedDevices = repositoryImpl.getCachedDevices()
 		#expect(cachedDevices?.count == devices.count)
@@ -113,7 +113,7 @@ struct MeRepositoryImplTests {
 
 	@Test func setLocation() async throws {
 		let devices = try await repositoryImpl.getDevices(useCache: false).toAsync().result.get()
-		#expect(devices.count == 2)
+		#expect(devices.count == 3)
 
 		let _ = try await repositoryImpl.setDeviceLocationById(deviceId: "124", lat: 0.0, lon: 0.0).toAsync().result
 

--- a/WeatherXMTests/DataLayer/Services/UserDevicesServiceTests.swift
+++ b/WeatherXMTests/DataLayer/Services/UserDevicesServiceTests.swift
@@ -25,10 +25,10 @@ struct UserDevicesServiceTests {
 
 	@Test func initialFetch() async throws {
 		let devices = try await service.getDevices(useCache: true).toAsync().result.get()
-		#expect(devices.count == 2)
+		#expect(devices.count == 3)
 
 		let cachedDevices = service.getCachedDevices()
-		#expect(cachedDevices?.count == 2)
+		#expect(cachedDevices?.count == 3)
 		#expect(cachedDevices?.first?.id == devices.first?.id)
 	}
 
@@ -94,7 +94,7 @@ struct UserDevicesServiceTests {
 
 		let deviceId = "124"
 		let states = try await service.getFollowStates().get()
-		#expect(states?.count == 2)
+		#expect(states?.count == 3)
 		#expect(states?.first?.deviceId == deviceId)
 
 		try await validateInitialState()
@@ -134,9 +134,9 @@ struct UserDevicesServiceTests {
 private extension UserDevicesServiceTests {
 	func validateInitialState() async throws {
 		let devices = try await service.getDevices(useCache: true).toAsync().result.get()
-		#expect(devices.count == 2)
+		#expect(devices.count == 3)
 
 		let cachedDevices = service.getCachedDevices()
-		#expect(cachedDevices?.count == 2)
+		#expect(cachedDevices?.count == 3)
 	}
 }

--- a/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/get_user_device.json
+++ b/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/get_user_device.json
@@ -1,118 +1,122 @@
 {
-  "id": "cb29a150-c0a6-11dc-a75c-a97bf0032a08",
-  "name": "TEST",
-  "label": "AE:66:F7:21:1F:21:75:11:EC",
-  "location": {
-    "lat": -41.230659,
-    "lon": -93.907064
-  },
-  "timezone": "Etc/GMT+6",
-  "relation": "owned",
-  "address": "-",
-  "bundle": {
-	  "name": "h1",
-	  "title": "H1",
-	  "connectivity": "wifi",
-	  "ws_model": "WS1000",
-	  "gw_model": "WG1000"
-  },
-  "metrics" : {
-	"pol_reason" : null,
-	"ts" : null,
-	"qod_score" : null
-  },
-  "bat_state": "low",
-  "attributes": {
-    "friendlyName": "Home",
-    "hex3": {
-      "index": "83d29afffffffff",
-      "polygon": [
-        {
-          "lat": -41.4475445082976,
-          "lon": -93.498892302025
-        },
-        {
-          "lat": -40.93069934671397,
-          "lon": -92.96459836815616
-        },
-        {
-          "lat": -40.31276675619656,
-          "lon": -93.29179018952695
-        },
-        {
-          "lat": -40.205086498865846,
-          "lon": -94.14315830838207
-        },
-        {
-          "lat": -40.71554434460866,
-          "lon": -94.68411404702701
-        },
-        {
-          "lat": -41.340059468705434,
-          "lon": -94.36729932775174
-        }
-      ],
-      "center": {
-        "lat": -40.82651031739257,
-        "lon": -93.82417433697604
-      }
-    },
-    "hex7": {
-      "index": "87d29a8a6ffffff",
-      "polygon": [
-        {
-          "lat": -41.23329701378177,
-          "lon": -93.89288943514127
-        },
-        {
-          "lat": -41.222792321685105,
-          "lon": -93.88182582123082
-        },
-        {
-          "lat": -41.21009620192915,
-          "lon": -93.88843184426945
-        },
-        {
-          "lat": -41.20790203591807,
-          "lon": -93.90609708663857
-        },
-        {
-          "lat": -41.21840406520972,
-          "lon": -93.91716349504759
-        },
-        {
-          "lat": -41.231102923224086,
-          "lon": -93.9105618688385
-        }
-      ],
-      "center": {
-        "lat": -41.22059962604695,
-        "lon": -93.89949458848605
-      }
-    },
-    "isActive": true,
-    "lastWeatherStationActivity": "2023-01-25T10:20:08-06:00",
-    "lastActiveAt": "2023-01-25T10:20:08-06:00",
-    "firmware": {
-      "current": "2.3.0",
-      "assigned": "2.3.0-internal"
-    }
-  },
-  "current_weather": {
-    "timestamp": "2023-01-25T10:20:08-06:00",
-    "temperature": 20.338020711659738,
-    "humidity": 59,
-    "wind_speed": 47.62365157837036,
-    "wind_gust": 25.762633951364656,
-    "wind_direction": 130,
-    "uv_index": 7,
-    "precipitation": 1.0720520490349283,
-    "pressure": 603.776966380233,
-    "feels_like": 20.338020711659738,
-    "icon": "drizzle"
-  },
-  "rewards": {
-    "actual_reward": null,
-    "total_rewards": null
-  }
+	"id": "76d13810-absd-11ec-812e-6312632e9ec",
+	"name": "Weatherwise Wintergreen Stratocumulus",
+	"label": null,
+	"timezone": "Europe/Athens",
+	"bundle": {
+		"name": "pulse",
+		"title": "Pulse",
+		"connectivity": "cellular",
+		"ws_model": "WS1000",
+		"gw_model": "WG1000",
+		"hw_class": "CONSUMER"
+	},
+	"relation": "owned",
+	"bat_state": "low",
+	"gateway_bat_state": "low",
+	"location": {
+		"lat": 37.981262,
+		"lon": 23.730503
+	},
+	"metrics": {
+		"qod_score": 0,
+		"pol_reason": null,
+		"ts": "2022-01-13T22:00:00+02:00"
+	},
+	"attributes": {
+		"isActive": true,
+		"lastWeatherStationActivity": "2022-01-13T22:00:00+02:00",
+		"firmware": {
+			"current": "1.0.0",
+			"assigned": "1.0.1"
+		},
+		"hex3": {
+			"index": "833f72fffffffff",
+			"polygon": [
+				{
+					"lat": 35.62983463943738,
+					"lon": 23.372801364962505
+				},
+				{
+					"lat": 34.958641140481404,
+					"lon": 23.339733257269025
+				},
+				{
+					"lat": 34.59685782123658,
+					"lon": 24.035997744251496
+				},
+				{
+					"lat": 34.903320885355384,
+					"lon": 24.76919455347358
+				},
+				{
+					"lat": 35.574007582813174,
+					"lon": 24.81200499077942
+				},
+				{
+					"lat": 35.938786456658356,
+					"lon": 24.11189955457401
+				}
+			],
+			"center": {
+				"lat": 37.981262,
+				"lon": 23.730503
+			}
+		},
+		"hex7": {
+			"index": "873f728d0ffffff",
+			"polygon": [
+				{
+					"lat": 37.52482636074315,
+					"lon": 23.014679947948405
+				},
+				{
+					"lat": 37.51114716956354,
+					"lon": 23.01391178034676
+				},
+				{
+					"lat": 37.50374631403231,
+					"lon": 23.02820018964633
+				},
+				{
+					"lat": 37.51002341064811,
+					"lon": 23.043258382501087
+				},
+				{
+					"lat": 37.52370239640629,
+					"lon": 23.044030629840638
+				},
+				{
+					"lat": 37.53110449138368,
+					"lon": 23.02974060478422
+				}
+			],
+			"center": {
+				"lat": 37.981262,
+				"lon": 23.730503
+			}
+		}
+	},
+	"current_weather": {
+		"timestamp": "2022-01-13T22:00:00+02:00",
+		"precipitation": 0.03,
+		"precipitation_accumulated": 14.10000022,
+		"temperature": -108.8,
+		"feels_like": 16.0,
+		"wind_direction": 54,
+		"humidity": 81,
+		"wind_speed": 11.5,
+		"icon": "partly-cloudy-night",
+		"precipitation_probability": 1,
+		"uv_index": 0,
+		"pressure": 1019.9,
+		"cloud_cover": 85,
+		"wind_gust": 17.4,
+		"precip_type": "rain"
+	},
+	"address": "Athens, GR",
+	"rewards": {
+		"total_rewards": 5555.65,
+		"actual_reward": 156.6
+	}
 }

--- a/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/get_user_devices.json
+++ b/wxm-ios/DataLayer/DataLayer/Networking/Mock/Jsons/get_user_devices.json
@@ -1,238 +1,351 @@
 [
-  {
-    "id": "124",
-    "name": "Staion Name A",
-    "label": "2C:F7:F1:C0:42:40:00:0D",
-    "location": {
-      "lat": 37.97282058661004,
-      "lon": 23.651339117978722
-    },
-    "timezone": "Europe/Athens",
-    "relation": "owned",
-    "address": "Somewhere in the world",
-	"bundle": {
-		"name": "h1",
-		"title": "H1",
-		"connectivity": "helium",
-		"ws_model": "WS1000",
-		"gw_model": "WG1000"
-	},
-	"bat_state": "low",
-    "attributes": {
-      "claimedAt": "2023-03-01T17:21:23+02:00",
-      "firmware": {
-        "current": "2.3.0",
-        "assigned": "2.3.0-internal"
-      },
-      "hex3": {
-        "index": "831edafffffffff",
-        "polygon": [
-          {
-            "lat": 38.644236094151005,
-            "lon": 22.784148869958848
-          },
-          {
-            "lat": 37.983542598121375,
-            "lon": 22.754162161175188
-          },
-          {
-            "lat": 37.6303425743379,
-            "lon": 23.47478087300285
-          },
-          {
-            "lat": 37.93511272705379,
-            "lon": 24.22974113863726
-          },
-          {
-            "lat": 38.5954640496184,
-            "lon": 24.270130249021037
-          },
-          {
-            "lat": 38.951438520683396,
-            "lon": 23.545178032093393
-          }
-        ],
-        "center": {
-          "lat": 38.29225710202074,
-          "lon": 23.50973159680952
-        }
-      },
-      "hex7": {
-        "index": "871eda750ffffff",
-        "polygon": [
-          {
-            "lat": 37.97061313218039,
-            "lon": 23.628439025654682
-          },
-          {
-            "lat": 37.95710575635591,
-            "lon": 23.62770629174598
-          },
-          {
-            "lat": 37.94983924168456,
-            "lon": 23.642394668336376
-          },
-          {
-            "lat": 37.95607893564099,
-            "lon": 23.65781754795612
-          },
-          {
-            "lat": 37.96958615439062,
-            "lon": 23.65855458239535
-          },
-          {
-            "lat": 37.97685383669051,
-            "lon": 23.64386443687226
-          }
-        ],
-        "center": {
-          "lat": 37.96334709215799,
-          "lon": 23.643129447388414
-        }
-      },
-      "isActive": false,
-      "lastWeatherStationActivity": "2023-03-01T18:11:56+02:00",
-      "lastActiveAt": "2023-03-01T18:11:56+02:00"
-    },
-    "current_weather": {
-      "timestamp": "2023-03-01T18:11:56+02:00",
-      "temperature": 20.7,
-      "humidity": 54,
-      "wind_speed": 0,
-      "wind_gust": 0,
-      "wind_direction": 258,
-      "uv_index": 0,
-      "precipitation": 0,
-      "pressure": 1010.1,
-      "feels_like": 20.7,
-      "icon": "partly-cloudy-day"
-    },
-    "rewards": {
-      "actual_reward": 10.165180164109882,
-      "total_rewards": 323.64723442479493
-    },
-	"metrics" : {
-	  "pol_reason" : "NO_LOCATION_DATA",
-	  "ts" : "2024-10-14T00:00:00+00:00",
-	  "qod_score" : 99
-	}
-  },
-  {
-	"id": "cb29a150-c0a6-11dc-a75c-a97bf0032a08",
-	"name": "TEST",
-	"label": "AE:66:F7:21:1F:21:75:11:EC",
-	"location": {
-	  "lat": -41.230659,
-	  "lon": -93.907064
-	},
-	"timezone": "Etc/GMT+6",
-	"relation": "owned",
-	"address": "-",
-	"bundle": {
-		"name": "h1",
-		"title": "H1",
-		"connectivity": "helium",
-		"ws_model": "WS1000",
-		"gw_model": "WG1000"
-	},
-	"metrics" : {
-	  "pol_reason" : null,
-	  "ts" : null,
-	  "qod_score" : null
-	},
-	"bat_state": "low",
-	"attributes": {
-	  "friendlyName": "Home",
-	  "hex3": {
-		"index": "83d29afffffffff",
-		"polygon": [
-		  {
-			"lat": -41.4475445082976,
-			"lon": -93.498892302025
-		  },
-		  {
-			"lat": -40.93069934671397,
-			"lon": -92.96459836815616
-		  },
-		  {
-			"lat": -40.31276675619656,
-			"lon": -93.29179018952695
-		  },
-		  {
-			"lat": -40.205086498865846,
-			"lon": -94.14315830838207
-		  },
-		  {
-			"lat": -40.71554434460866,
-			"lon": -94.68411404702701
-		  },
-		  {
-			"lat": -41.340059468705434,
-			"lon": -94.36729932775174
-		  }
-		],
-		"center": {
-		  "lat": -40.82651031739257,
-		  "lon": -93.82417433697604
+	{
+		"id": "124",
+		"name": "Staion Name A",
+		"label": "2C:F7:F1:C0:42:40:00:0D",
+		"location": {
+			"lat": 37.97282058661004,
+			"lon": 23.651339117978722
+		},
+		"timezone": "Europe/Athens",
+		"relation": "owned",
+		"address": "Somewhere in the world",
+		"bundle": {
+			"name": "h1",
+			"title": "H1",
+			"connectivity": "helium",
+			"ws_model": "WS1000",
+			"gw_model": "WG1000"
+		},
+		"bat_state": "low",
+		"attributes": {
+			"claimedAt": "2023-03-01T17:21:23+02:00",
+			"firmware": {
+				"current": "2.3.0",
+				"assigned": "2.3.0-internal"
+			},
+			"hex3": {
+				"index": "831edafffffffff",
+				"polygon": [
+					{
+						"lat": 38.644236094151005,
+						"lon": 22.784148869958848
+					},
+					{
+						"lat": 37.983542598121375,
+						"lon": 22.754162161175188
+					},
+					{
+						"lat": 37.6303425743379,
+						"lon": 23.47478087300285
+					},
+					{
+						"lat": 37.93511272705379,
+						"lon": 24.22974113863726
+					},
+					{
+						"lat": 38.5954640496184,
+						"lon": 24.270130249021037
+					},
+					{
+						"lat": 38.951438520683396,
+						"lon": 23.545178032093393
+					}
+				],
+				"center": {
+					"lat": 38.29225710202074,
+					"lon": 23.50973159680952
+				}
+			},
+			"hex7": {
+				"index": "871eda750ffffff",
+				"polygon": [
+					{
+						"lat": 37.97061313218039,
+						"lon": 23.628439025654682
+					},
+					{
+						"lat": 37.95710575635591,
+						"lon": 23.62770629174598
+					},
+					{
+						"lat": 37.94983924168456,
+						"lon": 23.642394668336376
+					},
+					{
+						"lat": 37.95607893564099,
+						"lon": 23.65781754795612
+					},
+					{
+						"lat": 37.96958615439062,
+						"lon": 23.65855458239535
+					},
+					{
+						"lat": 37.97685383669051,
+						"lon": 23.64386443687226
+					}
+				],
+				"center": {
+					"lat": 37.96334709215799,
+					"lon": 23.643129447388414
+				}
+			},
+			"isActive": false,
+			"lastWeatherStationActivity": "2023-03-01T18:11:56+02:00",
+			"lastActiveAt": "2023-03-01T18:11:56+02:00"
+		},
+		"current_weather": {
+			"timestamp": "2023-03-01T18:11:56+02:00",
+			"temperature": 20.7,
+			"humidity": 54,
+			"wind_speed": 0,
+			"wind_gust": 0,
+			"wind_direction": 258,
+			"uv_index": 0,
+			"precipitation": 0,
+			"pressure": 1010.1,
+			"feels_like": 20.7,
+			"icon": "partly-cloudy-day"
+		},
+		"rewards": {
+			"actual_reward": 10.165180164109882,
+			"total_rewards": 323.64723442479493
+		},
+		"metrics" : {
+			"pol_reason" : "NO_LOCATION_DATA",
+			"ts" : "2024-10-14T00:00:00+00:00",
+			"qod_score" : 99
 		}
-	  },
-	  "hex7": {
-		"index": "87d29a8a6ffffff",
-		"polygon": [
-		  {
-			"lat": -41.23329701378177,
-			"lon": -93.89288943514127
-		  },
-		  {
-			"lat": -41.222792321685105,
-			"lon": -93.88182582123082
-		  },
-		  {
-			"lat": -41.21009620192915,
-			"lon": -93.88843184426945
-		  },
-		  {
-			"lat": -41.20790203591807,
-			"lon": -93.90609708663857
-		  },
-		  {
-			"lat": -41.21840406520972,
-			"lon": -93.91716349504759
-		  },
-		  {
-			"lat": -41.231102923224086,
-			"lon": -93.9105618688385
-		  }
-		],
-		"center": {
-		  "lat": -41.22059962604695,
-		  "lon": -93.89949458848605
+	},
+	{
+		"id": "cb29a150-c0a6-11dc-a75c-a97bf0032a08",
+		"name": "TEST",
+		"label": "AE:66:F7:21:1F:21:75:11:EC",
+		"location": {
+			"lat": -41.230659,
+			"lon": -93.907064
+		},
+		"timezone": "Etc/GMT+6",
+		"relation": "owned",
+		"address": "-",
+		"bundle": {
+			"name": "h1",
+			"title": "H1",
+			"connectivity": "helium",
+			"ws_model": "WS1000",
+			"gw_model": "WG1000"
+		},
+		"metrics" : {
+			"pol_reason" : null,
+			"ts" : null,
+			"qod_score" : null
+		},
+		"bat_state": "low",
+		"attributes": {
+			"friendlyName": "Home",
+			"hex3": {
+				"index": "83d29afffffffff",
+				"polygon": [
+					{
+						"lat": -41.4475445082976,
+						"lon": -93.498892302025
+					},
+					{
+						"lat": -40.93069934671397,
+						"lon": -92.96459836815616
+					},
+					{
+						"lat": -40.31276675619656,
+						"lon": -93.29179018952695
+					},
+					{
+						"lat": -40.205086498865846,
+						"lon": -94.14315830838207
+					},
+					{
+						"lat": -40.71554434460866,
+						"lon": -94.68411404702701
+					},
+					{
+						"lat": -41.340059468705434,
+						"lon": -94.36729932775174
+					}
+				],
+				"center": {
+					"lat": -40.82651031739257,
+					"lon": -93.82417433697604
+				}
+			},
+			"hex7": {
+				"index": "87d29a8a6ffffff",
+				"polygon": [
+					{
+						"lat": -41.23329701378177,
+						"lon": -93.89288943514127
+					},
+					{
+						"lat": -41.222792321685105,
+						"lon": -93.88182582123082
+					},
+					{
+						"lat": -41.21009620192915,
+						"lon": -93.88843184426945
+					},
+					{
+						"lat": -41.20790203591807,
+						"lon": -93.90609708663857
+					},
+					{
+						"lat": -41.21840406520972,
+						"lon": -93.91716349504759
+					},
+					{
+						"lat": -41.231102923224086,
+						"lon": -93.9105618688385
+					}
+				],
+				"center": {
+					"lat": -41.22059962604695,
+					"lon": -93.89949458848605
+				}
+			},
+			"isActive": true,
+			"lastWeatherStationActivity": "2023-01-25T10:20:08-06:00",
+			"lastActiveAt": "2023-01-25T10:20:08-06:00",
+			"firmware": {
+				"current": "2.3.0",
+				"assigned": "2.3.0-internal"
+			}
+		},
+		"current_weather": {
+			"timestamp": "2023-01-25T10:20:08-06:00",
+			"temperature": 20.338020711659738,
+			"humidity": 59,
+			"wind_speed": 47.62365157837036,
+			"wind_gust": 25.762633951364656,
+			"wind_direction": 130,
+			"uv_index": 7,
+			"precipitation": 1.0720520490349283,
+			"pressure": 603.776966380233,
+			"feels_like": 20.338020711659738,
+			"icon": "drizzle"
+		},
+		"rewards": {
+			"actual_reward": null,
+			"total_rewards": null
 		}
-	  },
-	  "isActive": true,
-	  "lastWeatherStationActivity": "2023-01-25T10:20:08-06:00",
-	  "lastActiveAt": "2023-01-25T10:20:08-06:00",
-	  "firmware": {
-		"current": "2.3.0",
-		"assigned": "2.3.0-internal"
-	  }
 	},
-	"current_weather": {
-	  "timestamp": "2023-01-25T10:20:08-06:00",
-	  "temperature": 20.338020711659738,
-	  "humidity": 59,
-	  "wind_speed": 47.62365157837036,
-	  "wind_gust": 25.762633951364656,
-	  "wind_direction": 130,
-	  "uv_index": 7,
-	  "precipitation": 1.0720520490349283,
-	  "pressure": 603.776966380233,
-	  "feels_like": 20.338020711659738,
-	  "icon": "drizzle"
-	},
-	"rewards": {
-	  "actual_reward": null,
-	  "total_rewards": null
+	{
+		"id": "76d13810-absd-11ec-812e-6312632e9ec",
+		"name": "Big Blue Cloud",
+		"timezone": "Europe/Athens",
+		"bundle": {
+			"name": "pulse",
+			"title": "Pulse",
+			"connectivity": "cellular",
+			"ws_model": "WS1001",
+			"gw_model": "WG3000",
+			"hw_class": "CONSUMER"
+		},
+		"label": null,
+		"relation": "owned",
+		"bat_state": "ok",
+		"gateway_bat_state": "low",
+		"location": {
+			"lat": 37.981262,
+			"lon": 23.730503
+		},
+		"attributes": {
+			"isActive": true,
+			"lastWeatherStationActivity": "2024-10-08T17:30:00+03:00",
+			"hex3": {
+				"index": "833f72fffffffff",
+				"polygon": [
+					{
+						"lat": 35.62983463943738,
+						"lon": 23.372801364962505
+					},
+					{
+						"lat": 34.958641140481404,
+						"lon": 23.339733257269025
+					},
+					{
+						"lat": 34.59685782123658,
+						"lon": 24.035997744251496
+					},
+					{
+						"lat": 34.903320885355384,
+						"lon": 24.76919455347358
+					},
+					{
+						"lat": 35.574007582813174,
+						"lon": 24.81200499077942
+					},
+					{
+						"lat": 35.938786456658356,
+						"lon": 24.11189955457401
+					}
+				],
+				"center": {
+					"lat": 37.981262,
+					"lon": 23.730503
+				}
+			},
+			"hex7": {
+				"index": "873f728d0ffffff",
+				"polygon": [
+					{
+						"lat": 37.52482636074315,
+						"lon": 23.014679947948405
+					},
+					{
+						"lat": 37.51114716956354,
+						"lon": 23.01391178034676
+					},
+					{
+						"lat": 37.50374631403231,
+						"lon": 23.02820018964633
+					},
+					{
+						"lat": 37.51002341064811,
+						"lon": 23.043258382501087
+					},
+					{
+						"lat": 37.52370239640629,
+						"lon": 23.044030629840638
+					},
+					{
+						"lat": 37.53110449138368,
+						"lon": 23.02974060478422
+					}
+				],
+				"center": {
+					"lat": 37.981262,
+					"lon": 23.730503
+				}
+			}
+		},
+		"current_weather": {
+			"timestamp": "2022-01-13T22:00:00+02:00",
+			"precipitation": 0,
+			"precipitation_accumulated": 14.10000022,
+			"temperature": -38.8,
+			"feels_like": 16.0,
+			"wind_direction": 321,
+			"humidity": 55,
+			"wind_speed": 3.1,
+			"icon": "partly-cloudy-night",
+			"precipitation_probability": 15,
+			"uv_index": 0,
+			"pressure": 1019.6,
+			"cloud_cover": 89,
+			"wind_gust": 5.4,
+			"precipitation_type": "rain"
+		},
+		"address": "Athens, GR",
+		"rewards": {
+			"total_rewards": 3523.65,
+			"actual_reward": 156.6
+		}
 	}
-  }
 ]

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Devices/NetworkDevicesResponse.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/Codables/Devices/NetworkDevicesResponse.swift
@@ -14,6 +14,7 @@ public struct NetworkDevicesResponse: Codable, Identifiable, Sendable {
     public var label: String? = ""
     public var location: LocationCoordinates?
 	public var batteryState: BatteryState?
+	public var gatewayBatteryState: BatteryState?
     public var timezone: String? = ""
     public var address: String? = ""
     public var attributes: Attributes = .init()
@@ -28,6 +29,7 @@ public struct NetworkDevicesResponse: Codable, Identifiable, Sendable {
     enum CodingKeys: String, CodingKey {
 		case id, name, timezone, address, attributes, location, rewards, label, relation, bundle, metrics
 		case batteryState = "bat_state"
+		case gatewayBatteryState = "gateway_bat_state"
         case currentWeather = "current_weather"
     }
 
@@ -38,6 +40,7 @@ public struct NetworkDevicesResponse: Codable, Identifiable, Sendable {
         label = try? values.decodeIfPresent(String.self, forKey: .label)
         location = try? values.decodeIfPresent(LocationCoordinates.self, forKey: .location)
 		batteryState = try? values.decodeIfPresent(BatteryState.self, forKey: .batteryState)
+		gatewayBatteryState = try? values.decodeIfPresent(BatteryState.self, forKey: .gatewayBatteryState)
         timezone = try? values.decodeIfPresent(String.self, forKey: .timezone)
         address = try? values.decodeIfPresent(String.self, forKey: .address)
         attributes = try values.decodeIfPresent(Attributes.self, forKey: .attributes) ?? Attributes()

--- a/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/DeviceDetails.swift
+++ b/wxm-ios/DomainLayer/DomainLayer/Entities/DomainModels/DeviceDetails.swift
@@ -15,6 +15,7 @@ public struct DeviceDetails: Sendable {
     public var address: String?
 	public var location: LocationCoordinates?
 	public var batteryState: BatteryState?
+	public var gatewayBatteryState: BatteryState?
     public var cellIndex: String?
 	public var cellAvgDataQuality: Int?
     public var cellCenter: LocationCoordinates?
@@ -38,6 +39,7 @@ public struct DeviceDetails: Sendable {
 				address: String? = nil,
 				location: LocationCoordinates? = nil,
 				batteryState: BatteryState? = nil,
+				gatewayBatteryState: BatteryState? = nil,
 				cellIndex: String? = nil,
 				cellAvgDataQuality: Int? = nil,
 				cellCenter: LocationCoordinates? = nil,
@@ -60,6 +62,7 @@ public struct DeviceDetails: Sendable {
 		self.address = address
 		self.location = location
 		self.batteryState = batteryState
+		self.gatewayBatteryState = gatewayBatteryState
 		self.cellAvgDataQuality = cellAvgDataQuality
 		self.cellIndex = cellIndex
 		self.cellCenter = cellCenter
@@ -103,6 +106,7 @@ extension NetworkDevicesResponse {
                       address: address,
 					  location: location,
 					  batteryState: batteryState,
+					  gatewayBatteryState: gatewayBatteryState,
                       cellIndex: attributes.hex7?.index,
                       cellCenter: attributes.hex7?.center,
 					  cellPolygon: attributes.hex7?.polygon,

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -5500,17 +5500,6 @@
         }
       }
     },
-    "low_battery_warning_title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Low Battery"
-          }
-        }
-      }
-    },
     "mail_leave_message_note" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -11722,6 +11711,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wind Speed"
+          }
+        }
+      }
+    },
+    "ws_low_battery_warning_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Low WS Battery"
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -10725,6 +10725,28 @@
         }
       }
     },
+    "station_warning_gw_low_battery_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your gateway is reporting low battery. This will lead to data gaps and eventually loss of rewards. Read more on how to replace your station batteries."
+          }
+        }
+      }
+    },
+    "station_warning_gw_low_battery_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Low GW Battery"
+          }
+        }
+      }
+    },
     "station_warning_low_battery_button_title" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -10753,7 +10775,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Low Battery"
+            "value" : "Low WS Battery"
           }
         }
       }

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -5500,6 +5500,17 @@
         }
       }
     },
+    "low_battery_warning_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Low Battery"
+          }
+        }
+      }
+    },
     "mail_leave_message_note" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/Localizable.xcstrings
+++ b/wxm-ios/Resources/Localizable/Localizable.xcstrings
@@ -5159,6 +5159,17 @@
         }
       }
     },
+    "gw_low_battery_warning_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Low GW battery"
+          }
+        }
+      }
+    },
     "hidden_content_description_format" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/wxm-ios/Resources/Localizable/LocalizableConstants.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableConstants.swift
@@ -97,6 +97,8 @@ enum LocalizableString: WXMLocalizable {
 	case stationWarningLowBatteryTitle
 	case stationWarningLowBatteryDescription
 	case stationWarningLowBatteryButtonTitle
+	case stationWarningGWLowBatteryTitle
+	case stationWarningGWLowBatteryDescription
 	case troubleshootInstructionsHere
 	case changingFrequency
 	case invalidLocationErrorText
@@ -411,6 +413,10 @@ extension LocalizableString {
 				return "station_warning_low_battery_description"
 			case .stationWarningLowBatteryButtonTitle:
 				return "station_warning_low_battery_button_title"
+			case .stationWarningGWLowBatteryTitle:
+				return "station_warning_gw_low_battery_title"
+			case .stationWarningGWLowBatteryDescription:
+				return "station_warning_gw_low_battery_description"
 			case .troubleshootInstructionsHere:
 				return "troubleshoot_instructions_here"
 			case .changingFrequency:

--- a/wxm-ios/Resources/Localizable/LocalizableConstants.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableConstants.swift
@@ -150,6 +150,7 @@ enum LocalizableString: WXMLocalizable {
 	case alertsOwnedStationOfflineDescription
 	case alertsStationOfflineDescription
 	case lowBatteryWarningTitle
+	case gwLowBatteryWarningTitle
 	case updateRequiredTitle
 	case profileTitleText
 	case settings
@@ -516,6 +517,8 @@ extension LocalizableString {
 				return "alerts_station_offline_description"
 			case .lowBatteryWarningTitle:
 				return "low_battery_warning_title"
+			case .gwLowBatteryWarningTitle:
+				return "gw_low_battery_warning_title"
 			case .updateRequiredTitle:
 				return "update_required_warning_title"
 			case .profileTitleText:

--- a/wxm-ios/Resources/Localizable/LocalizableConstants.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableConstants.swift
@@ -151,7 +151,7 @@ enum LocalizableString: WXMLocalizable {
 	case alertsStationOfflineTitle
 	case alertsOwnedStationOfflineDescription
 	case alertsStationOfflineDescription
-	case lowBatteryWarningTitle
+	case wsLowBatteryWarningTitle
 	case gwLowBatteryWarningTitle
 	case updateRequiredTitle
 	case profileTitleText
@@ -521,8 +521,8 @@ extension LocalizableString {
 				return "alerts_owned_station_offline_description"
 			case .alertsStationOfflineDescription:
 				return "alerts_station_offline_description"
-			case .lowBatteryWarningTitle:
-				return "low_battery_warning_title"
+			case .wsLowBatteryWarningTitle:
+				return "ws_low_battery_warning_title"
 			case .gwLowBatteryWarningTitle:
 				return "gw_low_battery_warning_title"
 			case .updateRequiredTitle:

--- a/wxm-ios/Resources/Localizable/LocalizableConstants.swift
+++ b/wxm-ios/Resources/Localizable/LocalizableConstants.swift
@@ -151,6 +151,7 @@ enum LocalizableString: WXMLocalizable {
 	case alertsStationOfflineTitle
 	case alertsOwnedStationOfflineDescription
 	case alertsStationOfflineDescription
+	case lowBatteryWarningTitle
 	case wsLowBatteryWarningTitle
 	case gwLowBatteryWarningTitle
 	case updateRequiredTitle
@@ -521,6 +522,8 @@ extension LocalizableString {
 				return "alerts_owned_station_offline_description"
 			case .alertsStationOfflineDescription:
 				return "alerts_station_offline_description"
+			case .lowBatteryWarningTitle:
+				return "low_battery_warning_title"
 			case .wsLowBatteryWarningTitle:
 				return "ws_low_battery_warning_title"
 			case .gwLowBatteryWarningTitle:


### PR DESCRIPTION
## **Why?**
Hardware battery state in devices list, station details and station alerts
### **How?**
- Added `gatewayBatteryState` in device models
- Handle the `gatewayBatteryState` like the regular battery state
### **Testing**
Run  the mock scheme which loads the mock json that is updated to contain `gateway_bat_state`
### **Additional context**
fixes fe-2004


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway-specific low-battery detection and alerts with new gateway/workspace titles and descriptions; added Pulse batteries quick link.
  * Device data now carries gateway battery status for more accurate alerts.

* **Refactor**
  * Centralized link/navigation handling for alert actions.

* **Style**
  * Slightly lighter transparent button fill and updated alert button styling for improved contrast.

* **Tests**
  * Updated test expectations to reflect increased device counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->