### PR TITLE
Widgets in screen with tinted mode

### DIFF
--- a/PresentationLayer/UIComponents/BaseComponents/WeatherOverview/WeatherOverviewView.swift
+++ b/PresentationLayer/UIComponents/BaseComponents/WeatherOverview/WeatherOverviewView.swift
@@ -14,6 +14,8 @@ struct WeatherOverviewView: View {
     var showSecondaryFields: Bool = false
     let noDataText: LocalizableString
     var lastUpdatedText: String?
+    var dataViewBackground: ColorEnum = .top
+    var secondaryFieldsViewBackground: ColorEnum = .layer1
     var buttonTitle: String?
     var isButtonEnabled: Bool = true
     var buttonAction: (() -> Void)?
@@ -41,14 +43,14 @@ struct WeatherOverviewView: View {
                     noDataView
                 }
             }
-            .WXMCardStyle(backgroundColor: Color(colorEnum: .top),
+            .WXMCardStyle(backgroundColor: Color(colorEnum: dataViewBackground),
 						  insideHorizontalPadding: CGFloat(.defaultSidePadding),
 						  insideVerticalPadding: mainViewVerticalPadding,
 						  cornerRadius: CGFloat(.cardCornerRadius))
 
 			if showSecondaryFields {
 				secondaryFieldsView
-					.WXMCardStyle(backgroundColor: Color(colorEnum: .layer1),
+					.WXMCardStyle(backgroundColor: Color(colorEnum: secondaryFieldsViewBackground),
 								  insideHorizontalPadding: CGFloat(.defaultSidePadding),
 								  insideVerticalPadding: 0.0,
 								  cornerRadius: CGFloat(.cardCornerRadius))

--- a/station-widget/Views/StationWidgetView.swift
+++ b/station-widget/Views/StationWidgetView.swift
@@ -12,24 +12,34 @@ import WidgetKit
 struct StationWidgetView: View {
 	let entry: StationTimelineEntry
 	@Environment(\.widgetFamily) var family: WidgetFamily
+    @Environment(\.widgetRenderingMode) var renderingMode
 
-	var body: some View {
-		Group {
-			switch entry.timelineCase {
-				case .station(let device, let followState):
-					stationView(device: device, followState: followState, uiMode: entry.weatherOverViewMode)
-				case .loggedOut:
-					LoggedOutView()
-				case .empty:
-					emptyView
-				case .error(let info):
-					errorView(info: info)
-				case .selectStation:
-					selectStationView
-			}
-		}
-		.widgetURL(entry.timelineCase.widgetUrl)
-	}
+    var body: some View {
+        Group {
+            switch entry.timelineCase {
+                case .station(let device, let followState):
+                    stationView(device: device, followState: followState, uiMode: entry.weatherOverViewMode)
+                        .modify { view in
+                            if renderingMode == .accented {
+                                view
+                                    .luminanceToAlpha()
+                                    .widgetAccentable()
+                            } else {
+                                view
+                            }
+                        }
+                case .loggedOut:
+                    LoggedOutView()
+                case .empty:
+                    emptyView
+                case .error(let info):
+                    errorView(info: info)
+                case .selectStation:
+                    selectStationView
+            }
+        }
+        .widgetURL(entry.timelineCase.widgetUrl)
+    }
 }
 
 private extension StationWidgetView {
@@ -290,7 +300,7 @@ struct StationWidgetView_Preview: PreviewProvider {
 										   errorInfo: nil, // .init(title: "This is an error title",
 										   // description: LocalizableString.Error.noInternetAccess.localized),
 										   isLoggedIn: true))
-			.previewContext(WidgetPreviewContext(family: .systemMedium))
+			.previewContext(WidgetPreviewContext(family: .systemLarge))
 		}
 		.containerBackground(for: .widget) {
 			Color(colorEnum: .top)

--- a/station-widget/Views/StationWidgetView.swift
+++ b/station-widget/Views/StationWidgetView.swift
@@ -13,6 +13,9 @@ struct StationWidgetView: View {
 	let entry: StationTimelineEntry
 	@Environment(\.widgetFamily) var family: WidgetFamily
     @Environment(\.widgetRenderingMode) var renderingMode
+    private var isTinted: Bool {
+        renderingMode == .accented
+    }
 
     var body: some View {
         Group {
@@ -121,7 +124,10 @@ private extension StationWidgetView {
 
 			Spacer()
 
-			WeatherOverviewView(mode: .minimal, weather: device.weather, noDataText: followState.weatherNoDataText)
+			WeatherOverviewView(mode: .minimal,
+                                weather: device.weather,
+                                noDataText: followState.weatherNoDataText,
+                                dataViewBackground: isTinted ? .noColor : .top)
 		}
 		.padding(.vertical, CGFloat(.smallSidePadding))
 		.widgetBackground {
@@ -137,7 +143,10 @@ private extension StationWidgetView {
 			titleView(device: device, followState: followState)
 				.padding(.horizontal, CGFloat(.mediumSidePadding))
 
-			WeatherOverviewView(mode: uiMode, weather: device.weather, noDataText: followState.weatherNoDataText)
+			WeatherOverviewView(mode: uiMode,
+                                weather: device.weather,
+                                noDataText: followState.weatherNoDataText,
+                                dataViewBackground: isTinted ? .noColor : .top)
 
 			Spacer(minLength: 0.0)
 		}
@@ -153,7 +162,12 @@ private extension StationWidgetView {
 			titleView(device: device, followState: followState)
 				.padding(.horizontal, CGFloat(.mediumSidePadding))
 
-			WeatherOverviewView(mode: .large, weather: device.weather, showSecondaryFields: true, noDataText: followState.weatherNoDataText)
+			WeatherOverviewView(mode: .large,
+                                weather: device.weather,
+                                showSecondaryFields: true,
+                                noDataText: followState.weatherNoDataText,
+                                dataViewBackground: isTinted ? .noColor : .top,
+                                secondaryFieldsViewBackground: isTinted ? .noColor : .layer1)
 				.cornerRadius(CGFloat(.cardCornerRadius))
 
 		}

--- a/station-widget/Views/StationWidgetView.swift
+++ b/station-widget/Views/StationWidgetView.swift
@@ -23,7 +23,7 @@ struct StationWidgetView: View {
                 case .station(let device, let followState):
                     stationView(device: device, followState: followState, uiMode: entry.weatherOverViewMode)
                         .modify { view in
-                            if renderingMode == .accented {
+                            if isTinted {
                                 view
                                     .luminanceToAlpha()
                                     .widgetAccentable()


### PR DESCRIPTION
## **Why?**
The widget UI is broken in tinted mode
### **How?**
Clear colors in tinted mode
### **Testing**
Run the app and add widgets in all sizes. Then customize the Home Screen to tinted (screenshot) and ensure the UI seems better
### **Screenshots (if applicable)**
<img width="600" alt="Simulator Screenshot - iPhone 17 - 2025-11-28 at 17 26 06" src="https://github.com/user-attachments/assets/bac82097-cf13-4d06-8c72-67c679777ee8" />

### **Additional context**
fixes fe-2057


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weather overview displays now support configurable background colors, allowing different background treatments across widget sizes.
  * Widgets adapt their visuals to the system rendering/tinting context, switching to a neutral appearance when tinted and applying layered backgrounds otherwise.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->